### PR TITLE
Feat/#32/notification

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
           host: ${{ secrets.GCP_VM_HOST }}
           username: ${{ secrets.GCP_VM_USER }}
           key: ${{ secrets.GCP_VM_SSH_KEY }}
-          envs: GHCR_TOKEN,GITHUB_ACTOR,APP_IMAGE,APP_PORT,DB_PORT,DB_USERNAME,DB_PASSWORD,DB_NAME,JWT_SECRET,JWT_EXPIRES_IN,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_CALLBACK_URL,CLIENT_REDIRECT_URL
+          envs: GHCR_TOKEN,GITHUB_ACTOR,APP_IMAGE,APP_PORT,DB_PORT,DB_USERNAME,DB_PASSWORD,DB_NAME,JWT_SECRET,JWT_EXPIRES_IN,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_CALLBACK_URL,CLIENT_REDIRECT_URL,ENCRYPTION_KEY
           script: |
             echo "$GHCR_TOKEN" | sudo docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
             sudo docker pull "$APP_IMAGE"
@@ -61,6 +61,7 @@ jobs:
             printf 'GOOGLE_CLIENT_SECRET=%s\n' "$GOOGLE_CLIENT_SECRET" >> .env.production
             printf 'GOOGLE_CALLBACK_URL=%s\n' "$GOOGLE_CALLBACK_URL" >> .env.production
             printf 'CLIENT_REDIRECT_URL=%s\n' "$CLIENT_REDIRECT_URL" >> .env.production
+            printf 'ENCRYPTION_KEY=%s\n' "$ENCRYPTION_KEY" >> .env.production
             sudo APP_ENV_FILE=.env.production docker compose --env-file .env.production up -d
             for i in $(seq 1 12); do
               curl -sf "http://localhost:${APP_PORT:-3000}/api/v1/health" && break
@@ -86,6 +87,7 @@ jobs:
           GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
           GOOGLE_CALLBACK_URL: ${{ secrets.GOOGLE_CALLBACK_URL }}
           CLIENT_REDIRECT_URL: ${{ secrets.CLIENT_REDIRECT_URL }}
+          ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
 
   export-openapi:
     runs-on: ubuntu-latest

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -16,7 +16,6 @@ import { validate } from './config/env.validation';
 import { createTypeOrmModuleOptions } from './config/typeorm.config';
 import { GoogleModule } from './google/google.module';
 import { HealthModule } from './health/health.module';
-import { NotificationModule } from './notification/notification.module';
 import { ProjectModule } from './project/project.module';
 
 const ENV_FILE_PATHS = ['.env.production', '.env.staging', '.env.test', '.env.development', '.env'];
@@ -40,7 +39,6 @@ const ENV_FILE_PATHS = ['.env.production', '.env.staging', '.env.test', '.env.de
     CohortModule,
     ApplicationModule,
     BlogModule,
-    NotificationModule,
     ProjectModule,
   ],
   providers: [{ provide: APP_FILTER, useClass: HttpExceptionFilter }],

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -16,6 +16,7 @@ import { validate } from './config/env.validation';
 import { createTypeOrmModuleOptions } from './config/typeorm.config';
 import { GoogleModule } from './google/google.module';
 import { HealthModule } from './health/health.module';
+import { NotificationModule } from './notification/notification.module';
 import { ProjectModule } from './project/project.module';
 
 const ENV_FILE_PATHS = ['.env.production', '.env.staging', '.env.test', '.env.development', '.env'];
@@ -39,6 +40,7 @@ const ENV_FILE_PATHS = ['.env.production', '.env.staging', '.env.test', '.env.de
     CohortModule,
     ApplicationModule,
     BlogModule,
+    NotificationModule,
     ProjectModule,
   ],
   providers: [{ provide: APP_FILTER, useClass: HttpExceptionFilter }],

--- a/src/common/error/error-message.ts
+++ b/src/common/error/error-message.ts
@@ -28,6 +28,9 @@ export const ErrorMessage = {
   BLOG_POST_NOT_FOUND: '블로그 게시글을 찾을 수 없습니다.',
 
   PROJECT_NOT_FOUND: '프로젝트를 찾을 수 없습니다.',
+
+  EARLY_NOTIFICATION_CONFLICT:
+    '사전 알림 처리 중 일시적인 충돌이 발생했습니다. 다시 시도해주세요.',
 } as const;
 
 export type ErrorMessageKey = keyof typeof ErrorMessage;

