### PR TITLE
Feat/#31/blog

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -98,7 +98,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Fetch OpenAPI spec
-        run: curl -sf "https://admin.dddstudy.site/api-docs-json" -o openapi.json
+        run: curl -sf "https://admin.dddstudy.co.kr/api-docs-json" -o openapi.json
 
       - name: Commit OpenAPI spec
         run: |

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,3 +1,3 @@
-admin.dddstudy.site {
+admin.dddstudy.co.kr {
     reverse_proxy app:3000
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,7 @@ import { DataSource } from 'typeorm';
 import { addTransactionalDataSource } from 'typeorm-transactional';
 
 import { ApplicationModule } from './application/application.module';
+import { BlogModule } from './blog/blog.module';
 import { CohortModule } from './cohort/cohort.module';
 import { HttpExceptionFilter } from './common/exception/http-exception.filter';
 import { EncryptionTransformer } from './common/util/encryption.transformer';
@@ -36,6 +37,7 @@ const ENV_FILE_PATHS = ['.env.production', '.env.staging', '.env.test', '.env.de
     GoogleModule,
     CohortModule,
     ApplicationModule,
+    BlogModule,
   ],
   providers: [{ provide: APP_FILTER, useClass: HttpExceptionFilter }],
 })

--- a/src/blog/application/blog.service.spec.ts
+++ b/src/blog/application/blog.service.spec.ts
@@ -1,0 +1,169 @@
+import { HttpStatus } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+
+import { AppException } from '../../common/exception/app.exception';
+import { BlogRepository } from '../domain/blog.repository';
+import { BlogPost } from '../domain/blog-post.entity';
+import { BlogService } from './blog.service';
+
+jest.mock('typeorm-transactional', () => ({
+  Transactional: () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) =>
+    descriptor,
+  initializeTransactionalContext: jest.fn(),
+}));
+
+const mockBlogRepository = {
+  save: jest.fn(),
+  findById: jest.fn(),
+  findAll: jest.fn(),
+  update: jest.fn(),
+  deleteById: jest.fn(),
+};
+
+describe('BlogService', () => {
+  let blogService: BlogService;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [BlogService, { provide: BlogRepository, useValue: mockBlogRepository }],
+    }).compile();
+
+    blogService = module.get(BlogService);
+    jest.clearAllMocks();
+  });
+
+  const postFixture = {
+    id: 1,
+    title: 'DDD 15기 활동 후기',
+    excerpt: 'DDD 15기에서의 경험을 공유합니다.',
+    thumbnail: 'https://example.com/thumbnail.png',
+    externalUrl: 'https://medium.com/@ddd/post-1',
+    createdAt: new Date('2026-04-01'),
+    updatedAt: new Date('2026-04-01'),
+  } as BlogPost;
+
+  describe('createPost', () => {
+    it('블로그 게시글을 생성하고 반환한다', async () => {
+      // Given
+      const createInput = {
+        title: 'DDD 15기 활동 후기',
+        excerpt: 'DDD 15기에서의 경험을 공유합니다.',
+        thumbnail: 'https://example.com/thumbnail.png',
+        externalUrl: 'https://medium.com/@ddd/post-1',
+      };
+      mockBlogRepository.save.mockResolvedValue(postFixture);
+
+      // When
+      const result = await blogService.createPost({ post: createInput });
+
+      // Then
+      expect(result).toEqual(postFixture);
+      expect(mockBlogRepository.save).toHaveBeenCalledWith({
+        blogPost: expect.any(BlogPost),
+      });
+    });
+  });
+
+  describe('findAllPosts', () => {
+    it('모든 블로그 게시글을 반환한다', async () => {
+      // Given
+      mockBlogRepository.findAll.mockResolvedValue([postFixture]);
+
+      // When
+      const result = await blogService.findAllPosts();
+
+      // Then
+      expect(result).toEqual([postFixture]);
+      expect(mockBlogRepository.findAll).toHaveBeenCalled();
+    });
+  });
+
+  describe('findPostById', () => {
+    it('게시글이 존재하면 반환한다', async () => {
+      // Given
+      mockBlogRepository.findById.mockResolvedValue(postFixture);
+
+      // When
+      const result = await blogService.findPostById({ id: 1 });
+
+      // Then
+      expect(result).toEqual(postFixture);
+      expect(mockBlogRepository.findById).toHaveBeenCalledWith({ id: 1 });
+    });
+
+    it('게시글이 존재하지 않으면 BLOG_POST_NOT_FOUND 예외를 던진다', async () => {
+      // Given
+      mockBlogRepository.findById.mockResolvedValue(null);
+
+      // When & Then
+      await expect(blogService.findPostById({ id: 999 })).rejects.toThrow(
+        new AppException('BLOG_POST_NOT_FOUND', HttpStatus.NOT_FOUND),
+      );
+    });
+  });
+
+  describe('updatePost', () => {
+    it('게시글이 존재하면 수정한다', async () => {
+      // Given
+      const updateData = { title: '수정된 제목' };
+      mockBlogRepository.findById.mockResolvedValue(postFixture);
+      mockBlogRepository.update.mockResolvedValue(undefined);
+
+      // When
+      await blogService.updatePost({ id: 1, data: updateData });
+
+      // Then
+      expect(mockBlogRepository.update).toHaveBeenCalledWith({
+        id: 1,
+        patch: updateData,
+      });
+    });
+
+    it('변경 사항이 없으면 업데이트를 수행하지 않는다', async () => {
+      // Given
+      mockBlogRepository.findById.mockResolvedValue(postFixture);
+
+      // When
+      await blogService.updatePost({ id: 1, data: {} });
+
+      // Then
+      expect(mockBlogRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('게시글이 존재하지 않으면 BLOG_POST_NOT_FOUND 예외를 던진다', async () => {
+      // Given
+      mockBlogRepository.findById.mockResolvedValue(null);
+
+      // When & Then
+      await expect(blogService.updatePost({ id: 999, data: { title: '수정' } })).rejects.toThrow(
+        new AppException('BLOG_POST_NOT_FOUND', HttpStatus.NOT_FOUND),
+      );
+      expect(mockBlogRepository.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deletePost', () => {
+    it('게시글이 존재하면 소프트 삭제한다', async () => {
+      // Given
+      mockBlogRepository.findById.mockResolvedValue(postFixture);
+      mockBlogRepository.deleteById.mockResolvedValue(undefined);
+
+      // When
+      await blogService.deletePost({ id: 1 });
+
+      // Then
+      expect(mockBlogRepository.deleteById).toHaveBeenCalledWith({ id: 1 });
+    });
+
+    it('게시글이 존재하지 않으면 BLOG_POST_NOT_FOUND 예외를 던진다', async () => {
+      // Given
+      mockBlogRepository.findById.mockResolvedValue(null);
+
+      // When & Then
+      await expect(blogService.deletePost({ id: 999 })).rejects.toThrow(
+        new AppException('BLOG_POST_NOT_FOUND', HttpStatus.NOT_FOUND),
+      );
+      expect(mockBlogRepository.deleteById).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/blog/application/blog.service.spec.ts
+++ b/src/blog/application/blog.service.spec.ts
@@ -59,7 +59,7 @@ describe('BlogService', () => {
       // Then
       expect(result).toEqual(postFixture);
       expect(mockBlogRepository.save).toHaveBeenCalledWith({
-        blogPost: expect.any(BlogPost),
+        blogPost: expect.any(BlogPost) as unknown,
       });
     });
   });

--- a/src/blog/application/blog.service.ts
+++ b/src/blog/application/blog.service.ts
@@ -1,0 +1,55 @@
+import { HttpStatus, Injectable } from '@nestjs/common';
+import { Transactional } from 'typeorm-transactional';
+
+import { AppException } from '../../common/exception/app.exception';
+import { BlogRepository } from '../domain/blog.repository';
+import type { BlogPostCreateType, BlogPostUpdateType } from '../domain/blog.type';
+import { BlogPost } from '../domain/blog-post.entity';
+
+@Injectable()
+export class BlogService {
+  constructor(private readonly blogRepository: BlogRepository) {}
+
+  @Transactional()
+  async createPost({ post }: { post: BlogPostCreateType }) {
+    const blogPost = BlogPost.create(post);
+    return this.blogRepository.save({ blogPost });
+  }
+
+  async findAllPosts() {
+    return this.blogRepository.findAll();
+  }
+
+  async findPostById({ id }: { id: number }) {
+    const post = await this.blogRepository.findById({ id });
+    if (!post) {
+      throw new AppException('BLOG_POST_NOT_FOUND', HttpStatus.NOT_FOUND);
+    }
+    return post;
+  }
+
+  @Transactional()
+  async updatePost({ id, data }: { id: number; data: BlogPostUpdateType }) {
+    const post = await this.blogRepository.findById({ id });
+    if (!post) {
+      throw new AppException('BLOG_POST_NOT_FOUND', HttpStatus.NOT_FOUND);
+    }
+
+    const hasUpdate = Object.values(data).some((v) => v !== undefined);
+    if (!hasUpdate) {
+      return;
+    }
+
+    await this.blogRepository.update({ id, patch: data });
+  }
+
+  @Transactional()
+  async deletePost({ id }: { id: number }) {
+    const post = await this.blogRepository.findById({ id });
+    if (!post) {
+      throw new AppException('BLOG_POST_NOT_FOUND', HttpStatus.NOT_FOUND);
+    }
+
+    await this.blogRepository.deleteById({ id });
+  }
+}

--- a/src/blog/blog.module.ts
+++ b/src/blog/blog.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { RolesGuard } from '../common/guard/roles.guard';
+import { BlogService } from './application/blog.service';
+import { BlogRepository } from './domain/blog.repository';
+import { BlogPost } from './domain/blog-post.entity';
+import { WriteRepository } from './infrastructure/write.repository';
+import { AdminBlogController } from './interface/admin.blog.controller';
+import { PublicBlogController } from './interface/public.blog.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([BlogPost])],
+  controllers: [AdminBlogController, PublicBlogController],
+  providers: [BlogService, BlogRepository, WriteRepository, RolesGuard],
+  exports: [BlogService],
+})
+export class BlogModule {}

--- a/src/blog/domain/blog-post.entity.ts
+++ b/src/blog/domain/blog-post.entity.ts
@@ -1,0 +1,56 @@
+import { Column, Entity } from 'typeorm';
+
+import { BaseEntity } from '../../common/core/base.entity';
+
+@Entity('blog_posts')
+export class BlogPost extends BaseEntity {
+  @Column()
+  title: string;
+
+  @Column({ type: 'text' })
+  excerpt: string;
+
+  @Column({ nullable: true })
+  thumbnail: string;
+
+  @Column()
+  externalUrl: string;
+
+  static create({
+    title,
+    excerpt,
+    thumbnail,
+    externalUrl,
+  }: {
+    title: string;
+    excerpt: string;
+    thumbnail?: string;
+    externalUrl: string;
+  }): BlogPost {
+    const post = new BlogPost();
+    post.title = title;
+    post.excerpt = excerpt;
+    if (thumbnail) {
+      post.thumbnail = thumbnail;
+    }
+    post.externalUrl = externalUrl;
+    return post;
+  }
+
+  update({
+    title,
+    excerpt,
+    thumbnail,
+    externalUrl,
+  }: {
+    title?: string;
+    excerpt?: string;
+    thumbnail?: string;
+    externalUrl?: string;
+  }): void {
+    if (title !== undefined) this.title = title;
+    if (excerpt !== undefined) this.excerpt = excerpt;
+    if (thumbnail !== undefined) this.thumbnail = thumbnail;
+    if (externalUrl !== undefined) this.externalUrl = externalUrl;
+  }
+}

--- a/src/blog/domain/blog.repository.ts
+++ b/src/blog/domain/blog.repository.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+
+import { WriteRepository } from '../infrastructure/write.repository';
+import type { BlogPostUpdatePatch } from '../infrastructure/write.repository.type';
+import { BlogPost } from './blog-post.entity';
+
+@Injectable()
+export class BlogRepository {
+  constructor(private readonly writeRepository: WriteRepository) {}
+
+  async save({ blogPost }: { blogPost: BlogPost }) {
+    return this.writeRepository.save({ blogPost });
+  }
+
+  async findById({ id }: { id: number }) {
+    return this.writeRepository.findOne({ where: { id } });
+  }
+
+  async findAll() {
+    return this.writeRepository.findMany();
+  }
+
+  async update({ id, patch }: { id: number; patch: BlogPostUpdatePatch }) {
+    await this.writeRepository.update({ id, patch });
+  }
+
+  async deleteById({ id }: { id: number }) {
+    await this.writeRepository.softDelete({ where: { id } });
+  }
+}

--- a/src/blog/domain/blog.type.ts
+++ b/src/blog/domain/blog.type.ts
@@ -1,0 +1,13 @@
+export type BlogPostCreateType = {
+  title: string;
+  excerpt: string;
+  thumbnail?: string;
+  externalUrl: string;
+};
+
+export type BlogPostUpdateType = {
+  title?: string;
+  excerpt?: string;
+  thumbnail?: string;
+  externalUrl?: string;
+};

--- a/src/blog/infrastructure/write.repository.ts
+++ b/src/blog/infrastructure/write.repository.ts
@@ -1,0 +1,61 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource, FindOptionsWhere, Repository } from 'typeorm';
+
+import { BlogPost } from '../domain/blog-post.entity';
+import type { BlogPostFilter, BlogPostUpdatePatch } from './write.repository.type';
+
+@Injectable()
+export class WriteRepository {
+  private readonly repository: Repository<BlogPost>;
+
+  constructor(dataSource: DataSource) {
+    this.repository = dataSource.getRepository(BlogPost);
+  }
+
+  async save({ blogPost }: { blogPost: BlogPost }) {
+    return this.repository.save(blogPost);
+  }
+
+  async findOne({ where }: { where: BlogPostFilter }) {
+    return this.repository.findOne({ where: this.toWhereOptions(where) });
+  }
+
+  async findMany({ where = {} }: { where?: BlogPostFilter } = {}) {
+    return this.repository.find({
+      where: this.toWhereOptions(where),
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async update({ id, patch }: { id: number; patch: BlogPostUpdatePatch }) {
+    const defined = Object.fromEntries(Object.entries(patch).filter(([, v]) => v !== undefined));
+    if (Object.keys(defined).length === 0) {
+      return;
+    }
+    await this.repository.update(id, defined);
+  }
+
+  async softDelete({ where }: { where: BlogPostFilter }) {
+    const whereOptions = this.toWhereOptions(where);
+
+    if (this.isEmptyWhere(whereOptions)) {
+      throw new Error('BlogPost softDelete requires at least one where condition.');
+    }
+
+    await this.repository.softDelete(whereOptions);
+  }
+
+  private toWhereOptions(filter: BlogPostFilter): FindOptionsWhere<BlogPost> {
+    const where: FindOptionsWhere<BlogPost> = {};
+
+    if (filter.id !== undefined) {
+      where.id = filter.id;
+    }
+
+    return where;
+  }
+
+  private isEmptyWhere(where: FindOptionsWhere<BlogPost>) {
+    return Object.keys(where).length === 0;
+  }
+}

--- a/src/blog/infrastructure/write.repository.type.ts
+++ b/src/blog/infrastructure/write.repository.type.ts
@@ -1,0 +1,10 @@
+export type BlogPostFilter = {
+  id?: number;
+};
+
+export type BlogPostUpdatePatch = {
+  title?: string;
+  excerpt?: string;
+  thumbnail?: string;
+  externalUrl?: string;
+};

--- a/src/blog/interface/admin.blog.controller.ts
+++ b/src/blog/interface/admin.blog.controller.ts
@@ -1,0 +1,92 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { ApiTags } from '@nestjs/swagger';
+
+import { Roles } from '../../common/decorator/roles.decorator';
+import { RolesGuard } from '../../common/guard/roles.guard';
+import { ApiResponse } from '../../common/response/api-response';
+import { ApiDoc } from '../../common/swagger/api-doc.decorator';
+import { UserRole } from '../../user/domain/user.role';
+import { BlogService } from '../application/blog.service';
+import { CreateBlogPostRequestDto, UpdateBlogPostRequestDto } from './dto/blog.request.dto';
+import { BlogPostResponseDto } from './dto/blog.response.dto';
+
+@ApiTags('Admin - Blog')
+@Controller({ path: 'admin/blog-posts', version: '1' })
+@UseGuards(AuthGuard('jwt'), RolesGuard)
+@Roles(UserRole.계정관리)
+export class AdminBlogController {
+  constructor(private readonly blogService: BlogService) {}
+
+  @ApiDoc({
+    summary: '블로그 게시글 생성',
+    description: '새로운 블로그 게시글을 생성합니다.',
+    operationId: 'blog_createAdmin',
+    auth: true,
+  })
+  @Post()
+  async createPost(@Body() body: CreateBlogPostRequestDto) {
+    const post = await this.blogService.createPost({ post: body });
+    return ApiResponse.ok(BlogPostResponseDto.from(post));
+  }
+
+  @ApiDoc({
+    summary: '블로그 게시글 전체 목록 조회',
+    description: '모든 블로그 게시글을 조회합니다.',
+    operationId: 'blog_getAdminList',
+    auth: true,
+  })
+  @Get()
+  async findAllPosts() {
+    const posts = await this.blogService.findAllPosts();
+    return ApiResponse.ok(posts.map((post) => BlogPostResponseDto.from(post)));
+  }
+
+  @ApiDoc({
+    summary: '블로그 게시글 상세 조회',
+    description: '특정 블로그 게시글의 상세 정보를 조회합니다.',
+    operationId: 'blog_getAdminById',
+    auth: true,
+  })
+  @Get(':id')
+  async findPostById(@Param('id', ParseIntPipe) id: number) {
+    const post = await this.blogService.findPostById({ id });
+    return ApiResponse.ok(BlogPostResponseDto.from(post));
+  }
+
+  @ApiDoc({
+    summary: '블로그 게시글 수정',
+    description: '블로그 게시글 정보를 수정합니다.',
+    operationId: 'blog_updateAdminById',
+    auth: true,
+  })
+  @Patch(':id')
+  async updatePost(@Param('id', ParseIntPipe) id: number, @Body() body: UpdateBlogPostRequestDto) {
+    await this.blogService.updatePost({ id, data: body });
+    return ApiResponse.ok(null, '블로그 게시글이 수정되었습니다.');
+  }
+
+  @ApiDoc({
+    summary: '블로그 게시글 삭제',
+    description: '블로그 게시글을 소프트 삭제합니다.',
+    operationId: 'blog_deleteAdminById',
+    auth: true,
+  })
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async deletePost(@Param('id', ParseIntPipe) id: number) {
+    await this.blogService.deletePost({ id });
+  }
+}

--- a/src/blog/interface/dto/blog.request.dto.ts
+++ b/src/blog/interface/dto/blog.request.dto.ts
@@ -1,0 +1,49 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsNotEmpty, IsOptional, IsString, IsUrl } from 'class-validator';
+
+export class CreateBlogPostRequestDto {
+  @ApiProperty({ description: '블로그 제목', example: 'DDD 15기 활동 후기' })
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @ApiProperty({ description: '블로그 요약', example: 'DDD 15기에서의 경험을 공유합니다.' })
+  @IsString()
+  @IsNotEmpty()
+  excerpt: string;
+
+  @ApiPropertyOptional({
+    description: '썸네일 URL',
+    example: 'https://example.com/thumbnail.png',
+  })
+  @IsUrl()
+  @IsOptional()
+  thumbnail?: string;
+
+  @ApiProperty({ description: '외부 링크 URL', example: 'https://medium.com/@ddd/post-1' })
+  @IsUrl()
+  @IsNotEmpty()
+  externalUrl: string;
+}
+
+export class UpdateBlogPostRequestDto {
+  @ApiPropertyOptional({ description: '블로그 제목', example: 'DDD 15기 활동 후기 (수정)' })
+  @IsString()
+  @IsOptional()
+  title?: string;
+
+  @ApiPropertyOptional({ description: '블로그 요약' })
+  @IsString()
+  @IsOptional()
+  excerpt?: string;
+
+  @ApiPropertyOptional({ description: '썸네일 URL' })
+  @IsUrl()
+  @IsOptional()
+  thumbnail?: string;
+
+  @ApiPropertyOptional({ description: '외부 링크 URL' })
+  @IsUrl()
+  @IsOptional()
+  externalUrl?: string;
+}

--- a/src/blog/interface/dto/blog.response.dto.ts
+++ b/src/blog/interface/dto/blog.response.dto.ts
@@ -1,0 +1,38 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { BlogPost } from '../../domain/blog-post.entity';
+
+export class BlogPostResponseDto {
+  @ApiProperty({ description: 'ID', example: 1 })
+  id: number;
+
+  @ApiProperty({ description: '블로그 제목', example: 'DDD 15기 활동 후기' })
+  title: string;
+
+  @ApiProperty({ description: '블로그 요약', example: 'DDD 15기에서의 경험을 공유합니다.' })
+  excerpt: string;
+
+  @ApiProperty({ description: '썸네일 URL', nullable: true })
+  thumbnail: string | null;
+
+  @ApiProperty({ description: '외부 링크 URL', example: 'https://medium.com/@ddd/post-1' })
+  externalUrl: string;
+
+  @ApiProperty({ description: '생성 일시' })
+  createdAt: Date;
+
+  @ApiProperty({ description: '수정 일시' })
+  updatedAt: Date;
+
+  static from(post: BlogPost): BlogPostResponseDto {
+    const dto = new BlogPostResponseDto();
+    dto.id = post.id;
+    dto.title = post.title;
+    dto.excerpt = post.excerpt;
+    dto.thumbnail = post.thumbnail ?? null;
+    dto.externalUrl = post.externalUrl;
+    dto.createdAt = post.createdAt;
+    dto.updatedAt = post.updatedAt;
+    return dto;
+  }
+}

--- a/src/blog/interface/public.blog.controller.ts
+++ b/src/blog/interface/public.blog.controller.ts
@@ -1,0 +1,24 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+
+import { ApiResponse } from '../../common/response/api-response';
+import { ApiDoc } from '../../common/swagger/api-doc.decorator';
+import { BlogService } from '../application/blog.service';
+import { BlogPostResponseDto } from './dto/blog.response.dto';
+
+@ApiTags('Blog')
+@Controller({ path: 'blog-posts', version: '1' })
+export class PublicBlogController {
+  constructor(private readonly blogService: BlogService) {}
+
+  @ApiDoc({
+    summary: '블로그 게시글 목록 조회',
+    description: '공개된 블로그 게시글 목록을 조회합니다. 외부 링크 목록을 제공합니다.',
+    operationId: 'blog_getPublicList',
+  })
+  @Get()
+  async findAllPosts() {
+    const posts = await this.blogService.findAllPosts();
+    return ApiResponse.ok(posts.map((post) => BlogPostResponseDto.from(post)));
+  }
+}

--- a/src/common/error/error-message.ts
+++ b/src/common/error/error-message.ts
@@ -24,6 +24,8 @@ export const ErrorMessage = {
 
   INTERVIEW_SLOT_NOT_FOUND: '면접 슬롯을 찾을 수 없습니다.',
   INTERVIEW_SLOT_ALREADY_RESERVED: '이미 예약된 면접 슬롯입니다.',
+
+  BLOG_POST_NOT_FOUND: '블로그 게시글을 찾을 수 없습니다.',
 } as const;
 
 export type ErrorMessageKey = keyof typeof ErrorMessage;


### PR DESCRIPTION
## 📌 PR 제목

feat: 블로그 도메인 구현

---

## ✅ PR 설명

- 블로그 게시글(BlogPost) 도메인 전체 DDD Layered Architecture 구현
- 공개 API: 블로그 외부 링크 목록 조회 (`GET /api/v1/blog-posts`)
- 어드민 API: 블로그 CRUD (`POST/GET/PATCH/DELETE /api/v1/admin/blog-posts`)
- 관련 이슈: #31

### 구현 범위 (PLAN.md 섹션 4)

| 요구사항 | 상태 |
|---|---|
| `BlogPost` 엔티티: `thumbnail`, `title`, `excerpt`, `external_url` | ✅ |
| 공개 API: 외부 링크 목록 제공 (MVP, 내부 본문 페이지 미포함) | ✅ |
| 어드민 API: 블로그 CRUD + 공개 URL 생성 | ✅ |

### 파일 구조

```
src/blog/
├── application/
│   ├── blog.service.ts
│   └── blog.service.spec.ts
├── domain/
│   ├── blog-post.entity.ts
│   ├── blog.repository.ts
│   └── blog.type.ts
├── infrastructure/
│   ├── write.repository.ts
│   └── write.repository.type.ts
├── interface/
│   ├── admin.blog.controller.ts
│   ├── public.blog.controller.ts
│   └── dto/
│       ├── blog.request.dto.ts
│       └── blog.response.dto.ts
└── blog.module.ts
```

---

## 🧪 테스트 방법

- [x] 로컬 테스트 완료 (curl로 전체 CRUD + 예외 케이스 API 테스트)
- [x] 린트 및 빌드 통과
- [x] 유닛 테스트 9건 통과 (`BlogService` 전체 메서드)

### 테스트 결과

| 테스트 | 결과 |
|---|---|
| 게시글 생성 | ✅ 201 |
| Admin/Public 목록 조회 | ✅ 200 |
| 상세 조회 | ✅ 200 |
| 게시글 수정 | ✅ 200 |
| 게시글 삭제 (소프트) | ✅ 204 |
| 존재하지 않는 게시글 조회 | ✅ 404 BLOG_POST_NOT_FOUND |
| 인증 없이 Admin API 접근 | ✅ 401 UNAUTHORIZED |

---

## 🔍 체크리스트
- [x] 코드에 주석/불필요한 로그 제거
- [x] 코드 리뷰어가 이해하기 쉽게 커밋 정리
- [x] CODE_RULES.md 컨벤션 준수
- [x] DDD Layered Architecture 계층 분리 준수

---

## 📎 기타 참고 사항