### PR TITLE
ci(deploy): ADMIN_BOOTSTRAP_TOKEN 운영 배포 환경변수 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,8 @@ jobs:
           key: ${{ secrets.GCP_VM_SSH_KEY }}
           envs: >
             GHCR_TOKEN,GITHUB_ACTOR,APP_IMAGE,APP_PORT,DB_PORT,DB_USERNAME,DB_PASSWORD,DB_NAME,
-            JWT_SECRET,JWT_EXPIRES_IN,GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_CALLBACK_URL,
+            JWT_SECRET,JWT_EXPIRES_IN,ADMIN_BOOTSTRAP_TOKEN,ADMIN_BOOTSTRAP_TOKEN_EXPIRES_AT,
+            GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_CALLBACK_URL,
             CLIENT_REDIRECT_URL,ENCRYPTION_KEY,EMAIL_FROM,RESEND_API_KEY,GOOGLE_CALENDAR_ID,
             GCS_BUCKET_NAME,GCP_SERVICE_ACCOUNT_JSON,DISCORD_CLIENT_ID,DISCORD_CLIENT_SECRET,
             DISCORD_CALLBACK_URL,DISCORD_BOT_TOKEN,DISCORD_GUILD_ID,DISCORD_INVITE_URL,
@@ -68,6 +69,8 @@ jobs:
             printf 'APP_IMAGE=%s\n'   "$APP_IMAGE"   >> .env.production
             printf 'JWT_SECRET=%s\n'         "$JWT_SECRET"           >> .env.production
             printf 'JWT_EXPIRES_IN=%s\n'     "$JWT_EXPIRES_IN"       >> .env.production
+            printf 'ADMIN_BOOTSTRAP_TOKEN=%s\n'           "$ADMIN_BOOTSTRAP_TOKEN"           >> .env.production
+            printf 'ADMIN_BOOTSTRAP_TOKEN_EXPIRES_AT=%s\n' "$ADMIN_BOOTSTRAP_TOKEN_EXPIRES_AT" >> .env.production
             printf 'GOOGLE_CLIENT_ID=%s\n'   "$GOOGLE_CLIENT_ID"     >> .env.production
             printf 'GOOGLE_CLIENT_SECRET=%s\n' "$GOOGLE_CLIENT_SECRET" >> .env.production
             printf 'GOOGLE_CALLBACK_URL=%s\n' "$GOOGLE_CALLBACK_URL" >> .env.production
@@ -129,6 +132,8 @@ jobs:
           DB_NAME: ${{ secrets.DB_NAME }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
           JWT_EXPIRES_IN: ${{ secrets.JWT_EXPIRES_IN }}
+          ADMIN_BOOTSTRAP_TOKEN: ${{ secrets.ADMIN_BOOTSTRAP_TOKEN }}
+          ADMIN_BOOTSTRAP_TOKEN_EXPIRES_AT: ${{ secrets.ADMIN_BOOTSTRAP_TOKEN_EXPIRES_AT }}
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
           GOOGLE_CALLBACK_URL: ${{ secrets.GOOGLE_CALLBACK_URL }}


### PR DESCRIPTION
## 개요
PR #41/#42에서 추가된 부트스트랩 권한 부여 API(`PUT /api/v1/bootstrap/users/:userId/roles`)가 운영 환경에서 동작하도록 `.github/workflows/deploy.yml`에 두 환경변수 주입 경로를 추가합니다.

## 변경 이유
- 현재 deploy 워크플로의 `envs:`/`script:`/`env:` 어디에도 `ADMIN_BOOTSTRAP_TOKEN`이 없어서, GitHub Secrets에 값을 등록해도 운영 컨테이너에는 도달하지 않음.
- 이 PR이 머지되어야 secret을 통해 운영 환경에서 부트스트랩 토큰 게이트가 활성화됨.

## 주요 변경 사항
`.github/workflows/deploy.yml` 3군데 수정:
- `envs:` 목록(SSH로 전달할 변수 화이트리스트)에 `ADMIN_BOOTSTRAP_TOKEN`, `ADMIN_BOOTSTRAP_TOKEN_EXPIRES_AT` 추가
- `.env.production` 생성 스크립트에 두 변수 `printf` 추가
- `env:` 매핑(GitHub Secrets → 워크플로 env)에 두 변수 추가

## 아키텍처 영향
- 도메인 분리: 영향 없음 (CI 설정만)
- 레이어 변경: 없음
- 의존 방향 영향: 없음
- 트랜잭션 경계 영향: 없음
- **호환성**: GitHub Secrets에 두 값이 미등록이어도 배포는 정상 동작. env가 비면 BootstrapTokenGuard가 503으로 엔드포인트를 자동 봉인하므로 fail-closed.

## 테스트
- [ ] 단위 테스트 (CI 설정 변경이라 N/A)
- [ ] 통합 테스트 (N/A)
- [x] 수동 확인:
  - YAML 문법: `envs:` 라인 줄바꿈 위치 확인
  - secrets.* 참조 키명 일관성 확인 (`ADMIN_BOOTSTRAP_TOKEN`, `ADMIN_BOOTSTRAP_TOKEN_EXPIRES_AT`)
  - 머지 후 다음 main push 시 배포 잡에서 두 변수가 실제로 SSH로 전달되는지 확인 필요

## 리뷰 포인트
- secrets 키명: 코드(`src/config/env.validation.ts`, `src/common/guard/bootstrap-token.guard.ts`)에서 사용하는 env 이름과 일치 여부 — `ADMIN_BOOTSTRAP_TOKEN`, `ADMIN_BOOTSTRAP_TOKEN_EXPIRES_AT` 양쪽 모두 일치 확인했음.
- 머지 후 GitHub repository **Settings → Secrets and variables → Actions**에서 두 secret을 본인이 직접 등록해야 합니다.

## 리스크 / 후속 작업
- secret 미등록 상태로 배포되면 운영 env에 빈 값이 박힘 → 가드가 `BOOTSTRAP_TOKEN_NOT_CONFIGURED` 503 반환 (정상 fail-closed)
- 후속: secret 등록 후 본인 userId에 권한 부여 호출, 시드 완료 후 secret 즉시 삭제 또는 EXPIRES_AT을 과거로 변경

## 관련 이슈
- 후속 PR: #41 (부트스트랩 API 신설), #42 (보안/감사 보강)