--- a/src/notification/application/early-notification.service.spec.ts
+++ b/src/notification/application/early-notification.service.spec.ts
@@ -1,0 +1,284 @@
+jest.mock('typeorm-transactional', () => ({
+  Transactional: () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) =>
+    descriptor,
+  initializeTransactionalContext: jest.fn(),
+}));
+
+import { HttpStatus } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { QueryFailedError } from 'typeorm';
+
+import { CohortRepository } from '../../cohort/domain/cohort.repository';
+import { AppException } from '../../common/exception/app.exception';
+import { EarlyNotificationRepository } from '../domain/early-notification.repository';
+import { EarlyNotificationService } from './early-notification.service';
+import { NotificationService } from './notification.service';
+
+const mockEarlyNotificationRepository = {
+  register: jest.fn(),
+  existsByCohortAndEmail: jest.fn(),
+  findByCohort: jest.fn(),
+  findOne: jest.fn(),
+  findManyByIds: jest.fn(),
+  markManyNotified: jest.fn(),
+};
+
+const mockCohortRepository = {
+  findById: jest.fn(),
+};
+
+const mockNotificationService = {
+  sendEmail: jest.fn(),
+};
+
+describe('EarlyNotificationService', () => {
+  let earlyNotificationService: EarlyNotificationService;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        EarlyNotificationService,
+        { provide: EarlyNotificationRepository, useValue: mockEarlyNotificationRepository },
+        { provide: CohortRepository, useValue: mockCohortRepository },
+        { provide: NotificationService, useValue: mockNotificationService },
+      ],
+    }).compile();
+
+    earlyNotificationService = module.get(EarlyNotificationService);
+    jest.clearAllMocks();
+  });
+
+  describe('subscribe', () => {
+    const payload = { cohortId: 1, email: 'test@example.com' };
+
+    it('기수가 존재하지 않으면 COHORT_NOT_FOUND 예외를 던진다', async () => {
+      // Given
+      mockCohortRepository.findById.mockResolvedValue(null);
+
+      // When & Then
+      await expect(earlyNotificationService.subscribe(payload)).rejects.toThrow(
+        new AppException('COHORT_NOT_FOUND', HttpStatus.NOT_FOUND),
+      );
+      expect(mockCohortRepository.findById).toHaveBeenCalledWith({ id: 1 });
+    });
+
+    it('이미 신청한 이메일이면 기존 레코드를 반환한다', async () => {
+      // Given
+      const found = { id: 10, cohortId: 1, email: 'test@example.com', notifiedAt: null };
+      mockCohortRepository.findById.mockResolvedValue({ id: 1, name: '16기' });
+      mockEarlyNotificationRepository.findOne.mockResolvedValue(found);
+
+      // When
+      const result = await earlyNotificationService.subscribe(payload);
+
+      // Then
+      expect(result).toBe(found);
+      expect(mockEarlyNotificationRepository.register).not.toHaveBeenCalled();
+    });
+
+    it('신규 이메일이면 등록하고 반환한다', async () => {
+      // Given
+      const created = { id: 11, cohortId: 1, email: 'test@example.com', notifiedAt: null };
+      mockCohortRepository.findById.mockResolvedValue({ id: 1, name: '16기' });
+      mockEarlyNotificationRepository.findOne.mockResolvedValue(null);
+      mockEarlyNotificationRepository.register.mockResolvedValue(created);
+
+      // When
+      const result = await earlyNotificationService.subscribe(payload);
+
+      // Then
+      expect(result).toBe(created);
+      expect(mockEarlyNotificationRepository.register).toHaveBeenCalledWith({
+        cohortId: 1,
+        email: 'test@example.com',
+      });
+    });
+
+    it('동시 요청으로 unique 제약 위반 시 기존 레코드를 반환한다', async () => {
+      // Given
+      const record = { id: 12, cohortId: 1, email: 'test@example.com', notifiedAt: null };
+      mockCohortRepository.findById.mockResolvedValue({ id: 1, name: '16기' });
+      mockEarlyNotificationRepository.findOne
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(record);
+
+      const uniqueViolation = new QueryFailedError('INSERT', [], new Error('duplicate'));
+      (uniqueViolation as unknown as { driverError: { code: string } }).driverError = {
+        code: '23505',
+      };
+      mockEarlyNotificationRepository.register.mockRejectedValue(uniqueViolation);
+
+      // When
+      const result = await earlyNotificationService.subscribe(payload);
+
+      // Then
+      expect(result).toBe(record);
+      expect(mockEarlyNotificationRepository.findOne).toHaveBeenCalledTimes(2);
+    });
+
+    it('unique 제약 위반 후 재조회 결과가 null이면 EARLY_NOTIFICATION_CONFLICT(409)를 던진다', async () => {
+      // Given
+      mockCohortRepository.findById.mockResolvedValue({ id: 1, name: '16기' });
+      mockEarlyNotificationRepository.findOne
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null);
+
+      const uniqueViolation = new QueryFailedError('INSERT', [], new Error('duplicate'));
+      (uniqueViolation as unknown as { driverError: { code: string } }).driverError = {
+        code: '23505',
+      };
+      mockEarlyNotificationRepository.register.mockRejectedValue(uniqueViolation);
+
+      // When & Then
+      await expect(earlyNotificationService.subscribe(payload)).rejects.toThrow(
+        new AppException('EARLY_NOTIFICATION_CONFLICT', HttpStatus.CONFLICT),
+      );
+    });
+  });
+
+  describe('sendBulk', () => {
+    const bulkPayload = {
+      cohortId: 1,
+      subject: '[DDD] 모집 시작',
+      html: '<p>모집</p>',
+      text: '모집',
+    };
+
+    it('미발송 대상 전원에게 발송 성공하면 전부 notified 처리한다', async () => {
+      // Given
+      const records = [
+        { id: 1, email: 'a@test.com' },
+        { id: 2, email: 'b@test.com' },
+      ];
+      mockEarlyNotificationRepository.findByCohort.mockResolvedValue(records);
+      mockNotificationService.sendEmail.mockResolvedValue(undefined);
+      mockEarlyNotificationRepository.markManyNotified.mockResolvedValue(undefined);
+
+      // When
+      const result = await earlyNotificationService.sendBulk(bulkPayload);
+
+      // Then
+      expect(result).toEqual({ total: 2, success: 2, failed: 0 });
+      expect(mockNotificationService.sendEmail).toHaveBeenCalledTimes(2);
+      expect(mockEarlyNotificationRepository.markManyNotified).toHaveBeenCalledWith({
+        ids: [1, 2],
+        notifiedAt: expect.any(Date) as unknown,
+      });
+    });
+
+    it('일부 발송 실패 시 성공한 건만 notified 처리한다', async () => {
+      // Given
+      const records = [
+        { id: 1, email: 'a@test.com' },
+        { id: 2, email: 'b@test.com' },
+        { id: 3, email: 'c@test.com' },
+      ];
+      mockEarlyNotificationRepository.findByCohort.mockResolvedValue(records);
+      mockNotificationService.sendEmail
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error('발송 실패'))
+        .mockResolvedValueOnce(undefined);
+      mockEarlyNotificationRepository.markManyNotified.mockResolvedValue(undefined);
+
+      // When
+      const result = await earlyNotificationService.sendBulk(bulkPayload);
+
+      // Then
+      expect(result).toEqual({ total: 3, success: 2, failed: 1 });
+      expect(mockEarlyNotificationRepository.markManyNotified).toHaveBeenCalledWith({
+        ids: [1, 3],
+        notifiedAt: expect.any(Date) as unknown,
+      });
+    });
+
+    it('전원 발송 실패 시 markManyNotified를 호출하지 않는다', async () => {
+      // Given
+      const records = [
+        { id: 1, email: 'a@test.com' },
+        { id: 2, email: 'b@test.com' },
+      ];
+      mockEarlyNotificationRepository.findByCohort.mockResolvedValue(records);
+      mockNotificationService.sendEmail.mockRejectedValue(new Error('발송 실패'));
+
+      // When
+      const result = await earlyNotificationService.sendBulk(bulkPayload);
+
+      // Then
+      expect(result).toEqual({ total: 2, success: 0, failed: 2 });
+      expect(mockEarlyNotificationRepository.markManyNotified).not.toHaveBeenCalled();
+    });
+
+    it('대상이 없으면 발송 없이 0건 반환한다', async () => {
+      // Given
+      mockEarlyNotificationRepository.findByCohort.mockResolvedValue([]);
+
+      // When
+      const result = await earlyNotificationService.sendBulk(bulkPayload);
+
+      // Then
+      expect(result).toEqual({ total: 0, success: 0, failed: 0 });
+      expect(mockNotificationService.sendEmail).not.toHaveBeenCalled();
+      expect(mockEarlyNotificationRepository.markManyNotified).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('exportByCohort', () => {
+    it('CSV에 UTF-8 BOM이 포함되고 RFC 4180 규칙으로 이스케이프된다', async () => {
+      // Given
+      const records = [
+        {
+          id: 1,
+          email: 'simple@test.com',
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+          notifiedAt: new Date('2026-01-02T00:00:00.000Z'),
+        },
+        {
+          id: 2,
+          email: 'has,comma@test.com',
+          createdAt: new Date('2026-01-03T00:00:00.000Z'),
+          notifiedAt: null,
+        },
+        {
+          id: 3,
+          email: 'has"quote@test.com',
+          createdAt: new Date('2026-01-04T00:00:00.000Z'),
+          notifiedAt: null,
+        },
+      ];
+      mockEarlyNotificationRepository.findByCohort.mockResolvedValue(records);
+
+      // When
+      const result = await earlyNotificationService.exportByCohort({ cohortId: 1 });
+
+      // Then
+      expect(result.filename).toMatch(/^early-notifications-cohort-1-\d{8}\.csv$/);
+      expect(result.content.startsWith('\uFEFF')).toBe(true);
+
+      const lines = result.content.replace('\uFEFF', '').split('\r\n');
+      expect(lines[0]).toBe('id,email,createdAt,notifiedAt');
+      expect(lines[1]).toBe('1,simple@test.com,2026-01-01T00:00:00.000Z,2026-01-02T00:00:00.000Z');
+      expect(lines[2]).toBe('2,"has,comma@test.com",2026-01-03T00:00:00.000Z,');
+      expect(lines[3]).toBe('3,"has""quote@test.com",2026-01-04T00:00:00.000Z,');
+    });
+
+    it('이메일에 CR/LF가 포함되면 필드를 따옴표로 감싼다', async () => {
+      // Given
+      const records = [
+        {
+          id: 1,
+          email: 'line\r\nbreak@test.com',
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+          notifiedAt: null,
+        },
+      ];
+      mockEarlyNotificationRepository.findByCohort.mockResolvedValue(records);
+
+      // When
+      const result = await earlyNotificationService.exportByCohort({ cohortId: 1 });
+
+      // Then
+      const body = result.content.replace('\uFEFF', '');
+      expect(body).toContain('1,"line\r\nbreak@test.com",2026-01-01T00:00:00.000Z,');
+    });
+  });
+});

--- a/src/notification/application/early-notification.service.ts
+++ b/src/notification/application/early-notification.service.ts
@@ -1,0 +1,158 @@
+import { HttpStatus, Injectable, Logger } from '@nestjs/common';
+import { QueryFailedError } from 'typeorm';
+
+import { CohortRepository } from '../../cohort/domain/cohort.repository';
+import { AppException } from '../../common/exception/app.exception';
+import { EarlyNotificationRepository } from '../domain/early-notification.repository';
+import { NotificationService } from './notification.service';
+
+type SubscribePayload = {
+  cohortId: number;
+  email: string;
+};
+
+type FindByCohortPayload = {
+  cohortId: number;
+  onlyUnnotified?: boolean;
+};
+
+type ExportByCohortPayload = {
+  cohortId: number;
+};
+
+type ExportByCohortResult = {
+  filename: string;
+  content: string;
+};
+
+type SendBulkPayload = {
+  cohortId: number;
+  subject: string;
+  html: string;
+  text: string;
+};
+
+type SendBulkResult = {
+  total: number;
+  success: number;
+  failed: number;
+};
+
+@Injectable()
+export class EarlyNotificationService {
+  private readonly logger = new Logger(EarlyNotificationService.name);
+
+  constructor(
+    private readonly earlyNotificationRepository: EarlyNotificationRepository,
+    private readonly cohortRepository: CohortRepository,
+    private readonly notificationService: NotificationService,
+  ) {}
+
+  async subscribe({ cohortId, email }: SubscribePayload) {
+    const cohort = await this.cohortRepository.findById({ id: cohortId });
+    if (!cohort) {
+      throw new AppException('COHORT_NOT_FOUND', HttpStatus.NOT_FOUND);
+    }
+
+    const found = await this.earlyNotificationRepository.findOne({ cohortId, email });
+    if (found) {
+      return found;
+    }
+
+    try {
+      return await this.earlyNotificationRepository.register({ cohortId, email });
+    } catch (error: unknown) {
+      if (
+        error instanceof QueryFailedError &&
+        (error as QueryFailedError & { driverError?: { code?: string } }).driverError?.code ===
+          '23505'
+      ) {
+        const record = await this.earlyNotificationRepository.findOne({ cohortId, email });
+        if (!record) {
+          throw new AppException('EARLY_NOTIFICATION_CONFLICT', HttpStatus.CONFLICT);
+        }
+        return record;
+      }
+      throw error;
+    }
+  }
+
+  async findByCohort({ cohortId, onlyUnnotified }: FindByCohortPayload) {
+    return this.earlyNotificationRepository.findByCohort({ cohortId, onlyUnnotified });
+  }
+
+  async exportByCohort({ cohortId }: ExportByCohortPayload): Promise<ExportByCohortResult> {
+    const records = await this.earlyNotificationRepository.findByCohort({ cohortId });
+
+    const today = new Date();
+    const yyyyMMdd = [
+      today.getFullYear(),
+      String(today.getMonth() + 1).padStart(2, '0'),
+      String(today.getDate()).padStart(2, '0'),
+    ].join('');
+
+    const filename = `early-notifications-cohort-${cohortId}-${yyyyMMdd}.csv`;
+
+    const header = 'id,email,createdAt,notifiedAt';
+    const rows = records.map((record) => {
+      const escapedEmail = escapeCsvField(record.email);
+      const createdAt = record.createdAt.toISOString();
+      const notifiedAt = record.notifiedAt ? record.notifiedAt.toISOString() : '';
+      return `${record.id},${escapedEmail},${createdAt},${notifiedAt}`;
+    });
+
+    const content = '\uFEFF' + [header, ...rows].join('\r\n');
+
+    return { filename, content };
+  }
+
+  async sendBulk({ cohortId, subject, html, text }: SendBulkPayload): Promise<SendBulkResult> {
+    const records = await this.earlyNotificationRepository.findByCohort({
+      cohortId,
+      onlyUnnotified: true,
+    });
+
+    const total = records.length;
+    const sentIds: number[] = [];
+
+    const results = await Promise.allSettled(
+      records.map(async (record) => {
+        await this.notificationService.sendEmail({
+          to: record.email,
+          subject,
+          html,
+          text,
+        });
+        return record.id;
+      }),
+    );
+
+    for (const result of results) {
+      if (result.status === 'fulfilled') {
+        sentIds.push(result.value);
+      } else {
+        this.logger.error('사전 알림 이메일 발송 실패', result.reason);
+      }
+    }
+
+    if (sentIds.length > 0) {
+      await this.earlyNotificationRepository.markManyNotified({
+        ids: sentIds,
+        notifiedAt: new Date(),
+      });
+    }
+
+    return {
+      total,
+      success: sentIds.length,
+      failed: total - sentIds.length,
+    };
+  }
+}
+
+const escapeCsvField = (field: string): string => {
+  if (/[",\r\n]/.test(field)) {
+    return `"${field.replace(/"/g, '""')}"`;
+  }
+  return field;
+};

--- a/src/notification/application/early-notification.service.ts
+++ b/src/notification/application/early-notification.service.ts
@@ -114,24 +114,28 @@ export class EarlyNotificationService {
 
     const total = records.length;
     const sentIds: number[] = [];
+    const batchSize = 20;
 
-    const results = await Promise.allSettled(
-      records.map(async (record) => {
-        await this.notificationService.sendEmail({
-          to: record.email,
-          subject,
-          html,
-          text,
-        });
-        return record.id;
-      }),
-    );
+    for (let startIndex = 0; startIndex < records.length; startIndex += batchSize) {
+      const batch = records.slice(startIndex, startIndex + batchSize);
+      const results = await Promise.allSettled(
+        batch.map(async (record) => {
+          await this.notificationService.sendEmail({
+            to: record.email,
+            subject,
+            html,
+            text,
+          });
+          return record.id;
+        }),
+      );
 
-    for (const result of results) {
-      if (result.status === 'fulfilled') {
-        sentIds.push(result.value);
-      } else {
-        this.logger.error('사전 알림 이메일 발송 실패', result.reason);
+      for (const result of results) {
+        if (result.status === 'fulfilled') {
+          sentIds.push(result.value);
+        } else {
+          this.logger.error('사전 알림 이메일 발송 실패', result.reason);
+        }
       }
     }
 

--- a/src/notification/domain/early-notification.entity.ts
+++ b/src/notification/domain/early-notification.entity.ts
@@ -1,0 +1,36 @@
+import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
+
+import { Cohort } from '../../cohort/domain/cohort.entity';
+import { BaseEntity } from '../../common/core/base.entity';
+
+@Entity('early_notifications')
+@Index('uq_early_notifications_active_cohort_email', ['cohortId', 'email'], {
+  unique: true,
+  where: '"deletedAt" IS NULL',
+})
+export class EarlyNotification extends BaseEntity {
+  @ManyToOne(() => Cohort, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'cohortId' })
+  cohort?: Cohort;
+
+  @Column()
+  cohortId: number;
+
+  @Column()
+  email: string;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  notifiedAt: Date | null;
+
+  static create({ cohortId, email }: { cohortId: number; email: string }): EarlyNotification {
+    const notification = new EarlyNotification();
+    notification.cohortId = cohortId;
+    notification.email = email;
+    notification.notifiedAt = null;
+    return notification;
+  }
+
+  markNotified(now: Date = new Date()): void {
+    this.notifiedAt = now;
+  }
+}

--- a/src/notification/domain/early-notification.repository.ts
+++ b/src/notification/domain/early-notification.repository.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@nestjs/common';
+
+import { EarlyNotificationWriteRepository } from '../infrastructure/early-notification.write.repository';
+import { EarlyNotification } from './early-notification.entity';
+
+@Injectable()
+export class EarlyNotificationRepository {
+  constructor(
+    private readonly earlyNotificationWriteRepository: EarlyNotificationWriteRepository,
+  ) {}
+
+  async register({ cohortId, email }: { cohortId: number; email: string }) {
+    const notification = EarlyNotification.create({ cohortId, email });
+    return this.earlyNotificationWriteRepository.save({ notification });
+  }
+
+  async existsByCohortAndEmail({ cohortId, email }: { cohortId: number; email: string }) {
+    return this.earlyNotificationWriteRepository.exists({
+      where: { cohortId, email },
+    });
+  }
+
+  async findByCohort({ cohortId, onlyUnnotified }: { cohortId: number; onlyUnnotified?: boolean }) {
+    return this.earlyNotificationWriteRepository.findMany({
+      where: {
+        cohortId,
+        ...(onlyUnnotified ? { notifiedAtIsNull: true } : {}),
+      },
+    });
+  }
+
+  async findOne({ cohortId, email }: { cohortId: number; email: string }) {
+    return this.earlyNotificationWriteRepository.findOne({
+      where: { cohortId, email },
+    });
+  }
+
+  async findManyByIds({ ids }: { ids: number[] }) {
+    return this.earlyNotificationWriteRepository.findMany({
+      where: { ids },
+    });
+  }
+
+  async markManyNotified({ ids, notifiedAt }: { ids: number[]; notifiedAt: Date }) {
+    return this.earlyNotificationWriteRepository.updateNotifiedAt({ ids, notifiedAt });
+  }
+}

--- a/src/notification/infrastructure/early-notification.write.repository.ts
+++ b/src/notification/infrastructure/early-notification.write.repository.ts
@@ -1,0 +1,63 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource, In, IsNull, Repository } from 'typeorm';
+
+import { EarlyNotification } from '../domain/early-notification.entity';
+import type { EarlyNotificationFilter } from './early-notification.write.repository.type';
+
+@Injectable()
+export class EarlyNotificationWriteRepository {
+  private readonly repository: Repository<EarlyNotification>;
+
+  constructor(dataSource: DataSource) {
+    this.repository = dataSource.getRepository(EarlyNotification);
+  }
+
+  async save({ notification }: { notification: EarlyNotification }) {
+    return this.repository.save(notification);
+  }
+
+  async findOne({ where }: { where: EarlyNotificationFilter }) {
+    return this.repository.findOne({ where: this.buildWhere(where) });
+  }
+
+  async findMany({ where }: { where: EarlyNotificationFilter }) {
+    return this.repository.find({ where: this.buildWhere(where) });
+  }
+
+  async exists({ where }: { where: EarlyNotificationFilter }) {
+    return this.repository.exists({ where: this.buildWhere(where) });
+  }
+
+  async updateNotifiedAt({ ids, notifiedAt }: { ids: number[]; notifiedAt: Date }) {
+    if (ids.length === 0) {
+      return;
+    }
+    await this.repository.update({ id: In(ids) }, { notifiedAt });
+  }
+
+  private buildWhere(filter: EarlyNotificationFilter) {
+    const where: Record<string, unknown> = {};
+
+    if (filter.id !== undefined) {
+      where.id = filter.id;
+    }
+
+    if (filter.cohortId !== undefined) {
+      where.cohortId = filter.cohortId;
+    }
+
+    if (filter.email !== undefined) {
+      where.email = filter.email;
+    }
+
+    if (filter.notifiedAtIsNull === true) {
+      where.notifiedAt = IsNull();
+    }
+
+    if (filter.ids !== undefined && filter.ids.length > 0) {
+      where.id = In(filter.ids);
+    }
+
+    return where;
+  }
+}

--- a/src/notification/infrastructure/early-notification.write.repository.type.ts
+++ b/src/notification/infrastructure/early-notification.write.repository.type.ts
@@ -1,0 +1,7 @@
+export type EarlyNotificationFilter = {
+  id?: number;
+  cohortId?: number;
+  email?: string;
+  notifiedAtIsNull?: boolean;
+  ids?: number[];
+};

--- a/src/notification/interface/admin.early-notification.controller.ts
+++ b/src/notification/interface/admin.early-notification.controller.ts
@@ -1,0 +1,89 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Post,
+  Query,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { ApiTags } from '@nestjs/swagger';
+import type { Response } from 'express';
+
+import { Roles } from '../../common/decorator/roles.decorator';
+import { RolesGuard } from '../../common/guard/roles.guard';
+import { ApiResponse } from '../../common/response/api-response';
+import { ApiDoc } from '../../common/swagger/api-doc.decorator';
+import { UserRole } from '../../user/domain/user.role';
+import { EarlyNotificationService } from '../application/early-notification.service';
+import {
+  ExportAdminEarlyNotificationsQueryDto,
+  FindAdminEarlyNotificationsQueryDto,
+  SendBulkEarlyNotificationRequestDto,
+} from './dto/admin-early-notification.request.dto';
+import { AdminEarlyNotificationResponseDto } from './dto/admin-early-notification.response.dto';
+
+@ApiTags('Admin - Early Notification')
+@Controller({ path: 'admin/early-notifications', version: '1' })
+@UseGuards(AuthGuard('jwt'), RolesGuard)
+@Roles(UserRole.계정관리, UserRole.운영자)
+export class AdminEarlyNotificationController {
+  constructor(private readonly earlyNotificationService: EarlyNotificationService) {}
+
+  @ApiDoc({
+    summary: '사전 알림 목록 조회',
+    description: '기수별 사전 알림 신청 목록을 조회합니다.',
+    operationId: 'earlyNotification_getAdminList',
+    auth: true,
+  })
+  @Get()
+  async findList(@Query() query: FindAdminEarlyNotificationsQueryDto) {
+    const records = await this.earlyNotificationService.findByCohort({
+      cohortId: query.cohortId,
+      onlyUnnotified: query.onlyUnnotified,
+    });
+    return ApiResponse.ok(records.map((record) => AdminEarlyNotificationResponseDto.from(record)));
+  }
+
+  @ApiDoc({
+    summary: '사전 알림 목록 CSV 내보내기',
+    description: '기수별 사전 알림 신청 목록을 CSV 파일로 내보냅니다.',
+    operationId: 'earlyNotification_exportAdminCsv',
+    auth: true,
+  })
+  @Get('export')
+  async exportCsv(
+    @Query() query: ExportAdminEarlyNotificationsQueryDto,
+    @Res({ passthrough: true }) response: Response,
+  ) {
+    const { filename, content } = await this.earlyNotificationService.exportByCohort({
+      cohortId: query.cohortId,
+    });
+
+    response.setHeader('Content-Type', 'text/csv; charset=utf-8');
+    response.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+
+    return content;
+  }
+
+  @ApiDoc({
+    summary: '사전 알림 일괄 발송',
+    description: '기수별 미발송 대상에게 사전 알림 이메일을 일괄 발송합니다.',
+    operationId: 'earlyNotification_sendBulk',
+    auth: true,
+  })
+  @HttpCode(HttpStatus.OK)
+  @Post('send')
+  async sendBulk(@Body() body: SendBulkEarlyNotificationRequestDto) {
+    const result = await this.earlyNotificationService.sendBulk({
+      cohortId: body.cohortId,
+      subject: body.subject,
+      html: body.html,
+      text: body.text,
+    });
+    return ApiResponse.ok(result, '발송이 완료되었습니다.');
+  }
+}

--- a/src/notification/interface/dto/admin-early-notification.request.dto.ts
+++ b/src/notification/interface/dto/admin-early-notification.request.dto.ts
@@ -19,7 +19,17 @@ export class FindAdminEarlyNotificationsQueryDto {
 
   @ApiPropertyOptional({ description: '미발송 대상만 조회', example: true })
   @IsOptional()
-  @Transform(({ value }) => value === 'true' || value === true)
+  @Transform(({ value }) => {
+    if (value === 'true' || value === true) {
+      return true;
+    }
+
+    if (value === 'false' || value === false) {
+      return false;
+    }
+
+    return value as boolean;
+  })
   @IsBoolean()
   onlyUnnotified?: boolean;
 }

--- a/src/notification/interface/dto/admin-early-notification.request.dto.ts
+++ b/src/notification/interface/dto/admin-early-notification.request.dto.ts
@@ -1,0 +1,58 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform, Type } from 'class-transformer';
+import {
+  IsBoolean,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsPositive,
+  IsString,
+  MaxLength,
+} from 'class-validator';
+
+export class FindAdminEarlyNotificationsQueryDto {
+  @ApiProperty({ description: '기수 ID', example: 1 })
+  @Type(() => Number)
+  @IsInt()
+  @IsPositive()
+  cohortId: number;
+
+  @ApiPropertyOptional({ description: '미발송 대상만 조회', example: true })
+  @IsOptional()
+  @Transform(({ value }) => value === 'true' || value === true)
+  @IsBoolean()
+  onlyUnnotified?: boolean;
+}
+
+export class ExportAdminEarlyNotificationsQueryDto {
+  @ApiProperty({ description: '기수 ID', example: 1 })
+  @Type(() => Number)
+  @IsInt()
+  @IsPositive()
+  cohortId: number;
+}
+
+export class SendBulkEarlyNotificationRequestDto {
+  @ApiProperty({ description: '기수 ID', example: 1 })
+  @IsInt()
+  @IsPositive()
+  cohortId: number;
+
+  @ApiProperty({ description: '이메일 제목', example: '[DDD] 16기 모집이 시작되었습니다!' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(200)
+  subject: string;
+
+  @ApiProperty({ description: 'HTML 본문', example: '<p>DDD 16기 모집이 시작되었습니다.</p>' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(50000)
+  html: string;
+
+  @ApiProperty({ description: '텍스트 본문', example: 'DDD 16기 모집이 시작되었습니다.' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(50000)
+  text: string;
+}

--- a/src/notification/interface/dto/admin-early-notification.response.dto.ts
+++ b/src/notification/interface/dto/admin-early-notification.response.dto.ts
@@ -1,0 +1,41 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+import { EarlyNotification } from '../../domain/early-notification.entity';
+
+export class AdminEarlyNotificationResponseDto {
+  @ApiProperty({ description: 'ID', example: 1 })
+  id: number;
+
+  @ApiProperty({ description: '기수 ID', example: 1 })
+  cohortId: number;
+
+  @ApiProperty({ description: '이메일 주소', example: 'user@example.com' })
+  email: string;
+
+  @ApiProperty({ description: '생성 일시' })
+  createdAt: Date;
+
+  @ApiPropertyOptional({ description: '알림 발송 일시', nullable: true })
+  notifiedAt: Date | null;
+
+  static from(record: EarlyNotification): AdminEarlyNotificationResponseDto {
+    const dto = new AdminEarlyNotificationResponseDto();
+    dto.id = record.id;
+    dto.cohortId = record.cohortId;
+    dto.email = record.email;
+    dto.createdAt = record.createdAt;
+    dto.notifiedAt = record.notifiedAt;
+    return dto;
+  }
+}
+
+export class SendBulkEarlyNotificationResponseDto {
+  @ApiProperty({ description: '전체 대상 수', example: 100 })
+  total: number;
+
+  @ApiProperty({ description: '발송 성공 수', example: 98 })
+  success: number;
+
+  @ApiProperty({ description: '발송 실패 수', example: 2 })
+  failed: number;
+}

--- a/src/notification/interface/dto/public-early-notification.request.dto.ts
+++ b/src/notification/interface/dto/public-early-notification.request.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsInt, IsPositive, MaxLength } from 'class-validator';
+
+export class SubscribeEarlyNotificationRequestDto {
+  @ApiProperty({ description: '기수 ID', example: 1 })
+  @IsInt()
+  @IsPositive()
+  cohortId: number;
+
+  @ApiProperty({ description: '이메일 주소', example: 'user@example.com' })
+  @IsEmail()
+  @MaxLength(254)
+  email: string;
+}

--- a/src/notification/interface/dto/public-early-notification.response.dto.ts
+++ b/src/notification/interface/dto/public-early-notification.response.dto.ts
@@ -1,0 +1,30 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+import { EarlyNotification } from '../../domain/early-notification.entity';
+
+export class EarlyNotificationResponseDto {
+  @ApiProperty({ description: 'ID', example: 1 })
+  id: number;
+
+  @ApiProperty({ description: '기수 ID', example: 1 })
+  cohortId: number;
+
+  @ApiProperty({ description: '이메일 주소', example: 'user@example.com' })
+  email: string;
+
+  @ApiProperty({ description: '생성 일시' })
+  createdAt: Date;
+
+  @ApiPropertyOptional({ description: '알림 발송 일시', nullable: true })
+  notifiedAt: Date | null;
+
+  static from(record: EarlyNotification): EarlyNotificationResponseDto {
+    const dto = new EarlyNotificationResponseDto();
+    dto.id = record.id;
+    dto.cohortId = record.cohortId;
+    dto.email = record.email;
+    dto.createdAt = record.createdAt;
+    dto.notifiedAt = record.notifiedAt;
+    return dto;
+  }
+}

--- a/src/notification/interface/public.early-notification.controller.ts
+++ b/src/notification/interface/public.early-notification.controller.ts
@@ -1,0 +1,28 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+
+import { ApiResponse } from '../../common/response/api-response';
+import { ApiDoc } from '../../common/swagger/api-doc.decorator';
+import { EarlyNotificationService } from '../application/early-notification.service';
+import { SubscribeEarlyNotificationRequestDto } from './dto/public-early-notification.request.dto';
+import { EarlyNotificationResponseDto } from './dto/public-early-notification.response.dto';
+
+@ApiTags('Early Notification')
+@Controller({ path: 'early-notifications', version: '1' })
+export class PublicEarlyNotificationController {
+  constructor(private readonly earlyNotificationService: EarlyNotificationService) {}
+
+  @ApiDoc({
+    summary: '사전 알림 신청',
+    description: '기수별 사전 알림 이메일을 등록합니다.',
+    operationId: 'earlyNotification_subscribe',
+  })
+  @Post()
+  async subscribe(@Body() body: SubscribeEarlyNotificationRequestDto) {
+    const record = await this.earlyNotificationService.subscribe({
+      cohortId: body.cohortId,
+      email: body.email,
+    });
+    return ApiResponse.ok(EarlyNotificationResponseDto.from(record), '사전 알림이 신청되었습니다.');
+  }
+}

--- a/src/notification/notification.module.ts
+++ b/src/notification/notification.module.ts
@@ -1,20 +1,33 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { CohortModule } from '../cohort/cohort.module';
+import { RolesGuard } from '../common/guard/roles.guard';
+import { EarlyNotificationService } from './application/early-notification.service';
 import { NotificationService } from './application/notification.service';
+import { EarlyNotification } from './domain/early-notification.entity';
+import { EarlyNotificationRepository } from './domain/early-notification.repository';
 import { EmailLog } from './domain/email-log.entity';
 import { NotificationRepository } from './domain/notification.repository';
+import { EarlyNotificationWriteRepository } from './infrastructure/early-notification.write.repository';
 import { EmailLogWriteRepository } from './infrastructure/email-log.write.repository';
 import { ResendEmailClient } from './infrastructure/resend-email.client';
+import { AdminEarlyNotificationController } from './interface/admin.early-notification.controller';
+import { PublicEarlyNotificationController } from './interface/public.early-notification.controller';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([EmailLog])],
+  imports: [TypeOrmModule.forFeature([EmailLog, EarlyNotification]), CohortModule],
+  controllers: [PublicEarlyNotificationController, AdminEarlyNotificationController],
   providers: [
     NotificationService,
     NotificationRepository,
     ResendEmailClient,
     EmailLogWriteRepository,
+    EarlyNotificationService,
+    EarlyNotificationRepository,
+    EarlyNotificationWriteRepository,
+    RolesGuard,
   ],
-  exports: [NotificationService],
+  exports: [NotificationService, EarlyNotificationService],
 })
 export class NotificationModule {}


### PR DESCRIPTION
## 📌 PR 제목
> feat: 사전 알림(Early Notification) 기능 구현                                                       ---                                              

  ## ✅ PR 설명

  - 기수별 사전 알림 이메일 신청/조회/CSV
  내보내기/일괄 발송 기능 추가
  - deploy.yml에 ENCRYPTION_KEY 환경변수 주입 누락 
  수정 (배포 실패 원인)
  - 관련 이슈: #32

  ---

  ## 🧪 테스트 방법

  - [x] 로컬 테스트 완료
  - [x] 린트 및 빌드 통과
  - [x] 단위 테스트 111개 전체 통과
  - [x] 로컬 서버 기동 후 curl API 테스트 완료     
  (Public/Admin 전 엔드포인트)

  ---

  ## 🔍 체크리스트

  - [x] 코드에 주석/불필요한 로그 제거
  - [x] 코드 리뷰어가 이해하기 쉽게 커밋 정리      

  ---

  ## 📎 기타 참고 사항 (Optional)

  - **ENCRYPTION_KEY** GitHub Secret 추가 필요     
  (64자 hex 문자열, `openssl rand -hex 32`로 생성) 
  - Email provider가 `console`이면 실제 메일은     
  발송되지 않고 로그만 출력됩니다
  - 테이블 생성은 TypeORM `synchronize`로 처리되며,
   마이그레이션 파일은 별도 관리 예정입니다  