### PR TITLE
Feat/#19/cohort domain

### DIFF
--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -69,6 +69,8 @@
 
     단, Passport의 `validate` 메서드처럼 라이브러리에서 인자 순서(Positional Arguments)를 강제하는 경우는 예외로 한다.
 
+13. 함수/메서드 선언 시 명시적으로 `return` 타입을 작성하지 않는다. 불필요한 타이핑을 줄이고 TypeScript의 타입 자동 추론(Type Inference)을 적극 활용한다.
+
 ---
 
 ## 4) 네이밍/파일 구조 규칙 (MUST)

--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -71,6 +71,22 @@
 
 13. 함수/메서드 선언 시 명시적으로 `return` 타입을 작성하지 않는다. 불필요한 타이핑을 줄이고 TypeScript의 타입 자동 추론(Type Inference)을 적극 활용한다.
 
+14. TypeORM `@Column()`의 `type` 옵션은 생략을 기본으로 한다. TypeScript 필드 타입(`Date`, `string`, `number` 등)으로 자동 추론되며, PostgreSQL 전용 타입이 필요한 경우에만 명시한다.
+
+    ```ts
+    // ✅ 타입 생략 (TypeScript 타입으로 추론)
+    @Column()
+    recruitStartAt: Date;
+
+    // ✅ PostgreSQL 전용 타입이 필요한 경우에만 명시
+    @Column({ type: 'jsonb' })
+    metadata: Record<string, unknown>;
+
+    // ❌ 불필요하게 장황한 타입 명시
+    @Column({ type: 'timestamp with time zone' })
+    recruitStartAt: Date;
+    ```
+
 ---
 
 ## 4) 네이밍/파일 구조 규칙 (MUST)

--- a/CODE_RULES.md
+++ b/CODE_RULES.md
@@ -26,7 +26,8 @@
 ## 2) 아키텍처/레이어 규칙 (MUST)
 
 1. Domain Layer는 프레임워크/외부 라이브러리에 의존하지 않는다.
-2. Application Layer는 유스케이스를 조합하며 트랜잭션 경계를 가진다. 트랜잭션 시작/커밋/롤백은 Application Layer에서 선언하고, 실제 구현은 Infrastructure Layer(Unit of Work 등)에 위임한다.
+2. Application Layer는 유스케이스를 조합하며 트랜잭션 경계를 가진다.
+   트랜잭션의 시작/커밋/롤백은 Application Layer에서 선언하고, 실제 구현은 Infrastructure Layer(Unit of Work 등)에 위임한다.
 3. Infrastructure Layer는 DB, 외부 API, 메시징 등 구현 세부사항을 담당한다.
 4. Controller(Interface Layer)에는 비즈니스 로직을 넣지 않는다.
 5. Repository는 영속성 책임만 가지며, 도메인 정책 판단을 하지 않는다.
@@ -38,16 +39,15 @@
 ## 3) TypeScript/NestJS 규칙 (SHOULD)
 
 1. `any` 사용은 금지에 가깝게 관리하고, 불가피할 때만 범위를 최소화한다.
-2. DTO/Request 입력 검증은 명시적으로 수행한다(타입만 믿지 않는다).
+2. DTO/Request 입력 검증은 명시적으로 수행한다(형식, 범위, 필수값).
 3. 예외는 도메인/애플리케이션 의미를 담은 커스텀 예외로 던지고, 응답 변환은 전역 레벨에서 일괄 처리한다.
 4. `Promise` 반환 함수는 `async/await` 스타일을 일관되게 유지한다.
 5. 의존성 생성은 DI 컨테이너를 사용하고 `new` 직접 생성은 최소화한다.
 6. Import 순서는 자동 정렬 규칙(`simple-import-sort`)을 따른다.
