### PR TITLE
feat: hey-api 적용

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,3 +86,24 @@ jobs:
           GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
           GOOGLE_CALLBACK_URL: ${{ secrets.GOOGLE_CALLBACK_URL }}
           CLIENT_REDIRECT_URL: ${{ secrets.CLIENT_REDIRECT_URL }}
+
+  export-openapi:
+    runs-on: ubuntu-latest
+    needs: deploy
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Fetch OpenAPI spec
+        run: curl -sf "https://admin.dddstudy.site/api-docs/api-docs.json" -o openapi.json
+
+      - name: Commit OpenAPI spec
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add openapi.json
+          git diff --cached --quiet || git commit -m "chore: update openapi.json [skip ci]"
+          git push

--- a/src/cohort/interface/admin.cohort.controller.ts
+++ b/src/cohort/interface/admin.cohort.controller.ts
@@ -34,6 +34,7 @@ export class AdminCohortController {
   @ApiDoc({
     summary: '새 기수 생성',
     description: '새로운 기수를 생성합니다. 모집 파트 설정도 함께 포함할 수 있습니다.',
+    operationId: 'createAdminCohort',
     auth: true,
   })
   @Post()
@@ -54,6 +55,7 @@ export class AdminCohortController {
   @ApiDoc({
     summary: '기수 전체 목록 조회',
     description: '모든 기수와 각 기수별 파트 설정 정보를 조회합니다.',
+    operationId: 'getAdminCohorts',
     auth: true,
   })
   @Get()
@@ -65,6 +67,7 @@ export class AdminCohortController {
   @ApiDoc({
     summary: '기수 정보 및 상태 수정',
     description: '기수의 명칭, 일정, 상태 등을 수동으로 수정합니다.',
+    operationId: 'updateAdminCohortById',
     auth: true,
   })
   @Patch(':id')
@@ -77,6 +80,7 @@ export class AdminCohortController {
     summary: '기수별 파트 모집 설정',
     description:
       '기수별로 모집할 파트와 각 파트별 지원서 스키마(JSON)를 설정합니다. 전체 교체 방식으로 동작합니다.',
+    operationId: 'updateAdminCohortPartsById',
     auth: true,
   })
   @Put(':id/parts')
@@ -98,6 +102,7 @@ export class AdminCohortController {
   @ApiDoc({
     summary: '기수 삭제',
     description: '기수를 소프트 삭제합니다.',
+    operationId: 'deleteAdminCohortById',
     auth: true,
   })
   @Delete(':id')

--- a/src/cohort/interface/public.cohort.controller.ts
+++ b/src/cohort/interface/public.cohort.controller.ts
@@ -16,6 +16,7 @@ export class PublicCohortController {
   @ApiDoc({
     summary: '현재 활성 기수 조회',
     description: '현재 모집 중이거나 활동 중인 기수 정보와 홈페이지 CTA 버튼 상태를 반환합니다.',
+    operationId: 'getCohortActive',
   })
   @Get('active')
   async findActiveCohort() {

--- a/src/common/swagger/api-doc.decorator.ts
+++ b/src/common/swagger/api-doc.decorator.ts
@@ -10,7 +10,13 @@ interface ApiDocOptions {
   responses?: ApiResponseOptions[];
 }
 
-export const ApiDoc = ({ summary, description, operationId, auth = false, responses = [] }: ApiDocOptions) =>
+export const ApiDoc = ({
+  summary,
+  description,
+  operationId,
+  auth = false,
+  responses = [],
+}: ApiDocOptions) =>
   applyDecorators(
     ApiOperation({ summary, description, operationId }),
     ...(auth ? [ApiCookieAuth('access_token')] : []),

--- a/src/common/swagger/api-doc.decorator.ts
+++ b/src/common/swagger/api-doc.decorator.ts
@@ -5,13 +5,14 @@ import { ApiCookieAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
 interface ApiDocOptions {
   summary: string;
   description?: string;
+  operationId?: string;
   auth?: boolean;
   responses?: ApiResponseOptions[];
 }
 
-export const ApiDoc = ({ summary, description, auth = false, responses = [] }: ApiDocOptions) =>
+export const ApiDoc = ({ summary, description, operationId, auth = false, responses = [] }: ApiDocOptions) =>
   applyDecorators(
-    ApiOperation({ summary, description }),
+    ApiOperation({ summary, description, operationId }),
     ...(auth ? [ApiCookieAuth('access_token')] : []),
     ...responses.map((r) => ApiResponse(r)),
   );

--- a/src/google/interface/google-auth.controller.ts
+++ b/src/google/interface/google-auth.controller.ts
@@ -50,6 +50,7 @@ export class GoogleAuthController {
   @ApiDoc({
     summary: 'Google OAuth 로그인 시작',
     description: 'Google 로그인 페이지로 리다이렉트됩니다.',
+    operationId: 'getAuthGoogle',
   })
   @Get('google')
   @UseGuards(AuthGuard('google'))
@@ -58,6 +59,7 @@ export class GoogleAuthController {
   @ApiDoc({
     summary: 'Google OAuth 콜백',
     description: '로그인 성공 시 access_token · refresh_token 쿠키가 발급됩니다.',
+    operationId: 'getAuthGoogleCallback',
     responses: [GoogleAuthSwagger.googleCallback.success],
   })
   @Get('google/callback')
@@ -86,6 +88,7 @@ export class GoogleAuthController {
   @ApiDoc({
     summary: 'Access Token 재발급',
     description: 'refresh_token 쿠키를 사용해 새 토큰을 발급합니다. 두 쿠키 모두 갱신됩니다.',
+    operationId: 'refreshAuthToken',
     responses: [GoogleAuthSwagger.refresh.success, GoogleAuthSwagger.refresh.unauthorized],
   })
   @HttpCode(HttpStatus.OK)
@@ -113,6 +116,7 @@ export class GoogleAuthController {
   @ApiDoc({
     summary: '로그아웃',
     description: 'access_token · refresh_token 쿠키를 삭제합니다.',
+    operationId: 'logoutAuth',
     auth: true,
     responses: [GoogleAuthSwagger.logout.noContent, GoogleAuthSwagger.logout.unauthorized],
   })
@@ -129,6 +133,7 @@ export class GoogleAuthController {
   @ApiDoc({
     summary: '회원 탈퇴',
     description: 'Google 토큰 revoke 후 계정을 소프트 삭제합니다.',
+    operationId: 'deleteAuthWithdrawal',
     auth: true,
     responses: [
       GoogleAuthSwagger.withdrawal.noContent,

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get } from '@nestjs/common';
+import { ApiOperation } from '@nestjs/swagger';
 import { HealthCheck, HealthCheckService, TypeOrmHealthIndicator } from '@nestjs/terminus';
 
 @Controller({ path: 'health', version: '1' })
@@ -8,6 +9,7 @@ export class HealthController {
     private readonly database: TypeOrmHealthIndicator,
   ) {}
 
+  @ApiOperation({ summary: 'Health check', operationId: 'getHealth' })
   @Get()
   @HealthCheck()
   async check() {


### PR DESCRIPTION
## 📌 PR 제목

feat: hey-api 연동을 위한 Swagger operationId 추가 적용

---

## ✅ PR 설명

- 프론트엔드 API 클라이언트 자동 생성(`hey-api`)을 위해 전체 API 엔드포인트의 Swagger 명세에 `operationId`를 명시적으로 추가했습니다.
- 프론트엔드 환경에서 생성될 SDK 메서드명을 직관적으로 사용할 수 있도록 RESTful 표준(Verb+Noun) 네이밍 컨벤션을 따랐습니다. (예: `createAdminCohort`, `updateAdminCohortById`, `refreshAuthToken` 등)
- 기존 공통 커스텀 데코레이터(`@ApiDoc()`) 옵션을 확장하여 내부 `@ApiOperation()`에 `operationId`를 매핑하도록 구현했습니다.
- 예외:
  - 로그아웃(logoutAuth)
  - 리프레쉬 토큰(refreshAuthToken)
 
---

## 🧪 테스트 방법

- [x] 로컬 테스트 완료
- [x] 린트 및 빌드 통과 (타입 및 데코레이터 컴파일 에러 없음 검증 완료)

---

## 🔍 체크리스트

- [x] 코드에 주석/불필요한 로그 제거
- [x] 코드 리뷰어가 이해하기 쉽게 커밋 정리

---

## 📎 기타 참고 사항 (Optional)
