### PR TITLE
[Feature] 기수 도메인 기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@nestjs/jwt": "^11.0.2",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/schedule": "^6.1.1",
     "@nestjs/swagger": "^11.2.6",
     "@nestjs/terminus": "^11.1.1",
     "@nestjs/typeorm": "^11.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module, OnModuleInit } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { APP_FILTER } from '@nestjs/core';
+import { ScheduleModule } from '@nestjs/schedule';
 import { InjectDataSource, TypeOrmModule } from '@nestjs/typeorm';
 import { DataSource } from 'typeorm';
 import { addTransactionalDataSource } from 'typeorm-transactional';
@@ -24,6 +25,7 @@ import { HealthModule } from './health/health.module';
       useFactory: createTypeOrmModuleOptions,
       inject: [ConfigService],
     }),
+    ScheduleModule.forRoot(),
     HealthModule,
     GoogleModule,
     CohortModule,

--- a/src/cohort/application/cohort.service.spec.ts
+++ b/src/cohort/application/cohort.service.spec.ts
@@ -13,7 +13,7 @@ jest.mock('typeorm-transactional', () => ({
 }));
 
 const mockCohortRepository = {
-  create: jest.fn(),
+  register: jest.fn(),
   checkActiveCohortExists: jest.fn(),
 };
 
@@ -46,7 +46,7 @@ describe('CohortService', () => {
         await expect(cohortService.createCohort({ cohort: cohortInput })).rejects.toThrow(
           new AppException('COHORT_ALREADY_EXISTS', HttpStatus.CONFLICT),
         );
-        expect(mockCohortRepository.create).not.toHaveBeenCalled();
+        expect(mockCohortRepository.register).not.toHaveBeenCalled();
       });
     });
 
@@ -55,14 +55,14 @@ describe('CohortService', () => {
         // Given
         const createdCohort = { id: 1, ...cohortInput };
         mockCohortRepository.checkActiveCohortExists.mockResolvedValue(false);
-        mockCohortRepository.create.mockResolvedValue(createdCohort);
+        mockCohortRepository.register.mockResolvedValue(createdCohort);
 
         // When
         const result = await cohortService.createCohort({ cohort: cohortInput });
 
         // Then
         expect(result).toEqual(createdCohort);
-        expect(mockCohortRepository.create).toHaveBeenCalledWith({ cohort: cohortInput });
+        expect(mockCohortRepository.register).toHaveBeenCalledWith({ cohort: cohortInput });
       });
     });
   });

--- a/src/cohort/application/cohort.service.ts
+++ b/src/cohort/application/cohort.service.ts
@@ -3,7 +3,12 @@ import { Transactional } from 'typeorm-transactional';
 
 import { AppException } from '../../common/exception/app.exception';
 import { CohortRepository } from '../domain/cohort.repository';
-import type { CohortCreateType } from '../domain/cohort.type';
+import { CohortStatus } from '../domain/cohort.status';
+import type {
+  CohortCreateType,
+  CohortPartCreateType,
+  CohortUpdateType,
+} from '../domain/cohort.type';
 
 @Injectable()
 export class CohortService {
@@ -16,6 +21,59 @@ export class CohortService {
       throw new AppException('COHORT_ALREADY_EXISTS', HttpStatus.CONFLICT);
     }
 
-    return this.cohortRepository.create({ cohort });
+    return this.cohortRepository.register({ cohort });
+  }
+
+  async findAllCohorts() {
+    return this.cohortRepository.findAll();
+  }
+
+  async findActiveCohort() {
+    return this.cohortRepository.findActive();
+  }
+
+  @Transactional()
+  async updateCohort({ id, data }: { id: number; data: CohortUpdateType }) {
+    const found = await this.cohortRepository.findById({ id });
+    if (!found) {
+      throw new AppException('COHORT_NOT_FOUND', HttpStatus.NOT_FOUND);
+    }
+
+    // MEMO: 상태 변경 시 활성 기수 중복 검증은 의도적으로 생략합니다. 단순 수정 API를 지원하며, 상태 전이 로직은 추후 별도 유스케이스로 분리합니다.
+    const hasUpdate = Object.values(data).some((v) => v !== undefined);
+    if (!hasUpdate) {
+      return;
+    }
+
+    await this.cohortRepository.update({ id, ...data });
+  }
+
+  @Transactional()
+  async updateCohortParts({ id, parts }: { id: number; parts: CohortPartCreateType[] }) {
+    const found = await this.cohortRepository.findById({ id });
+    if (!found) {
+      throw new AppException('COHORT_NOT_FOUND', HttpStatus.NOT_FOUND);
+    }
+
+    found.updateParts(parts);
+
+    await this.cohortRepository.save({ cohort: found });
+  }
+
+  @Transactional()
+  async deleteCohort({ id }: { id: number }) {
+    const found = await this.cohortRepository.findById({ id });
+    if (!found) {
+      throw new AppException('COHORT_NOT_FOUND', HttpStatus.NOT_FOUND);
+    }
+
+    await this.cohortRepository.deleteById({ id });
+  }
+
+  async transitionExpiredToActive() {
+    const expired = await this.cohortRepository.findExpiredRecruiting();
+    await Promise.all(
+      expired.map(({ id }) => this.cohortRepository.update({ id, status: CohortStatus.ACTIVE })),
+    );
   }
 }