-7. Prettier/ESLint 규칙을 로컬에서 통과하지 못하는 코드는 커밋하지 않는다.
-8. 반환 타입은 인라인 객체(`{ data: string }`) 대신 `type`/`interface`로 명시해 재사용 가능하게 관리한다.
-9. `Pick`/`Omit`/중첩 유틸리티 타입 등 복잡한 타입 조합은 지양하고, 의도가 드러나는 명시 타입을 우선한다.
-10. `if` 문은 단일 라인이더라도 항상 중괄호(`{}`)를 사용한다. (❌ `if (x) return;` → ✅ `if (x) { return; }`)
-11. `try-catch` 블록 밖에서는 `return await`를 생략한다. `try-catch` 블록 안에서는 rejection이 catch에서 잡히도록 반드시 `return await`를 사용한다.
+7. 반환 타입은 인라인 객체(`{ data: string }`) 대신 `type`/`interface`로 명시해 재사용 가능하게 관리한다.
+8. `Pick`/`Omit`/중첩 유틸리티 타입 등 복잡한 타입 조합은 지양하고, 의도가 드러나는 명시 타입을 우선한다.
+9. `if` 문은 단일 라인이더라도 항상 중괄호(`{}`)를 사용한다. (❌ `if (x) return;` → ✅ `if (x) { return; }`)
+10. `try-catch` 블록 밖에서는 `return await`를 생략한다. `try-catch` 블록 안에서는 rejection이 catch에서 잡히도록 반드시 `return await`를 사용한다.
 
     ```ts
     // ❌ try-catch 안에서 await 생략 — rejection이 catch에서 잡히지 않음
@@ -65,13 +65,18 @@
     }
     ```
 
-12. 함수 파라미터는 읽기 쉽고 확장이 용이하도록 **객체 구조 분해 할당(`{}`) 방식**을 권장한다.
+11. 함수 파라미터는 읽기 쉽고 확장이 용이하도록 **객체 구조 분해 할당(`{}`) 방식**을 권장한다.
 
     단, Passport의 `validate` 메서드처럼 라이브러리에서 인자 순서(Positional Arguments)를 강제하는 경우는 예외로 한다.
 
-13. 함수/메서드 선언 시 명시적으로 `return` 타입을 작성하지 않는다. 불필요한 타이핑을 줄이고 TypeScript의 타입 자동 추론(Type Inference)을 적극 활용한다.
+12. 함수/메서드가 값을 반환한다면 원칙적으로 반환 타입을 명시해 인터페이스(계약)를 명확히 한다.
 
-14. TypeORM `@Column()`의 `type` 옵션은 생략을 기본으로 한다. TypeScript 필드 타입(`Date`, `string`, `number` 등)으로 자동 추론되며, PostgreSQL 전용 타입이 필요한 경우에만 명시한다.
+    - **명시 대상**: `Promise<RegisterResult>`, `Promise<ApiResponse<T>>`, `Promise<DTO>` 등 **사용자 정의 복합 타입(Custom Type)** 반환.
+    - **생략 허용**: `void`/`Promise<void>`, `boolean`/`number`/`string` 등 **원시 타입(Primitive Type)** 반환.
+    - **생략 허용**: `Promise<User>`, `Promise<Cohort>`, `Promise<User | null>`처럼 도메인 **엔티티(Entity)**를 그대로 반환하는 Repository/Service 메서드(추론이 자명한 경우).
+    - **생략 허용**: `Controller` (Interface Layer) 엔드포인트 라우터 핸들러 메서드(추론 및 Swagger 데코레이터 명세 우선).
+
+13. TypeORM `@Column()`의 `type` 옵션은 생략을 기본으로 한다. TypeScript 필드 타입(`Date`, `string`, `number` 등)으로 자동 추론되며, PostgreSQL 전용 타입이 필요한 경우에만 명시한다.
 
     ```ts
     // ✅ 타입 생략 (TypeScript 타입으로 추론)
@@ -155,6 +160,18 @@ src/
   config/                 # 환경 설정
 ```
 
+### BaseEntity 사용 기준
+
+프로젝트에는 목적이 다른 두 가지 BaseEntity가 존재한다. 새 도메인 엔티티를 추가할 때 아래 기준으로 선택한다.
+
+| 클래스 | 위치 | 포함 필드 | 사용 기준 |
+|---|---|---|---|
+| `BaseEntity` | `common/entity/base.entity.ts` | `createdAt`, `updatedAt`, `deletedAt` | `id`를 도메인 엔티티에서 직접 선언하는 경우 |
+| `BaseEntity` (확장) | `common/core/base.entity.ts` | `id`, `uuid`, `createdAt`, `updatedAt`, `deletedAt` + 복합 인덱스 | `id`/`uuid`를 공통으로 관리하고 커서 기반 조회 인덱스가 필요한 경우 |
+
+> 하나의 프로젝트에서 두 BaseEntity가 혼재하면 테이블 컬럼 구성과 소프트 삭제 정책이 도메인마다 달라진다.
+> 새 도메인은 `common/core/base.entity.ts`를 기본으로 사용하고, 기존 도메인(`user`, `user-role`)은 현행 유지한다.
+
 ---
 
 ## 5) 테스트/품질 규칙 (SHOULD)
