### PR TITLE
feat(cohort): 모집 파트 공개 조회 API

### DIFF
--- a/src/cohort/application/cohort.service.spec.ts
+++ b/src/cohort/application/cohort.service.spec.ts
@@ -17,6 +17,7 @@ const mockCohortRepository = {
   register: jest.fn(),
   checkActiveCohortExists: jest.fn(),
   findById: jest.fn(),
+  findPartById: jest.fn(),
   checkActiveCohortExistsExcept: jest.fn(),
   update: jest.fn(),
 };
@@ -90,6 +91,59 @@ describe('CohortService', () => {
           data: { status: CohortStatus.RECRUITING },
         }),
       ).rejects.toThrow(new AppException('COHORT_ALREADY_EXISTS', HttpStatus.CONFLICT));
+    });
+  });
+
+  describe('findPartByIdOrThrow', () => {
+    const expectedException = new AppException('COHORT_PART_NOT_FOUND', HttpStatus.NOT_FOUND);
+
+    it('파트가 존재하지 않으면 404를 던진다', async () => {
+      mockCohortRepository.findPartById.mockResolvedValue(null);
+
+      await expect(cohortService.findPartByIdOrThrow({ id: 1 })).rejects.toThrow(expectedException);
+    });
+
+    it('파트가 닫혀있으면 404를 던진다', async () => {
+      mockCohortRepository.findPartById.mockResolvedValue({
+        id: 1,
+        isOpen: false,
+        cohort: { status: CohortStatus.RECRUITING },
+      });
+
+      await expect(cohortService.findPartByIdOrThrow({ id: 1 })).rejects.toThrow(expectedException);
+    });
+
+    it('소속 기수가 RECRUITING이 아니면 404를 던진다', async () => {
+      mockCohortRepository.findPartById.mockResolvedValue({
+        id: 1,
+        isOpen: true,
+        cohort: { status: CohortStatus.UPCOMING },
+      });
+
+      await expect(cohortService.findPartByIdOrThrow({ id: 1 })).rejects.toThrow(expectedException);
+    });
+
+    it('파트의 cohort relation이 비어있으면 404를 던진다', async () => {
+      mockCohortRepository.findPartById.mockResolvedValue({
+        id: 1,
+        isOpen: true,
+        cohort: undefined,
+      });
+
+      await expect(cohortService.findPartByIdOrThrow({ id: 1 })).rejects.toThrow(expectedException);
+    });
+
+    it('오픈된 파트이고 RECRUITING 기수에 속하면 파트를 반환한다', async () => {
+      const part = {
+        id: 1,
+        isOpen: true,
+        cohort: { status: CohortStatus.RECRUITING },
+      };
+      mockCohortRepository.findPartById.mockResolvedValue(part);
+
+      const result = await cohortService.findPartByIdOrThrow({ id: 1 });
+
+      expect(result).toBe(part);
     });
   });
 });

--- a/src/cohort/application/cohort.service.ts
+++ b/src/cohort/application/cohort.service.ts
@@ -149,6 +149,14 @@ export class CohortService {
     return this.cohortRepository.findPartById({ id });
   }
 