--- a/src/cohort/cohort.module.ts
+++ b/src/cohort/cohort.module.ts
@@ -5,11 +5,15 @@ import { CohortService } from './application/cohort.service';
 import { Cohort } from './domain/cohort.entity';
 import { CohortRepository } from './domain/cohort.repository';
 import { CohortPart } from './domain/cohort-part.entity';
+import { CohortScheduler } from './infrastructure/cohort.scheduler';
 import { WriteRepository } from './infrastructure/write.repository';
+import { AdminCohortController } from './interface/admin.cohort.controller';
+import { PublicCohortController } from './interface/public.cohort.controller';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Cohort, CohortPart])],
-  providers: [CohortService, CohortRepository, WriteRepository],
+  controllers: [AdminCohortController, PublicCohortController],
+  providers: [CohortService, CohortRepository, WriteRepository, CohortScheduler],
   exports: [CohortService],
 })
 export class CohortModule {}

--- a/src/cohort/domain/cohort-part.entity.ts
+++ b/src/cohort/domain/cohort-part.entity.ts
@@ -11,7 +11,7 @@ export class CohortPart extends BaseEntity {
   @Column({ default: false })
   isOpen: boolean;
 
-  @Column({ type: 'json' })
+  @Column({ type: 'jsonb' })
   applicationSchema: Record<string, unknown>;
 
   @ManyToOne(() => Cohort, (cohort) => cohort.parts, {
@@ -19,4 +19,23 @@ export class CohortPart extends BaseEntity {
     onDelete: 'CASCADE',
   })
   cohort: Cohort;
+
+  static create({
+    partName,
+    isOpen,
+    applicationSchema,
+    cohort,
+  }: {
+    partName: string;
+    isOpen?: boolean;
+    applicationSchema: Record<string, unknown>;
+    cohort: Cohort;
+  }): CohortPart {
+    const part = new CohortPart();
+    part.partName = partName;
+    part.isOpen = isOpen ?? false;
+    part.applicationSchema = applicationSchema;
+    part.cohort = cohort;
+    return part;
+  }
 }

--- a/src/cohort/domain/cohort.entity.ts
+++ b/src/cohort/domain/cohort.entity.ts
@@ -33,7 +33,7 @@ export class Cohort extends BaseEntity {
     this.parts = parts.map((part) => {
       const foundPart = this.parts?.find((p) => p.partName === part.partName);
       if (foundPart) {
-        foundPart.isOpen = part.isOpen ?? foundPart.isOpen;
+        foundPart.isOpen = part.isOpen ?? false;
         foundPart.applicationSchema = part.applicationSchema;
         return foundPart;
       }

--- a/src/cohort/domain/cohort.entity.ts
+++ b/src/cohort/domain/cohort.entity.ts
@@ -2,6 +2,7 @@ import { Column, Entity, OneToMany } from 'typeorm';
 
 import { BaseEntity } from '../../common/core/base.entity';
 import { CohortStatus } from './cohort.status';
+import type { CohortPartCreateType } from './cohort.type';
 import { CohortPart } from './cohort-part.entity';
 
 @Entity('cohorts')
@@ -24,6 +25,20 @@ export class Cohort extends BaseEntity {
 
   @OneToMany(() => CohortPart, (part) => part.cohort, {
     cascade: true,
+    orphanedRowAction: 'delete',
   })
   parts?: CohortPart[];
+
+  updateParts(parts: CohortPartCreateType[]): void {
+    this.parts = parts.map((part) => {
+      const foundPart = this.parts?.find((p) => p.partName === part.partName);
+      if (foundPart) {
+        foundPart.isOpen = part.isOpen ?? foundPart.isOpen;
+        foundPart.applicationSchema = part.applicationSchema;
+        return foundPart;
+      }
+
+      return CohortPart.create({ ...part, cohort: this });
+    });
+  }
 }

--- a/src/cohort/domain/cohort.repository.ts
+++ b/src/cohort/domain/cohort.repository.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@nestjs/common';
 import { WriteRepository } from '../infrastructure/write.repository';
 import { Cohort } from './cohort.entity';
 import { CohortStatus } from './cohort.status';
-import type { CohortCreateType, CohortUpdateType } from './cohort.type';
+import type { CohortCreateType } from './cohort.type';
 
 @Injectable()
 export class CohortRepository {
@@ -30,15 +30,30 @@ export class CohortRepository {
   }
 
   async findExpiredRecruiting() {
-    return this.writeRepository.findExpiredRecruiting();
+    return this.writeRepository.findByStatusBefore({
+      status: CohortStatus.RECRUITING,
+      date: new Date(),
+    });
   }
 
   async findAll() {
     return this.writeRepository.find();
   }
 
-  async update({ id, ...data }: { id: number } & CohortUpdateType) {
-    await this.writeRepository.update({ id, ...data });
+  async update({
+    id,
+    name,
+    recruitStartAt,
+    recruitEndAt,
+    status,
+  }: {
+    id: number;
+    name?: string;
+    recruitStartAt?: Date;
+    recruitEndAt?: Date;
+    status?: CohortStatus;
+  }) {
+    await this.writeRepository.update({ id, name, recruitStartAt, recruitEndAt, status });
   }
 
   async save({ cohort }: { cohort: Cohort }) {

--- a/src/cohort/domain/cohort.repository.ts
+++ b/src/cohort/domain/cohort.repository.ts
@@ -1,14 +1,15 @@
 import { Injectable } from '@nestjs/common';
 
 import { WriteRepository } from '../infrastructure/write.repository';
+import { Cohort } from './cohort.entity';
 import { CohortStatus } from './cohort.status';
-import type { CohortCreateType } from './cohort.type';
+import type { CohortCreateType, CohortUpdateType } from './cohort.type';
 
 @Injectable()
 export class CohortRepository {
   constructor(private readonly writeRepository: WriteRepository) {}
 
-  async create({ cohort }: { cohort: CohortCreateType }) {
+  async register({ cohort }: { cohort: CohortCreateType }) {
     return this.writeRepository.create({ cohort });
   }
 
@@ -20,5 +21,31 @@ export class CohortRepository {
 
   async findById({ id }: { id: number }) {
     return this.writeRepository.findOne({ id });
+  }
+
+  async findActive() {
+    return this.writeRepository.findOneByStatuses({
+      statuses: [CohortStatus.RECRUITING, CohortStatus.ACTIVE],
+    });
+  }
+
+  async findExpiredRecruiting() {
+    return this.writeRepository.findExpiredRecruiting();
+  }
+
+  async findAll() {
+    return this.writeRepository.find();
+  }
+
+  async update({ id, ...data }: { id: number } & CohortUpdateType) {
+    await this.writeRepository.update({ id, ...data });
+  }
+
+  async save({ cohort }: { cohort: Cohort }) {
+    return this.writeRepository.save({ cohort });
+  }
+
+  async deleteById({ id }: { id: number }) {
+    await this.writeRepository.softDelete({ id });
   }
 }

--- a/src/cohort/domain/cohort.type.ts
+++ b/src/cohort/domain/cohort.type.ts
@@ -13,3 +13,10 @@ export type CohortCreateType = {
   status?: CohortStatus;
   parts?: CohortPartCreateType[];
 };
+
+export type CohortUpdateType = {
+  name?: string;
+  recruitStartAt?: Date;
+  recruitEndAt?: Date;
+  status?: CohortStatus;
+};

--- a/src/cohort/infrastructure/cohort.scheduler.ts
+++ b/src/cohort/infrastructure/cohort.scheduler.ts
@@ -1,0 +1,17 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+
+import { CohortService } from '../application/cohort.service';
+
+@Injectable()
+export class CohortScheduler {
+  private readonly logger = new Logger(CohortScheduler.name);
+
+  constructor(private readonly cohortService: CohortService) {}
+
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  async transitionExpiredRecruitingCohorts() {
+    this.logger.log('모집 종료된 기수 상태 전환 시작');
+    await this.cohortService.transitionExpiredToActive();
+  }
+}

--- a/src/cohort/infrastructure/write.repository.ts
+++ b/src/cohort/infrastructure/write.repository.ts
@@ -1,9 +1,9 @@
 import { Injectable } from '@nestjs/common';
-import { DataSource, In, Repository } from 'typeorm';
+import { DataSource, In, LessThan, Repository } from 'typeorm';
 
 import { Cohort } from '../domain/cohort.entity';
-import type { CohortStatus } from '../domain/cohort.status';
-import type { CohortCreateType } from '../domain/cohort.type';
+import { CohortStatus } from '../domain/cohort.status';
+import type { CohortCreateType, CohortUpdateType } from '../domain/cohort.type';
 
 @Injectable()
 export class WriteRepository {
@@ -17,13 +17,43 @@ export class WriteRepository {
     return this.repository.save(cohort);
   }
 
-  async exists({ statuses }: { statuses?: CohortStatus[] }) {
-    return this.repository.exists({
-      where: statuses && statuses.length > 0 ? { status: In(statuses) } : {},
+  async save({ cohort }: { cohort: Cohort }) {
+    return this.repository.save(cohort);
+  }
+
+  async exists({ statuses }: { statuses: CohortStatus[] }) {
+    return this.repository.exists({ where: { status: In(statuses) } });
+  }
+
+  async find() {
+    return this.repository.find({ relations: { parts: true } });
+  }
+
+  async findOne({ id }: { id?: number }) {
+    return this.repository.findOne({ where: { id }, relations: { parts: true } });
+  }
+
+  async findOneByStatuses({ statuses }: { statuses: CohortStatus[] }) {
+    return this.repository.findOne({
+      where: statuses.map((status) => ({ status })),
+      relations: { parts: true },
     });
   }
 
-  async findOne({ id }: { id: number }) {
-    return this.repository.findOne({ where: { id }, relations: { parts: true } });
+  async findExpiredRecruiting() {
+    return this.repository.find({
+      where: {
+        status: CohortStatus.RECRUITING,
+        recruitEndAt: LessThan(new Date()),
+      },
+    });
+  }
+
+  async update({ id, ...data }: { id: number } & CohortUpdateType) {
+    await this.repository.update(id, data);
+  }
+
+  async softDelete({ id }: { id: number }) {
+    await this.repository.softDelete(id);
   }
 }

--- a/src/cohort/infrastructure/write.repository.ts
+++ b/src/cohort/infrastructure/write.repository.ts
@@ -3,7 +3,12 @@ import { DataSource, In, LessThan, Repository } from 'typeorm';
 
 import { Cohort } from '../domain/cohort.entity';
 import { CohortStatus } from '../domain/cohort.status';
-import type { CohortCreateType, CohortUpdateType } from '../domain/cohort.type';
+import type { CohortCreateType } from '../domain/cohort.type';
+
+type CohortFindCondition = {
+  id?: number;
+  status?: CohortStatus;
+};
 
 @Injectable()
 export class WriteRepository {
@@ -25,12 +30,12 @@ export class WriteRepository {
     return this.repository.exists({ where: { status: In(statuses) } });
   }
 
-  async find() {
-    return this.repository.find({ relations: { parts: true } });
+  async find(condition: CohortFindCondition = {}) {
+    return this.repository.find({ where: condition, relations: { parts: true } });
   }
 
-  async findOne({ id }: { id?: number }) {
-    return this.repository.findOne({ where: { id }, relations: { parts: true } });
+  async findOne(condition: CohortFindCondition) {
+    return this.repository.findOne({ where: condition, relations: { parts: true } });
   }
 
   async findOneByStatuses({ statuses }: { statuses: CohortStatus[] }) {
@@ -40,17 +45,24 @@ export class WriteRepository {
     });
   }
 
-  async findExpiredRecruiting() {
-    return this.repository.find({
-      where: {
-        status: CohortStatus.RECRUITING,
-        recruitEndAt: LessThan(new Date()),
-      },
-    });
+  async findByStatusBefore({ status, date }: { status: CohortStatus; date: Date }) {
+    return this.repository.find({ where: { status, recruitEndAt: LessThan(date) } });
   }
 
-  async update({ id, ...data }: { id: number } & CohortUpdateType) {
-    await this.repository.update(id, data);
+  async update({
+    id,
+    name,
+    recruitStartAt,
+    recruitEndAt,
+    status,
+  }: {
+    id: number;
+    name?: string;
+    recruitStartAt?: Date;
+    recruitEndAt?: Date;
+    status?: CohortStatus;
+  }) {
+    await this.repository.update(id, { name, recruitStartAt, recruitEndAt, status });
   }
 
   async softDelete({ id }: { id: number }) {

--- a/src/cohort/interface/admin.cohort.controller.ts
+++ b/src/cohort/interface/admin.cohort.controller.ts
@@ -1,0 +1,108 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Put,
+  UseGuards,
+} from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { ApiTags } from '@nestjs/swagger';
+
+import { ApiResponse } from '../../common/response/api-response';
+import { ApiDoc } from '../../common/swagger/api-doc.decorator';
+import { CohortService } from '../application/cohort.service';
+import {
+  CreateCohortRequestDto,
+  UpdateCohortPartsRequestDto,
+  UpdateCohortRequestDto,
+} from './dto/admin-cohort.request.dto';
+import { CohortAdminResponseDto } from './dto/admin-cohort.response.dto';
+
+@ApiTags('Admin - Cohort')
+@Controller({ path: 'admin/cohorts', version: '1' })
+@UseGuards(AuthGuard('jwt'))
+export class AdminCohortController {
+  constructor(private readonly cohortService: CohortService) {}
+
+  @ApiDoc({
+    summary: '새 기수 생성',
+    description: '새로운 기수를 생성합니다. 모집 파트 설정도 함께 포함할 수 있습니다.',
+    auth: true,
+  })
+  @Post()
+  async createCohort(@Body() body: CreateCohortRequestDto) {
+    const cohort = await this.cohortService.createCohort({
+      cohort: {
+        ...body,
+        parts: body.parts?.map(({ name, isOpen, formSchema }) => ({
+          partName: name,
+          isOpen,
+          applicationSchema: formSchema,
+        })),
+      },
+    });
+    return ApiResponse.ok(CohortAdminResponseDto.from(cohort));
+  }
+
+  @ApiDoc({
+    summary: '기수 전체 목록 조회',
+    description: '모든 기수와 각 기수별 파트 설정 정보를 조회합니다.',
+    auth: true,
+  })
+  @Get()
+  async findAllCohorts() {
+    const cohorts = await this.cohortService.findAllCohorts();
+    return ApiResponse.ok(cohorts.map((cohort) => CohortAdminResponseDto.from(cohort)));
+  }
+
+  @ApiDoc({
+    summary: '기수 정보 및 상태 수정',
+    description: '기수의 명칭, 일정, 상태 등을 수동으로 수정합니다.',
+    auth: true,
+  })
+  @Patch(':id')
+  async updateCohort(@Param('id', ParseIntPipe) id: number, @Body() body: UpdateCohortRequestDto) {
+    await this.cohortService.updateCohort({ id, data: body });
+    return ApiResponse.ok(null, '기수 정보가 수정되었습니다.');
+  }
+
+  @ApiDoc({
+    summary: '기수별 파트 모집 설정',
+    description:
+      '기수별로 모집할 파트와 각 파트별 지원서 스키마(JSON)를 설정합니다. 전체 교체 방식으로 동작합니다.',
+    auth: true,
+  })
+  @Put(':id/parts')
+  async updateCohortParts(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() body: UpdateCohortPartsRequestDto,
+  ) {
+    await this.cohortService.updateCohortParts({
+      id,
+      parts: body.parts.map(({ name, isOpen, formSchema }) => ({
+        partName: name,
+        isOpen,
+        applicationSchema: formSchema,
+      })),
+    });
+    return ApiResponse.ok(null, '파트 설정이 저장되었습니다.');
+  }
+
+  @ApiDoc({
+    summary: '기수 삭제',
+    description: '기수를 소프트 삭제합니다.',
+    auth: true,
+  })
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async deleteCohort(@Param('id', ParseIntPipe) id: number) {
+    await this.cohortService.deleteCohort({ id });
+  }
+}

--- a/src/cohort/interface/dto/admin-cohort.request.dto.ts
+++ b/src/cohort/interface/dto/admin-cohort.request.dto.ts
@@ -1,0 +1,110 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  ArrayMinSize,
+  IsArray,
+  IsBoolean,
+  IsDate,
+  IsEnum,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+
+import { CohortStatus } from '../../domain/cohort.status';
+
+export class CohortPartConfigDto {
+  @ApiProperty({ description: '파트명', example: 'iOS' })
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @ApiPropertyOptional({ description: '모집 오픈 여부', default: false })
+  @IsBoolean()
+  @IsOptional()
+  isOpen?: boolean;
+
+  @ApiProperty({
+    description: '지원서 스키마 JSON',
+    example: { questions: [] },
+  })
+  @IsObject()
+  @IsNotEmpty()
+  formSchema: Record<string, unknown>;
+}
+
+export class CreateCohortRequestDto {
+  @ApiProperty({ description: '기수 명칭', example: '15기' })
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @ApiProperty({ description: '모집 시작일', example: '2024-03-01T00:00:00Z' })
+  @Type(() => Date)
+  @IsDate()
+  @IsNotEmpty()
+  recruitStartAt: Date;
+
+  @ApiProperty({ description: '모집 종료일', example: '2024-03-15T23:59:59Z' })
+  @Type(() => Date)
+  @IsDate()
+  @IsNotEmpty()
+  recruitEndAt: Date;
+
+  @ApiPropertyOptional({
+    description: '기수 상태',
+    enum: CohortStatus,
+    default: CohortStatus.PLANNED,
+  })
+  @IsEnum(CohortStatus)
+  @IsOptional()
+  status?: CohortStatus;
+
+  @ApiPropertyOptional({
+    description: '파트별 모집 설정',
+    type: [CohortPartConfigDto],
+  })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CohortPartConfigDto)
+  @IsOptional()
+  parts?: CohortPartConfigDto[];
+}
+
+export class UpdateCohortRequestDto {
+  @ApiPropertyOptional({ description: '기수 명칭', example: '15기 수정' })
+  @IsString()
+  @IsOptional()
+  name?: string;
+
+  @ApiPropertyOptional({ description: '모집 시작일' })
+  @Type(() => Date)
+  @IsDate()
+  @IsOptional()
+  recruitStartAt?: Date;
+
+  @ApiPropertyOptional({ description: '모집 종료일' })
+  @Type(() => Date)
+  @IsDate()
+  @IsOptional()
+  recruitEndAt?: Date;
+
+  @ApiPropertyOptional({ description: '기수 상태', enum: CohortStatus })
+  @IsEnum(CohortStatus)
+  @IsOptional()
+  status?: CohortStatus;
+}
+
+export class UpdateCohortPartsRequestDto {
+  @ApiProperty({
+    description: '파트별 모집 설정 목록',
+    type: [CohortPartConfigDto],
+  })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => CohortPartConfigDto)
+  parts: CohortPartConfigDto[];
+}

--- a/src/cohort/interface/dto/admin-cohort.response.dto.ts
+++ b/src/cohort/interface/dto/admin-cohort.response.dto.ts
@@ -1,0 +1,73 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import type { Cohort } from '../../domain/cohort.entity';
+import { CohortStatus } from '../../domain/cohort.status';
+import type { CohortPart } from '../../domain/cohort-part.entity';
+
+export class CohortPartAdminResponseDto {
+  @ApiProperty({ description: 'ID', example: 1 })
+  id: number;
+
+  @ApiProperty({ description: '파트명', example: 'Web' })
+  partName: string;
+
+  @ApiProperty({ description: '모집 오픈 여부', example: false })
+  isOpen: boolean;
+
+  @ApiProperty({
+    description: '지원서 스키마 JSON',
+    example: { questions: [] },
+  })
+  applicationSchema: Record<string, unknown>;
+
+  static from(part: CohortPart): CohortPartAdminResponseDto {
+    const dto = new CohortPartAdminResponseDto();
+    dto.id = part.id;
+    dto.partName = part.partName;
+    dto.isOpen = part.isOpen;
+    dto.applicationSchema = part.applicationSchema;
+    return dto;
+  }
+}
+
+export class CohortAdminResponseDto {
+  @ApiProperty({ description: 'ID', example: 1 })
+  id: number;
+
+  @ApiProperty({ description: '기수 명칭', example: '15기' })
+  name: string;
+
+  @ApiProperty({ description: '모집 시작일' })
+  recruitStartAt: Date;
+
+  @ApiProperty({ description: '모집 종료일' })
+  recruitEndAt: Date;
+
+  @ApiProperty({ description: '기수 상태', enum: CohortStatus })
+  status: CohortStatus;
+
+  @ApiProperty({
+    description: '파트별 모집 설정 목록',
+    type: [CohortPartAdminResponseDto],
+  })
+  parts: CohortPartAdminResponseDto[];
+
+  @ApiProperty({ description: '생성일' })
+  createdAt: Date;
+
+  @ApiProperty({ description: '수정일' })
+  updatedAt: Date;
+
+  static from(cohort: Cohort): CohortAdminResponseDto {
+    const dto = new CohortAdminResponseDto();
+    dto.id = cohort.id;
+    dto.name = cohort.name;
+    dto.recruitStartAt = cohort.recruitStartAt;
+    dto.recruitEndAt = cohort.recruitEndAt;
+    dto.status = cohort.status;
+    dto.parts = (cohort.parts ?? []).map((part) => CohortPartAdminResponseDto.from(part));
+    dto.createdAt = cohort.createdAt;
+    dto.updatedAt = cohort.updatedAt;
+    return dto;
+  }
+}

--- a/src/cohort/interface/dto/public-cohort.response.dto.ts
+++ b/src/cohort/interface/dto/public-cohort.response.dto.ts
@@ -1,0 +1,39 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import type { Cohort } from '../../domain/cohort.entity';
+import { CohortStatus } from '../../domain/cohort.status';
+
+export class PublicCohortResponseDto {
+  @ApiProperty({ description: 'ID', example: 1 })
+  id: number;
+
+  @ApiProperty({ description: '기수 명칭', example: '15기' })
+  name: string;
+
+  @ApiProperty({ description: '모집 시작일' })
+  recruitStartAt: Date;
+
+  @ApiProperty({ description: '모집 종료일' })
+  recruitEndAt: Date;
+
+  @ApiProperty({ description: '기수 상태', enum: CohortStatus })
+  status: CohortStatus;
+
+  @ApiProperty({ description: '지원 버튼 활성화 여부', example: true })
+  isRecruitmentOpen: boolean;
+
+  @ApiProperty({ description: '모집 중인 파트 목록', example: ['Web', 'Server'] })
+  openParts: string[];
+
+  static from(cohort: Cohort): PublicCohortResponseDto {
+    const dto = new PublicCohortResponseDto();
+    dto.id = cohort.id;
+    dto.name = cohort.name;
+    dto.recruitStartAt = cohort.recruitStartAt;
+    dto.recruitEndAt = cohort.recruitEndAt;
+    dto.status = cohort.status;
+    dto.openParts = (cohort.parts ?? []).filter((p) => p.isOpen).map((p) => p.partName);
+    dto.isRecruitmentOpen = cohort.status === CohortStatus.RECRUITING && dto.openParts.length > 0;
+    return dto;
+  }
+}

--- a/src/cohort/interface/public.cohort.controller.ts
+++ b/src/cohort/interface/public.cohort.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, HttpStatus } from '@nestjs/common';
+import { Get } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+
+import { AppException } from '../../common/exception/app.exception';
+import { ApiResponse } from '../../common/response/api-response';
+import { ApiDoc } from '../../common/swagger/api-doc.decorator';
+import { CohortService } from '../application/cohort.service';
+import { PublicCohortResponseDto } from './dto/public-cohort.response.dto';
+
+@ApiTags('Cohort')
+@Controller({ path: 'cohorts', version: '1' })
+export class PublicCohortController {
+  constructor(private readonly cohortService: CohortService) {}
+
+  @ApiDoc({
+    summary: '현재 활성 기수 조회',
+    description: '현재 모집 중이거나 활동 중인 기수 정보와 홈페이지 CTA 버튼 상태를 반환합니다.',
+  })
+  @Get('active')
+  async findActiveCohort() {
+    const cohort = await this.cohortService.findActiveCohort();
+    if (!cohort) {
+      throw new AppException('COHORT_NOT_FOUND', HttpStatus.NOT_FOUND);
+    }
+
+    return ApiResponse.ok(PublicCohortResponseDto.from(cohort));
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,9 +19,7 @@ const bootstrap = async () => {
 
   const configService = app.get(ConfigService);
 
-  if (configService.get('NODE_ENV') !== 'production') {
-    setupSwagger(app);
-  }
+  setupSwagger(app);
 
   const port = configService.getOrThrow<number>('PORT');
 

--- a/src/user/domain/user.entity.ts
+++ b/src/user/domain/user.entity.ts
@@ -20,7 +20,7 @@ export class User extends BaseEntity {
   @Column({ unique: true })
   sub: string;
 
-  @Column({ nullable: true })
+  @Column({ type: 'varchar', nullable: true })
   refreshToken: string | null;
 
   @Column({ nullable: true })

--- a/src/user/domain/user.repository.ts
+++ b/src/user/domain/user.repository.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 
 import { WriteRepository } from '../infrastructure/write.repository';
-import { UserType } from './user.type';
+import type { UserType } from './user.type';
 
 @Injectable()
 export class UserRepository {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1019,6 +1019,13 @@
     path-to-regexp "8.3.0"
     tslib "2.8.1"
 
+"@nestjs/schedule@^6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@nestjs/schedule/-/schedule-6.1.1.tgz#757775c099d4b5df8e11e9a8c2f701115b4ed5cd"
+  integrity sha512-kQl1RRgi02GJ0uaUGCrXHCcwISsCsJDciCKe38ykJZgnAeeoeVWs8luWtBo4AqAAXm4nS5K8RlV0smHUJ4+2FA==
+  dependencies:
+    cron "4.4.0"
+
 "@nestjs/schematics@^11.0.0", "@nestjs/schematics@^11.0.1":
   version "11.0.9"
   resolved "https://registry.yarnpkg.com/@nestjs/schematics/-/schematics-11.0.9.tgz#18a0d128c609be76410f5c7ea02680c8cd297113"
@@ -1309,6 +1316,11 @@
   dependencies:
     "@types/ms" "*"
     "@types/node" "*"
+
+"@types/luxon@~3.7.0":
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-3.7.1.tgz#ef51b960ff86801e4e2de80c68813a96e529d531"
+  integrity sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==
 
 "@types/methods@^1.1.4":
   version "1.1.4"
@@ -2494,6 +2506,14 @@ create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
+cron@4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/cron/-/cron-4.4.0.tgz#1488444a23ea7134e2b7686c17711abdffcebba8"
+  integrity sha512-fkdfq+b+AHI4cKdhZlppHveI/mgz2qpiYxcm+t5E5TsxX7QrLS1VE0+7GENEk9z0EeGPcpSciGv6ez24duWhwQ==
+  dependencies:
+    "@types/luxon" "~3.7.0"
+    luxon "~3.7.0"
 
 cross-spawn@^7.0.3, cross-spawn@^7.0.6:
   version "7.0.6"
@@ -4087,6 +4107,11 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+luxon@~3.7.0:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.7.2.tgz#d697e48f478553cca187a0f8436aff468e3ba0ba"
+  integrity sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==
 
 magic-string@0.30.17:
   version "0.30.17"


### PR DESCRIPTION
## 📌 PR 제목

> feat: 기수(Cohort) 도메인 전체 기능 구현

---

## ✅ PR 설명

- 기수(Cohort) 및 모집 파트(CohortPart) 엔티티 설계 및 구현
- 활성화된 기수(PLANNED, RECRUITING) 중복 생성 방지 비즈니스 로직(checkActiveCohortExists) 구현
- 기수 모집 상태(`RECRUITING` -> `ACTIVE`) 자동 전환 로직(`transitionExpiredToActive`) 구현
- 일반 웹사이트용 활성 기수 조회 공개 API (`GET /cohorts/active`) 연동
- 어드민용 기수 CRUD API (`/admin/cohorts`) 구현 및 Swagger Mocks 문서화 반영
- `AuthGuard('jwt')`를 통한 API 인증 파이프라인 연동
- 관련 이슈: #21 , #22 

---

## 🧪 테스트 방법

- [x] 로컬 환경 스웨거 테스트 완료 (`/api/v1/admin/cohorts`, `/api/v1/cohorts/active`)
- [x] 의존성 주입 및 모듈 연동 간 린트 및 빌드 통과

---

## 🔍 체크리스트

- [x] 코드에 주석/불필요한 로그 제거
- [x] 코드 리뷰어가 이해하기 쉽게 커밋 정리

---

## 📎 기타 참고 사항 (Optional)

- 모집 기간 만료 후 상태 자동 전환을 위한 `transitionExpiredToActive` 트랜잭션 로직을 서버 단 서비스에 구현해두었으며, 추후 스케줄러(Cron) 추가 시 즉시 연동되도록 모듈화했습니다.
- 다양한 모집 직군에서의 변화에 유연하게 대처하기 위해 파트 모집 스키마는 JSON 형태로 저장되도록 CohortPart 테이블에 `applicationSchema` 컬럼을 적용해 두었습니다.