@@ -223,6 +240,7 @@ type ApiResponse<T> = {
 1. URI는 리소스 중심 명사로 설계하고, 동작은 HTTP Method로 표현한다.
 2. URI는 소문자 kebab-case를 사용한다. (`/user-profiles`, `/order-items`)
 3. HTTP Status Code는 의미에 맞게 사용한다.
+4. 엔드포인트/DTO 네이밍은 일관된 REST 규칙을 따른다.
 
 | 상황 | Status Code |
 |---|---|
@@ -258,13 +276,6 @@ type PaginationMeta = {
   hasNext: boolean;
 };
 ```
-
-### 기타
-
-1. NestJS 표준 구조(Controller, Provider, Module, DI, Decorator)를 우선 사용한다.
-2. 엔드포인트/DTO 네이밍은 일관된 REST 규칙을 따른다.
-
----
 
 ## 8) Git 커밋 규칙 (MUST)
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,7 @@ import { InjectDataSource, TypeOrmModule } from '@nestjs/typeorm';
 import { DataSource } from 'typeorm';
 import { addTransactionalDataSource } from 'typeorm-transactional';
 
+import { CohortModule } from './cohort/cohort.module';
 import { HttpExceptionFilter } from './common/exception/http-exception.filter';
 import { validate } from './config/env.validation';
 import { createTypeOrmModuleOptions } from './config/typeorm.config';
@@ -25,6 +26,7 @@ import { HealthModule } from './health/health.module';
     }),
     HealthModule,
     GoogleModule,
+    CohortModule,
   ],
   providers: [{ provide: APP_FILTER, useClass: HttpExceptionFilter }],
 })

--- a/src/cohort/application/cohort.service.spec.ts
+++ b/src/cohort/application/cohort.service.spec.ts
@@ -1,0 +1,69 @@
+import { HttpStatus } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+
+import { AppException } from '../../common/exception/app.exception';
+import { CohortRepository } from '../domain/cohort.repository';
+import { CohortStatus } from '../domain/cohort.status';
+import { CohortService } from './cohort.service';
+
+jest.mock('typeorm-transactional', () => ({
+  Transactional: () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) =>
+    descriptor,
+  initializeTransactionalContext: jest.fn(),
+}));
+
+const mockCohortRepository = {
+  create: jest.fn(),
+  checkActiveCohortExists: jest.fn(),
+};
+
+describe('CohortService', () => {
+  let cohortService: CohortService;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [CohortService, { provide: CohortRepository, useValue: mockCohortRepository }],
+    }).compile();
+
+    cohortService = module.get(CohortService);
+    jest.clearAllMocks();
+  });
+
+  describe('createCohort', () => {
+    const cohortInput = {
+      name: '1기',
+      recruitStartAt: new Date('2024-01-01'),
+      recruitEndAt: new Date('2024-01-31'),
+      status: CohortStatus.PLANNED,
+    };
+
+    describe('PLANNED 또는 RECRUITING 기수가 이미 존재할 때', () => {
+      it('COHORT_ALREADY_EXISTS 예외를 던진다', async () => {
+        // Given
+        mockCohortRepository.checkActiveCohortExists.mockResolvedValue(true);
+
+        // When & Then
+        await expect(cohortService.createCohort({ cohort: cohortInput })).rejects.toThrow(
+          new AppException('COHORT_ALREADY_EXISTS', HttpStatus.CONFLICT),
+        );
+        expect(mockCohortRepository.create).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('활성 기수가 없을 때', () => {
+      it('기수를 생성하고 반환한다', async () => {
+        // Given
+        const createdCohort = { id: 1, ...cohortInput };
+        mockCohortRepository.checkActiveCohortExists.mockResolvedValue(false);
+        mockCohortRepository.create.mockResolvedValue(createdCohort);
+
+        // When
+        const result = await cohortService.createCohort({ cohort: cohortInput });
+
+        // Then
+        expect(result).toEqual(createdCohort);
+        expect(mockCohortRepository.create).toHaveBeenCalledWith({ cohort: cohortInput });
+      });
+    });
+  });
+});

--- a/src/cohort/application/cohort.service.ts
+++ b/src/cohort/application/cohort.service.ts
@@ -1,0 +1,21 @@
+import { HttpStatus, Injectable } from '@nestjs/common';
+import { Transactional } from 'typeorm-transactional';
+
+import { AppException } from '../../common/exception/app.exception';
+import { CohortRepository } from '../domain/cohort.repository';
+import type { CohortCreateType } from '../domain/cohort.type';
+
+@Injectable()
+export class CohortService {
+  constructor(private readonly cohortRepository: CohortRepository) {}
+
+  @Transactional()
+  async createCohort({ cohort }: { cohort: CohortCreateType }) {
+    const isExists = await this.cohortRepository.checkActiveCohortExists();
+    if (isExists) {
+      throw new AppException('COHORT_ALREADY_EXISTS', HttpStatus.CONFLICT);
+    }
+
+    return this.cohortRepository.create({ cohort });
+  }
+}

--- a/src/cohort/cohort.module.ts
+++ b/src/cohort/cohort.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { CohortService } from './application/cohort.service';
+import { Cohort } from './domain/cohort.entity';
+import { CohortRepository } from './domain/cohort.repository';
+import { WriteRepository } from './infrastructure/write.repository';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Cohort])],
+  providers: [CohortService, CohortRepository, WriteRepository],
+  exports: [CohortService],
+})
+export class CohortModule {}

--- a/src/cohort/domain/cohort.entity.ts
+++ b/src/cohort/domain/cohort.entity.ts
@@ -1,0 +1,23 @@
+import { Column, Entity } from 'typeorm';
+
+import { BaseEntity } from '../../common/core/base.entity';
+import { CohortStatus } from './cohort.status';
+
+@Entity('cohorts')
+export class Cohort extends BaseEntity {
+  @Column()
+  name: string;
+
+  @Column()
+  recruitStartAt: Date;
+
+  @Column()
+  recruitEndAt: Date;
+
+  @Column({
+    type: 'enum',
+    enum: CohortStatus,
+    default: CohortStatus.PLANNED,
+  })
+  status: CohortStatus;
+}

--- a/src/cohort/domain/cohort.repository.ts
+++ b/src/cohort/domain/cohort.repository.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+
+import { WriteRepository } from '../infrastructure/write.repository';
+import { CohortStatus } from './cohort.status';
+import type { CohortCreateType } from './cohort.type';
+
+@Injectable()
+export class CohortRepository {
+  constructor(private readonly writeRepository: WriteRepository) {}
+
+  async create({ cohort }: { cohort: CohortCreateType }) {
+    return this.writeRepository.create({ cohort });
+  }
+
+  async checkActiveCohortExists() {
+    return this.writeRepository.exists({
+      statuses: [CohortStatus.PLANNED, CohortStatus.RECRUITING],
+    });
+  }
+}

--- a/src/cohort/domain/cohort.status.ts
+++ b/src/cohort/domain/cohort.status.ts
@@ -1,0 +1,6 @@
+export enum CohortStatus {
+  PLANNED = 'PLANNED',
+  RECRUITING = 'RECRUITING',
+  ACTIVE = 'ACTIVE',
+  COMPLETED = 'COMPLETED',
+}

--- a/src/cohort/domain/cohort.type.ts
+++ b/src/cohort/domain/cohort.type.ts
@@ -1,0 +1,8 @@
+import type { CohortStatus } from './cohort.status';
+
+export type CohortCreateType = {
+  name: string;
+  recruitStartAt: Date;
+  recruitEndAt: Date;
+  status?: CohortStatus;
+};

--- a/src/cohort/infrastructure/write.repository.ts
+++ b/src/cohort/infrastructure/write.repository.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource, In, Repository } from 'typeorm';
+
+import { Cohort } from '../domain/cohort.entity';
+import type { CohortStatus } from '../domain/cohort.status';
+import type { CohortCreateType } from '../domain/cohort.type';
+
+@Injectable()
+export class WriteRepository {
+  private readonly repository: Repository<Cohort>;
+
+  constructor(dataSource: DataSource) {
+    this.repository = dataSource.getRepository(Cohort);
+  }
+
+  async create({ cohort }: { cohort: CohortCreateType }) {
+    return this.repository.save(cohort);
+  }
+
+  async exists({ statuses }: { statuses?: CohortStatus[] }) {
+    return this.repository.exists({
+      where: statuses && statuses.length > 0 ? { status: In(statuses) } : {},
+    });
+  }
+}

--- a/src/common/error/error-message.ts
+++ b/src/common/error/error-message.ts
@@ -9,6 +9,7 @@ export const ErrorMessage = {
   GOOGLE_AUTH_FAILED: '구글 인증 정보를 가져올 수 없습니다.',
 
   COHORT_NOT_FOUND: '기수를 찾을 수 없습니다.',
+  COHORT_ALREADY_EXISTS: '이미 진행 중인 기수가 존재합니다.',
 
   APPLICATION_FORM_NOT_FOUND: '지원서를 찾을 수 없습니다.',
 

--- a/src/common/exception/http-exception.filter.ts
+++ b/src/common/exception/http-exception.filter.ts
@@ -17,9 +17,9 @@ export class HttpExceptionFilter implements ExceptionFilter {
   private readonly logger = new Logger(HttpExceptionFilter.name);
 
   catch(exception: unknown, host: ArgumentsHost): void {
-    const ctx = host.switchToHttp();
-    const response = ctx.getResponse<Response>();
-    const request = ctx.getRequest<Request>();
+    const context = host.switchToHttp();
+    const response = context.getResponse<Response>();
+    const request = context.getRequest<Request>();
 
     if (exception instanceof AppException) {
       response

--- a/src/google/application/google-auth.service.spec.ts
+++ b/src/google/application/google-auth.service.spec.ts
@@ -2,6 +2,11 @@ import { HttpStatus } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 
 import { AuthService } from '../../auth/application/auth.service';
+
+jest.mock('typeorm-transactional', () => ({
+  Transactional: () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) => descriptor,
+  initializeTransactionalContext: jest.fn(),
+}));
 import { AppException } from '../../common/exception/app.exception';
 import { UserService } from '../../user/application/user.service';
 import { GoogleApiClient } from '../infrastructure/google-api.client';

--- a/src/google/application/google-auth.service.spec.ts
+++ b/src/google/application/google-auth.service.spec.ts
@@ -4,7 +4,8 @@ import { Test } from '@nestjs/testing';
 import { AuthService } from '../../auth/application/auth.service';
 
 jest.mock('typeorm-transactional', () => ({
-  Transactional: () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) => descriptor,
+  Transactional: () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) =>
+    descriptor,
   initializeTransactionalContext: jest.fn(),
 }));
 import { AppException } from '../../common/exception/app.exception';

--- a/src/google/application/google-auth.service.ts
+++ b/src/google/application/google-auth.service.ts
@@ -70,12 +70,12 @@ export class GoogleAuthService {
     return { accessToken, refreshToken: newRefreshToken };
   }
 
-  async logout({ userId }: { userId: number }): Promise<void> {
+  async logout({ userId }: { userId: number }) {
     await this.userService.saveRefreshToken({ id: userId, refreshToken: null });
   }
 
-  @Transactional()
-  async withdrawal({ userId }: { userId: number }): Promise<void> {
+  // MEMO: @Transactional()을 의도적으로 제외합니다. (외부 API, 단일쿼리: 원자성 보장)
+  async withdrawal({ userId }: { userId: number }) {
     const user = await this.userService.findById({ id: userId });
     if (!user) {
       throw new AppException('USER_NOT_FOUND', HttpStatus.NOT_FOUND);

--- a/src/google/application/google-auth.service.ts
+++ b/src/google/application/google-auth.service.ts
@@ -1,4 +1,5 @@
 import { HttpStatus, Injectable } from '@nestjs/common';
+import { Transactional } from 'typeorm-transactional';
 
 import { AuthService } from '../../auth/application/auth.service';
 import { AppException } from '../../common/exception/app.exception';
@@ -14,6 +15,7 @@ export class GoogleAuthService {
     private readonly googleApiClient: GoogleApiClient,
   ) {}
 
+  @Transactional()
   async googleLogin({
     email,
     firstName,
@@ -72,6 +74,7 @@ export class GoogleAuthService {
     await this.userService.saveRefreshToken({ id: userId, refreshToken: null });
   }
 
+  @Transactional()
   async withdrawal({ userId }: { userId: number }): Promise<void> {
     const user = await this.userService.findById({ id: userId });
     if (!user) {

--- a/src/google/infrastructure/google-api.client.ts
+++ b/src/google/infrastructure/google-api.client.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 @Injectable()
 export class GoogleApiClient {
-  async revokeToken({ token }: { token: string }): Promise<void> {
+  async revokeToken({ token }: { token: string }) {
     const response = await fetch(`https://oauth2.googleapis.com/revoke?token=${token}`, {
       method: 'POST',
       headers: {

--- a/src/google/interface/google-auth.controller.ts
+++ b/src/google/interface/google-auth.controller.ts
@@ -65,7 +65,7 @@ export class GoogleAuthController {
   async googleAuthRedirect(
     @AuthUser() profile: GoogleProfile,
     @Res({ passthrough: true }) response: Response,
-  ): Promise<ApiResponse<GoogleAuthCallbackResult> | void> {
+  ) {
     const { user } = await this.googleAuthService.googleLogin(profile);
 
     this.setAuthCookies({
@@ -93,7 +93,7 @@ export class GoogleAuthController {
   async refreshToken(
     @Cookie('refresh_token') refreshToken: string | undefined,
     @Res({ passthrough: true }) response: Response,
-  ): Promise<ApiResponse<GoogleRefreshResult>> {
+  ) {
     if (!refreshToken) {
       throw new AppException('UNAUTHORIZED', HttpStatus.UNAUTHORIZED);
     }
@@ -119,10 +119,7 @@ export class GoogleAuthController {
   @Post('logout')
   @HttpCode(HttpStatus.NO_CONTENT)
   @UseGuards(AuthGuard('jwt'))
-  async logout(
-    @AuthUser() jwtUser: JwtUser,
-    @Res({ passthrough: true }) response: Response,
-  ): Promise<void> {
+  async logout(@AuthUser() jwtUser: JwtUser, @Res({ passthrough: true }) response: Response) {
     await this.googleAuthService.logout({ userId: jwtUser.id });
 
     response.clearCookie('access_token');
@@ -142,10 +139,7 @@ export class GoogleAuthController {
   @Delete('withdrawal')
   @HttpCode(HttpStatus.NO_CONTENT)
   @UseGuards(AuthGuard('jwt'))
-  async withdrawal(
-    @AuthUser() jwtUser: JwtUser,
-    @Res({ passthrough: true }) response: Response,
-  ): Promise<void> {
+  async withdrawal(@AuthUser() jwtUser: JwtUser, @Res({ passthrough: true }) response: Response) {
     await this.googleAuthService.withdrawal({ userId: jwtUser.id });
 
     response.clearCookie('access_token');

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -5,13 +5,13 @@ import { HealthCheck, HealthCheckService, TypeOrmHealthIndicator } from '@nestjs
 export class HealthController {
   constructor(
     private readonly health: HealthCheckService,
-    private readonly db: TypeOrmHealthIndicator,
+    private readonly database: TypeOrmHealthIndicator,
   ) {}
 
   @Get()
   @HealthCheck()
   async check() {
-    const checks = [() => this.db.pingCheck('database')];
+    const checks = [() => this.database.pingCheck('database')];
     return this.health.check(checks);
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import { initializeTransactionalContext } from 'typeorm-transactional';
 import { AppModule } from './app.module';
 import { setupSwagger } from './config/swagger.config';
 
-const bootstrap = async (): Promise<void> => {
+const bootstrap = async () => {
   initializeTransactionalContext();
 
   const app = await NestFactory.create(AppModule);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Logger, VersioningType } from '@nestjs/common';
+import { Logger, ValidationPipe, VersioningType } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
 import cookieParser from 'cookie-parser';
@@ -13,6 +13,7 @@ const bootstrap = async (): Promise<void> => {
   const app = await NestFactory.create(AppModule);
   app.use(cookieParser());
 
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
   app.setGlobalPrefix('api');
   app.enableVersioning({ type: VersioningType.URI });
 

--- a/src/user/application/user.service.spec.ts
+++ b/src/user/application/user.service.spec.ts
@@ -3,6 +3,11 @@ import { Test } from '@nestjs/testing';
 import { UserRepository } from '../domain/user.repository';
 import { UserService } from './user.service';
 
+jest.mock('typeorm-transactional', () => ({
+  Transactional: () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) => descriptor,
+  initializeTransactionalContext: jest.fn(),
+}));
+
 const mockUserRepository = {
   findByEmail: jest.fn(),
   findById: jest.fn(),

--- a/src/user/application/user.service.spec.ts
+++ b/src/user/application/user.service.spec.ts
@@ -4,7 +4,8 @@ import { UserRepository } from '../domain/user.repository';
 import { UserService } from './user.service';
 
 jest.mock('typeorm-transactional', () => ({
-  Transactional: () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) => descriptor,
+  Transactional: () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) =>
+    descriptor,
   initializeTransactionalContext: jest.fn(),
 }));
 

--- a/src/user/application/user.service.ts
+++ b/src/user/application/user.service.ts
@@ -1,13 +1,15 @@
 import { Injectable } from '@nestjs/common';
+import { Transactional } from 'typeorm-transactional';
 
-import { User } from '../domain/user.entity';
+import type { User } from '../domain/user.entity';
 import { UserRepository } from '../domain/user.repository';
-import { RegisterResult, UserType } from '../domain/user.type';
+import type { RegisterResult, UserType } from '../domain/user.type';
 
 @Injectable()
 export class UserService {
   constructor(private readonly userRepository: UserRepository) {}
 
+  @Transactional()
   async register({
     email,
     firstName,

--- a/src/user/application/user.service.ts
+++ b/src/user/application/user.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { Transactional } from 'typeorm-transactional';
 
-import type { User } from '../domain/user.entity';
 import { UserRepository } from '../domain/user.repository';
 import type { RegisterResult, UserType } from '../domain/user.type';
 
@@ -48,25 +47,19 @@ export class UserService {
     return { user, isNew: true };
   }
 
-  async findById({ id }: { id: number }): Promise<User | null> {
+  async findById({ id }: { id: number }) {
     return this.userRepository.findById({ id });
   }
 
-  async findByRefreshToken({ hash }: { hash: string }): Promise<User | null> {
+  async findByRefreshToken({ hash }: { hash: string }) {
     return this.userRepository.findByRefreshToken({ hash });
   }
 
-  async saveRefreshToken({
-    id,
-    refreshToken,
-  }: {
-    id: number;
-    refreshToken: string | null;
-  }): Promise<void> {
+  async saveRefreshToken({ id, refreshToken }: { id: number; refreshToken: string | null }) {
     await this.userRepository.saveRefreshToken({ id, refreshToken });
   }
 
-  async withdraw({ id }: { id: number }): Promise<void> {
+  async withdraw({ id }: { id: number }) {
     await this.userRepository.withdraw({ id });
   }
 }

--- a/src/user/domain/user.repository.ts
+++ b/src/user/domain/user.repository.ts
@@ -1,28 +1,21 @@
 import { Injectable } from '@nestjs/common';
 
 import { WriteRepository } from '../infrastructure/write.repository';
-import type { User } from './user.entity';
 import { UserType } from './user.type';
 
 @Injectable()
 export class UserRepository {
   constructor(private readonly writeRepository: WriteRepository) {}
 
-  async findByEmail({
-    email,
-    withDeleted = false,
-  }: {
-    email: string;
-    withDeleted?: boolean;
-  }): Promise<User | null> {
+  async findByEmail({ email, withDeleted = false }: { email: string; withDeleted?: boolean }) {
     return this.writeRepository.findOne({ email }, withDeleted);
   }
 
-  async findById({ id }: { id: number }): Promise<User | null> {
+  async findById({ id }: { id: number }) {
     return this.writeRepository.findOne({ id });
   }
 
-  async findByRefreshToken({ hash }: { hash: string }): Promise<User | null> {
+  async findByRefreshToken({ hash }: { hash: string }) {
     return this.writeRepository.findOne({ refreshToken: hash });
   }
 
@@ -33,27 +26,21 @@ export class UserRepository {
     sub,
     googleAccessToken,
     googleRefreshToken,
-  }: UserType): Promise<User> {
+  }: UserType) {
     return this.writeRepository.create({
       user: { email, firstName, lastName, sub, googleAccessToken, googleRefreshToken },
     });
   }
 
-  async saveRefreshToken({
-    id,
-    refreshToken,
-  }: {
-    id: number;
-    refreshToken: string | null;
-  }): Promise<void> {
+  async saveRefreshToken({ id, refreshToken }: { id: number; refreshToken: string | null }) {
     await this.writeRepository.update({ id, refreshToken });
   }
 
-  async withdraw({ id }: { id: number }): Promise<void> {
+  async withdraw({ id }: { id: number }) {
     await this.writeRepository.softDelete({ id });
   }
 
-  async restore({ id }: { id: number }): Promise<void> {
+  async restore({ id }: { id: number }) {
     await this.writeRepository.restore({ id });
   }
 
@@ -65,7 +52,7 @@ export class UserRepository {
     id: number;
     googleAccessToken?: string;
     googleRefreshToken?: string;
-  }): Promise<void> {
+  }) {
     await this.writeRepository.updateGoogleTokens({ id, googleAccessToken, googleRefreshToken });
   }
 }

--- a/src/user/infrastructure/write.repository.ts
+++ b/src/user/infrastructure/write.repository.ts
@@ -18,19 +18,19 @@ export class WriteRepository {
     this.repository = dataSource.getRepository(User);
   }
 
-  async create({ user }: { user: UserType }): Promise<User> {
+  async create({ user }: { user: UserType }) {
     return this.repository.save(user);
   }
 
-  async softDelete({ id }: { id: number }): Promise<void> {
+  async softDelete({ id }: { id: number }) {
     await this.repository.softDelete(id);
   }
 
-  async restore({ id }: { id: number }): Promise<void> {
+  async restore({ id }: { id: number }) {
     await this.repository.restore(id);
   }
 
-  async findOne(condition: UserFindCondition, withDeleted = false): Promise<User | null> {
+  async findOne(condition: UserFindCondition, withDeleted = false) {
     return this.repository.findOne({
       where: condition,
       relations: { userRoles: true },
@@ -38,7 +38,7 @@ export class WriteRepository {
     });
   }
 
-  async update({ id, refreshToken }: { id: number; refreshToken: string | null }): Promise<void> {
+  async update({ id, refreshToken }: { id: number; refreshToken: string | null }) {
     await this.repository.update(id, { refreshToken });
   }
 
@@ -50,7 +50,7 @@ export class WriteRepository {
     id: number;
     googleAccessToken?: string;
     googleRefreshToken?: string;
-  }): Promise<void> {
+  }) {
     const updateData: Partial<User> = {};
     if (googleAccessToken !== undefined) {
       updateData.googleAccessToken = googleAccessToken;


### PR DESCRIPTION
## 📌 PR 제목

> feat: 기수(Cohort) 도메인 초기화 및 중복 생성 방어 검증 로직 구현 (#19)

---

## ✅ PR 설명

- **기수(Cohort) 기능의 1단계 핵심 뼈대 구성 및 도메인 규칙 적용**
- 관련 이슈: #19

**세부 작업 내역:**
- `src/cohort` 모듈 및 폴더 아키텍처(DDD 리포지토리 패턴) 셋업 및 `app.module.ts` 등록
- `Cohort` 엔티티 및 상태 Enum(`PLANNED`, `RECRUITING`, `ACTIVE`, `COMPLETED`) 정의
- 정책 구현: 시스템 상에 `PLANNED` 또는 `RECRUITING` 상태인 기수는 동시에 1개만 존재해야 함 (Domain Repository 및 `CohortService.createCohort` 내 `AppException` 방어 로직 추가)
- **문서화 및 코드 룰 업데이트**: `CODE_RULES.md`에 `return` 타입 명시 생략 규칙(13번) 및 `@Column({ type: ... })` 불필요한 명시 제한 규칙(14번)을 추가하고 기존 코드 리팩토링

---

## 🧪 테스트 방법

- [x] 로컬 테스트 완료 (`yarn dev` 모듈 의존성 연결 확인)
- [x] 린트 및 빌드 통과 (`yarn format`, `yarn lint`, `tsc --noEmit` 오류 없음 확인)

---

## 🔍 체크리스트

- [x] 코드에 주석/불필요한 로그 제거
- [x] 코드 리뷰어가 이해하기 쉽게 커밋 정리 (Layer 구분 및 코드 컨벤션 적용 완료)

---

## 📎 기타 참고 사항 (Optional)