+  async findPartByIdOrThrow({ id }: { id: number }) {
+    const part = await this.cohortRepository.findPartById({ id });
+    if (!part || !part.isOpen || part.cohort?.status !== CohortStatus.RECRUITING) {
+      throw new AppException('COHORT_PART_NOT_FOUND', HttpStatus.NOT_FOUND);
+    }
+    return part;
+  }
+
   @Transactional()
   async transitionExpiredToActive() {
     const expired = await this.cohortRepository.findExpiredRecruiting();

--- a/src/cohort/infrastructure/part.write.repository.spec.ts
+++ b/src/cohort/infrastructure/part.write.repository.spec.ts
@@ -5,13 +5,13 @@ import { PartWriteRepository } from './part.write.repository';
 
 describe('PartWriteRepository', () => {
   describe('findOne', () => {
-    it('삭제되지 않은 cohort에 속한 part만 조회한다', async () => {
-      const innerJoin = jest.fn().mockReturnThis();
+    it('삭제되지 않은 cohort을 함께 조회한다', async () => {
+      const innerJoinAndSelect = jest.fn().mockReturnThis();
       const where = jest.fn().mockReturnThis();
       const andWhere = jest.fn().mockReturnThis();
       const getOne = jest.fn().mockResolvedValue(null);
       const createQueryBuilder = jest.fn().mockReturnValue({
-        innerJoin,
+        innerJoinAndSelect,
         where,
         andWhere,
         getOne,
@@ -27,7 +27,11 @@ describe('PartWriteRepository', () => {
       await partWriteRepository.findOne({ where: { id: 1 } });
 
       expect(createQueryBuilder).toHaveBeenCalledWith('part');
-      expect(innerJoin).toHaveBeenCalledWith('part.cohort', 'cohort', 'cohort.deletedAt IS NULL');
+      expect(innerJoinAndSelect).toHaveBeenCalledWith(
+        'part.cohort',
+        'cohort',
+        'cohort.deletedAt IS NULL',
+      );
       expect(where).toHaveBeenCalledWith('part.id = :id', { id: 1 });
       expect(andWhere).toHaveBeenCalledWith('part.deletedAt IS NULL');
       expect(getOne).toHaveBeenCalledTimes(1);

--- a/src/cohort/infrastructure/part.write.repository.ts
+++ b/src/cohort/infrastructure/part.write.repository.ts
@@ -14,7 +14,7 @@ export class PartWriteRepository {
   async findOne({ where }: { where: { id: number } }) {
     return this.repository
       .createQueryBuilder('part')
-      .innerJoin('part.cohort', 'cohort', 'cohort.deletedAt IS NULL')
+      .innerJoinAndSelect('part.cohort', 'cohort', 'cohort.deletedAt IS NULL')
       .where('part.id = :id', { id: where.id })
       .andWhere('part.deletedAt IS NULL')
       .getOne();

--- a/src/cohort/interface/dto/public-cohort.response.dto.ts
+++ b/src/cohort/interface/dto/public-cohort.response.dto.ts
@@ -2,6 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 
 import type { Cohort } from '../../domain/cohort.entity';
 import { CohortStatus } from '../../domain/cohort.status';
+import type { CohortPart } from '../../domain/cohort-part.entity';
 import type { CohortPartName } from '../../domain/cohort-part-name';
 
 export enum CohortCtaStatus {
@@ -79,6 +80,30 @@ export class PublicCohortResponseDto {
     } else {
       dto.ctaStatus = CohortCtaStatus.CLOSED;
     }
+    return dto;
+  }
+}
+
+export class PublicCohortPartResponseDto {
+  @ApiProperty({ description: '파트 ID', example: 1 })
+  id: number;
+
+  @ApiProperty({ description: '파트명', example: 'FE' })
+  partName: CohortPartName;
+
+  @ApiProperty({
+    description: '지원서 스키마 JSON',
+    type: 'object',
+    additionalProperties: true,
+    example: { questions: [] },
+  })
+  applicationSchema: Record<string, unknown>;
+
+  static from(part: CohortPart): PublicCohortPartResponseDto {
+    const dto = new PublicCohortPartResponseDto();
+    dto.id = part.id;
+    dto.partName = part.partName;
+    dto.applicationSchema = part.applicationSchema ?? {};
     return dto;
   }
 }

--- a/src/cohort/interface/public.cohort.controller.ts
+++ b/src/cohort/interface/public.cohort.controller.ts
@@ -1,10 +1,13 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 
 import { ApiResponse } from '../../common/response/api-response';
 import { ApiDoc } from '../../common/swagger/api-doc.decorator';
 import { CohortService } from '../application/cohort.service';
-import { PublicCohortResponseDto } from './dto/public-cohort.response.dto';
+import {
+  PublicCohortPartResponseDto,
+  PublicCohortResponseDto,
+} from './dto/public-cohort.response.dto';
 
 @ApiTags('Cohort')
 @Controller({ path: 'cohorts', version: '1' })
@@ -20,5 +23,16 @@ export class PublicCohortController {
   async findActiveCohort() {
     const cohort = await this.cohortService.findActiveCohortOrThrow();
     return ApiResponse.ok(PublicCohortResponseDto.from(cohort));
+  }
+
+  @ApiDoc({
+    summary: '모집 파트 상세 조회',
+    description: '특정 기수의 모집 분야(파트) 상세 정보 및 지원서 문항(Schema)을 조회합니다.',
+    operationId: 'cohort_getPublicPartById',
+  })
+  @Get('parts/:id')
+  async findPartById(@Param('id', ParseIntPipe) id: number) {
+    const part = await this.cohortService.findPartByIdOrThrow({ id });
+    return ApiResponse.ok(PublicCohortPartResponseDto.from(part));
   }
 }

--- a/src/common/error/error-message.ts
+++ b/src/common/error/error-message.ts
@@ -10,6 +10,7 @@ export const ErrorMessage = {
 
   COHORT_NOT_FOUND: '기수를 찾을 수 없습니다.',
   COHORT_ALREADY_EXISTS: '이미 진행 중인 기수가 존재합니다.',
+  COHORT_PART_NOT_FOUND: '모집 중인 파트를 찾을 수 없습니다.',
 
   APPLICATION_FORM_NOT_FOUND: '지원서를 찾을 수 없습니다.',
   COHORT_PART_CLOSED: '모집이 마감되었거나 존재하지 않는 파트입니다.',


### PR DESCRIPTION
## 개요
지원서 폼 질문(applicationSchema)을 비로그인 사용자도 조회할 수 있는 공개 API `GET /v1/cohorts/parts/:id`를 추가합니다.

## 변경 이유
- 모집 페이지에서 활성 기수 조회 후, 사용자가 파트를 선택했을 때 해당 파트의 지원서 문항을 받아갈 수 있어야 합니다.
- 기존에는 어드민 API(`/v1/admin/cohorts/:id`)를 통해서만 스키마 조회가 가능했습니다.

## 주요 변경 사항
- `PublicCohortController.findPartById` (`GET /v1/cohorts/parts/:id`) 추가
- `CohortService.findPartByIdOrThrow` 추가
  - 노출 조건: `cohort.status === RECRUITING` AND `part.isOpen`
  - 그 외(파트 미존재, 닫힌 파트, 비활성 기수 소속 파트)는 모두 `404 COHORT_PART_NOT_FOUND`
- `PartWriteRepository.findOne`: `innerJoin` → `innerJoinAndSelect`로 변경하여 cohort relation 함께 로딩
- `PublicCohortPartResponseDto` 신설 (id / partName / applicationSchema)
- `applicationSchema`에 Swagger `type: 'object'`, `additionalProperties: true` 명시
- `COHORT_PART_NOT_FOUND` 에러 코드 추가

## 아키텍처 영향
- 도메인 분리: cohort 도메인 내부 변경, 다른 도메인 영향 없음
- 레이어 변경: 없음 (Interface → Application → Infrastructure 의존 방향 유지)
- 의존 방향 영향: 없음
- 트랜잭션 경계 영향: 없음 (조회 전용)
- 호환성: `application.service.ts`의 `findPartById` 호출은 cohort relation 추가 select에 영향받지 않음 (해당 서비스는 cohort 객체를 사용하지 않음)

## 테스트
- [x] 단위 테스트 (`cohort.service.spec.ts` + `part.write.repository.spec.ts`)
- [ ] 통합 테스트
- [ ] 수동 테스트
- 확인 내용:
  - `findPartByIdOrThrow` 4개 분기(미존재 / 닫힌 파트 / 비활성 기수 / 정상) 모두 검증
  - 전체 cohort 테스트 10개 + application 테스트 137개 통과
  - lint/build 모두 통과

## 리뷰 포인트
- 노출 정책: "RECRUITING 기수의 isOpen 파트만 노출, 그 외 404" — 의도와 일치하는지 확인 부탁드립니다.
- 라우트 `/cohorts/parts/:id` (전역 Part ID) — 향후 `/cohorts/:cohortId/parts/:partId` 형식이 더 적절할 수 있으나 이번 PR에서는 보류.
- `findPartById` (no-throw)는 `application.service.ts`에서 사용 중이라 통합 보류.

## 리스크 / 후속 작업
- 클라이언트가 이전 기수 파트 ID를 캐시해두고 호출하면 404 — 의도된 동작입니다.
- 후속: 이번 노출 정책에서 `UPCOMING` 시 미리보기 노출이 필요해지면 정책 재논의 필요.

## 관련 이슈
- N/A