### PR TITLE
feat(interview): 면접 캘린더 라이프사이클 + provider 검증

### DIFF
--- a/src/common/error/error-message.ts
+++ b/src/common/error/error-message.ts
@@ -32,6 +32,7 @@ export const ErrorMessage = {
   INTERVIEW_SLOT_ALREADY_RESERVED: '이미 예약된 면접 슬롯입니다.',
   INTERVIEW_SLOTS_NOT_READY: '해당 파트의 면접 슬롯이 준비되지 않아 서류합격 처리할 수 없습니다.',
   INVALID_INTERVIEW_SLOT_RANGE: '면접 슬롯의 종료 시간은 시작 시간보다 늦어야 합니다.',
+  INTERVIEW_RESERVATION_NOT_FOUND: '면접 예약을 찾을 수 없습니다.',
 
   BLOG_POST_NOT_FOUND: '블로그 게시글을 찾을 수 없습니다.',
 

--- a/src/config/env.validation.spec.ts
+++ b/src/config/env.validation.spec.ts
@@ -37,4 +37,41 @@ describe('env validation', () => {
       });
     }).toThrow('ENCRYPTION_KEY must be a 64-character hex string.');
   });
+
+  describe('CALENDAR_PROVIDER 조건부 검증', () => {
+    it('CALENDAR_PROVIDER 미설정(기본 console)이면 GOOGLE_CALENDAR_ID/KEY 없이 통과한다', () => {
+      expect(() => validate(createValidConfig())).not.toThrow();
+    });
+
+    it('CALENDAR_PROVIDER=google 인데 GOOGLE_CALENDAR_ID가 없으면 실패한다', () => {
+      expect(() => {
+        validate({
+          ...createValidConfig(),
+          CALENDAR_PROVIDER: 'google',
+          GOOGLE_CALENDAR_KEY_FILE_PATH: '/app/gcp-key.json',
+        });
+      }).toThrow('GOOGLE_CALENDAR_ID');
+    });
+
+    it('CALENDAR_PROVIDER=google 인데 GOOGLE_CALENDAR_KEY_FILE_PATH가 없으면 실패한다', () => {
+      expect(() => {
+        validate({
+          ...createValidConfig(),
+          CALENDAR_PROVIDER: 'google',
+          GOOGLE_CALENDAR_ID: 'test@group.calendar.google.com',
+        });
+      }).toThrow('GOOGLE_CALENDAR_KEY_FILE_PATH');
+    });
+
+    it('CALENDAR_PROVIDER=google 이고 ID/KEY가 모두 있으면 통과한다', () => {
+      expect(() =>
+        validate({
+          ...createValidConfig(),
+          CALENDAR_PROVIDER: 'google',
+          GOOGLE_CALENDAR_ID: 'test@group.calendar.google.com',
+          GOOGLE_CALENDAR_KEY_FILE_PATH: '/app/gcp-key.json',
+        }),
+      ).not.toThrow();
+    });
+  });
 });

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -1,5 +1,15 @@
 import { plainToInstance } from 'class-transformer';
-import { IsNumber, IsOptional, IsString, Matches, Max, Min, validateSync } from 'class-validator';
+import {
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Matches,
+  Max,
+  Min,
+  ValidateIf,
+  validateSync,
+} from 'class-validator';
 
 class EnvironmentVariables {
   @IsNumber()
@@ -102,12 +112,22 @@ class EnvironmentVariables {
   @IsOptional()
   CALENDAR_PROVIDER?: string = 'console';
 
-  @IsString()
-  @IsOptional()
+  @ValidateIf((env: EnvironmentVariables) => env.CALENDAR_PROVIDER === 'google')
+  @IsString({
+    message: 'CALENDAR_PROVIDER=google 일 때 GOOGLE_CALENDAR_ID는 필수입니다.',
+  })
+  @IsNotEmpty({
+    message: 'CALENDAR_PROVIDER=google 일 때 GOOGLE_CALENDAR_ID는 필수입니다.',
+  })
   GOOGLE_CALENDAR_ID?: string;
 
-  @IsString()
-  @IsOptional()
+  @ValidateIf((env: EnvironmentVariables) => env.CALENDAR_PROVIDER === 'google')
+  @IsString({
+    message: 'CALENDAR_PROVIDER=google 일 때 GOOGLE_CALENDAR_KEY_FILE_PATH는 필수입니다.',
+  })
+  @IsNotEmpty({
+    message: 'CALENDAR_PROVIDER=google 일 때 GOOGLE_CALENDAR_KEY_FILE_PATH는 필수입니다.',
+  })
   GOOGLE_CALENDAR_KEY_FILE_PATH?: string;
 
   @IsString()

--- a/src/interview/application/interview.service.spec.ts
+++ b/src/interview/application/interview.service.spec.ts
@@ -24,13 +24,17 @@ const mockInterviewRepository = {
   deleteSlot: jest.fn(),
   countSlotsByCohortPartId: jest.fn(),
   saveReservation: jest.fn(),
+  findReservationById: jest.fn(),
   findReservationByApplicationFormId: jest.fn(),
   findReservations: jest.fn(),
   countActiveReservationsBySlotId: jest.fn(),
+  deleteReservation: jest.fn(),
 };
 
 const mockGoogleCalendarClient = {
   createEvent: jest.fn(),
+  updateEvent: jest.fn(),
+  deleteEvent: jest.fn(),
 };
 
 const mockNotificationService = {
@@ -209,6 +213,112 @@ describe('InterviewService', () => {
           ]),
         }),
       );
+    });
+  });
+
+  describe('cancelReservation', () => {
+    it('예약이 없으면 INTERVIEW_RESERVATION_NOT_FOUND(404)를 던진다', async () => {
+      // Given
+      mockInterviewRepository.findReservationById.mockResolvedValue(null);
+
+      // When / Then
+      await expect(service.cancelReservation({ id: 100 })).rejects.toThrow(
+        new AppException('INTERVIEW_RESERVATION_NOT_FOUND', HttpStatus.NOT_FOUND),
+      );
+    });
+
+    it('예약 soft delete 후 캘린더 이벤트도 삭제한다', async () => {
+      // Given
+      const reservation = buildReservation({ calendarEventId: 'event-123' });
+      mockInterviewRepository.findReservationById.mockResolvedValue(reservation);
+
+      // When
+      await service.cancelReservation({ id: 100 });
+
+      // Then
+      expect(mockInterviewRepository.deleteReservation).toHaveBeenCalledWith({ id: 100 });
+      expect(mockGoogleCalendarClient.deleteEvent).toHaveBeenCalledWith({ eventId: 'event-123' });
+    });
+
+    it('연동된 캘린더 이벤트가 없으면 deleteEvent를 호출하지 않는다', async () => {
+      // Given
+      const reservation = buildReservation({ calendarEventId: null });
+      mockInterviewRepository.findReservationById.mockResolvedValue(reservation);
+
+      // When
+      await service.cancelReservation({ id: 100 });
+
+      // Then
+      expect(mockInterviewRepository.deleteReservation).toHaveBeenCalledWith({ id: 100 });
+      expect(mockGoogleCalendarClient.deleteEvent).not.toHaveBeenCalled();
+    });
+
+    it('캘린더 이벤트 삭제 실패해도 예약 취소는 성공으로 마무리한다', async () => {
+      // Given
+      const reservation = buildReservation({ calendarEventId: 'event-123' });
+      mockInterviewRepository.findReservationById.mockResolvedValue(reservation);
+      mockGoogleCalendarClient.deleteEvent.mockRejectedValue(new Error('calendar down'));
+
+      // When / Then
+      await expect(service.cancelReservation({ id: 100 })).resolves.toBeUndefined();
+      expect(mockInterviewRepository.deleteReservation).toHaveBeenCalledWith({ id: 100 });
+    });
+  });
+
+  describe('updateSlot', () => {
+    const baseSlot = (): InterviewSlot =>
+      buildSlot({
+        reservations: [
+          buildReservation({ id: 101, calendarEventId: 'event-aaa' }),
+          buildReservation({ id: 102, calendarEventId: null }),
+          buildReservation({ id: 103, calendarEventId: 'event-bbb' }),
+        ] as InterviewSlot['reservations'],
+      });
+
+    it('startAt이 변경되면 calendarEventId가 있는 예약만 캘린더 이벤트 업데이트를 호출한다', async () => {
+      // Given
+      mockInterviewRepository.findSlotById.mockResolvedValue(baseSlot());
+      const nextStartAt = new Date('2026-05-01T11:00:00Z');
+      const nextEndAt = new Date('2026-05-01T11:30:00Z');
+
+      // When
+      await service.updateSlot({ id: 1, patch: { startAt: nextStartAt, endAt: nextEndAt } });
+
+      // Then
+      expect(mockInterviewRepository.updateSlot).toHaveBeenCalled();
+      expect(mockGoogleCalendarClient.updateEvent).toHaveBeenCalledTimes(2);
+      expect(mockGoogleCalendarClient.updateEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ eventId: 'event-aaa', startAt: nextStartAt, endAt: nextEndAt }),
+      );
+      expect(mockGoogleCalendarClient.updateEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ eventId: 'event-bbb', startAt: nextStartAt, endAt: nextEndAt }),
+      );
+    });
+
+    it('capacity만 변경되면 캘린더 이벤트는 동기화하지 않는다', async () => {
+      // Given
+      mockInterviewRepository.findSlotById.mockResolvedValue(baseSlot());
+
+      // When
+      await service.updateSlot({ id: 1, patch: { capacity: 2 } });
+
+      // Then
+      expect(mockInterviewRepository.updateSlot).toHaveBeenCalled();
+      expect(mockGoogleCalendarClient.updateEvent).not.toHaveBeenCalled();
+    });
+
+    it('일부 캘린더 이벤트 업데이트가 실패해도 나머지 이벤트는 계속 동기화한다', async () => {
+      // Given
+      mockInterviewRepository.findSlotById.mockResolvedValue(baseSlot());
+      mockGoogleCalendarClient.updateEvent
+        .mockRejectedValueOnce(new Error('calendar down'))
+        .mockResolvedValueOnce(undefined);
+
+      // When
+      await service.updateSlot({ id: 1, patch: { location: '판교' } });
+
+      // Then
+      expect(mockGoogleCalendarClient.updateEvent).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/src/interview/application/interview.service.ts
+++ b/src/interview/application/interview.service.ts
@@ -64,6 +64,37 @@ export class InterviewService {
     }
 
     await this.interviewRepository.updateSlot({ id, patch });
+
+    const calendarRelevantChanged =
+      patch.startAt !== undefined ||
+      patch.endAt !== undefined ||
+      patch.location !== undefined ||
+      patch.description !== undefined;
+    if (!calendarRelevantChanged) {
+      return;
+    }
+
+    const nextLocation = patch.location ?? slot.location;
+    const nextDescription = patch.description ?? slot.description;
+    const reservationsToSync = (slot.reservations ?? []).filter(
+      (reservation) => reservation.calendarEventId,
+    );
+    for (const reservation of reservationsToSync) {
+      try {
+        await this.googleCalendarClient.updateEvent({
+          eventId: reservation.calendarEventId as string,
+          startAt: nextStartAt,
+          endAt: nextEndAt,
+          location: nextLocation,
+          description: nextDescription,
+        });
+      } catch (error) {
+        this.logger.error(
+          `구글 캘린더 이벤트 업데이트 실패 (eventId=${reservation.calendarEventId})`,
+          error,
+        );
+      }
+    }
   }
 
   @Transactional()
@@ -144,6 +175,29 @@ export class InterviewService {
 
   async findReservationsBySlotId({ slotId }: { slotId: number }): Promise<InterviewReservation[]> {
     return this.interviewRepository.findReservations({ where: { slotId } });
+  }
+
+  @Transactional()
+  async cancelReservation({ id }: { id: number }): Promise<void> {
+    const reservation = await this.interviewRepository.findReservationById({ id });
+    if (!reservation) {
+      throw new AppException('INTERVIEW_RESERVATION_NOT_FOUND', HttpStatus.NOT_FOUND);
+    }
+
+    await this.interviewRepository.deleteReservation({ id });
+
+    if (reservation.calendarEventId) {
+      try {
+        await this.googleCalendarClient.deleteEvent({
+          eventId: reservation.calendarEventId,
+        });
+      } catch (error) {
+        this.logger.error(
+          `구글 캘린더 이벤트 삭제 실패 (eventId=${reservation.calendarEventId})`,
+          error,
+        );
+      }
+    }
   }
 
   private validateSlotRange({ startAt, endAt }: { startAt: Date; endAt: Date }): void {

--- a/src/interview/infrastructure/google-calendar.client.ts
+++ b/src/interview/infrastructure/google-calendar.client.ts
@@ -10,6 +10,15 @@ type CreateEventPayload = {
   location?: string;
 };
 
+type UpdateEventPayload = {
+  eventId: string;
+  summary?: string;
+  description?: string;
+  startAt?: Date;
+  endAt?: Date;
+  location?: string;
+};
+
 @Injectable()
 export class GoogleCalendarClient {
   private readonly logger = new Logger(GoogleCalendarClient.name);
@@ -26,10 +35,9 @@ export class GoogleCalendarClient {
       const calendarId = this.configService.get<string>('GOOGLE_CALENDAR_ID');
 
       if (!keyFilename || !calendarId) {
-        this.logger.error(
+        throw new Error(
           'CALENDAR_PROVIDER=google 이지만 GOOGLE_CALENDAR_KEY_FILE_PATH 또는 GOOGLE_CALENDAR_ID가 누락되었습니다.',
         );
-        return;
       }
 
       const auth = new google.auth.GoogleAuth({
@@ -72,6 +80,45 @@ export class GoogleCalendarClient {
     }
 
     return response.data.id;
+  }
+
+  async updateEvent({
+    eventId,
+    summary,
+    description,
+    startAt,
+    endAt,
+    location,
+  }: UpdateEventPayload): Promise<void> {
+    if (!this.calendar || !this.calendarId) {
+      this.logger.log(
+        `[캘린더 미리보기] update eventId=${eventId}, start=${startAt?.toISOString() ?? '(unchanged)'}`,
+      );
+      return;
+    }
+
+    const requestBody: calendar_v3.Schema$Event = {};
+    if (summary !== undefined) {
+      requestBody.summary = summary;
+    }
+    if (description !== undefined) {
+      requestBody.description = description;
+    }
+    if (location !== undefined) {
+      requestBody.location = location;
+    }
+    if (startAt !== undefined) {
+      requestBody.start = { dateTime: startAt.toISOString(), timeZone: 'Asia/Seoul' };
+    }
+    if (endAt !== undefined) {
+      requestBody.end = { dateTime: endAt.toISOString(), timeZone: 'Asia/Seoul' };
+    }
+
+    await this.calendar.events.patch({
+      calendarId: this.calendarId,
+      eventId,
+      requestBody,
+    });
   }
 
   async deleteEvent({ eventId }: { eventId: string }): Promise<void> {

--- a/src/interview/interface/admin.interview.controller.ts
+++ b/src/interview/interface/admin.interview.controller.ts
@@ -147,4 +147,16 @@ export class AdminInterviewController {
     });
     return ApiResponse.ok(InterviewReservationResponseDto.from(reservation));
   }
+
+  @ApiDoc({
+    summary: '면접 예약 취소',
+    description: '면접 예약을 취소하고 연동된 구글 캘린더 이벤트를 삭제합니다.',
+    operationId: 'interview_cancelReservation',
+    auth: true,
+  })
+  @Delete('reservations/:reservationId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async cancelReservation(@Param('reservationId', ParseIntPipe) reservationId: number) {
+    await this.interviewService.cancelReservation({ id: reservationId });
+  }
 }


### PR DESCRIPTION
## 개요
면접 예약 라이프사이클의 미완성 부분을 보강했습니다. 정의만 되어 있고 호출처가 없던 `GoogleCalendarClient.deleteEvent`를 실제 예약 취소 흐름에 연결하고, 슬롯 시간/장소 변경 시 캘린더 이벤트도 함께 동기화되도록 했습니다. 또한 `CALENDAR_PROVIDER=google` 인데 키/ID가 누락된 채 부팅되어 silent 하게 console preview 모드로 동작하던 문제를 운영에서 fail-fast 하도록 검증을 강화했습니다.

## 변경 이유
- (P0) 예약 취소·재배정 흐름에서 구글 캘린더 이벤트가 정리되지 않아 캘린더에 좀비 이벤트가 누적될 수 있었음
- (P0) 슬롯 시간 변경 시 사용자 캘린더와 실제 면접 시간이 어긋날 수 있었음
- (P1) `CALENDAR_PROVIDER=google` 인데 키/ID 누락 시 앱이 정상 부팅되어 캘린더 미동작을 운영팀이 즉시 인지하기 어려웠음

## 주요 변경 사항
- `DELETE /admin/interview-slots/reservations/:reservationId` 엔드포인트 추가 — 예약 soft delete 후 연동된 캘린더 이벤트를 삭제
- `InterviewService.updateSlot` 에서 `startAt/endAt/location/description` 변경 시 `calendarEventId` 가 있는 예약의 캘린더 이벤트를 `events.patch` 로 동기화
- `GoogleCalendarClient.updateEvent` 메서드 추가 (events.patch 호출, 변경된 필드만 반영)
- `env.validation`: 새 환경변수를 추가하지 않고, `ValidateIf` 로 `CALENDAR_PROVIDER === 'google'` 일 때만 `GOOGLE_CALENDAR_ID`/`GOOGLE_CALENDAR_KEY_FILE_PATH` 가 required 가 되도록 검증을 강화
- `GoogleCalendarClient` 생성자: 키/ID 누락 시 `logger.error` + console preview fallback 대신 `throw` 로 변경하여 부팅 실패시킴
- 신규 에러 코드 `INTERVIEW_RESERVATION_NOT_FOUND` 추가
- 캘린더 이벤트 작업이 실패해도 핵심 DB 처리(예약 취소/슬롯 수정)는 성공으로 마무리되도록 try/catch + 로깅 유지 (기존 `createReservation` 패턴과 일관)

## 아키텍처 영향
- 도메인 분리: 변경 없음. `googleapis` SDK 의존은 여전히 `infrastructure` 레이어 안에만 있음
- 레이어 변경: 없음. Controller → Application(Service) → Infrastructure(GoogleCalendarClient/Repository) 흐름 유지
- 의존 방향 영향: 없음
- 트랜잭션 경계: `cancelReservation`/`updateSlot` 모두 기존 `createReservation` 과 동일하게 `@Transactional()` 내부에서 캘린더 호출(외부 호출 swallow 패턴 유지). 트랜잭션 외부로 분리하는 리팩토링은 후속 작업으로 분리

## 테스트
- [x] 단위 테스트
- [ ] 통합 테스트
- [x] 수동 테스트 (빌드 + jest)

확인 내용:
- `yarn build` 통과
- `yarn jest src/interview/application/interview.service.spec.ts src/config/env.validation.spec.ts` 22/22 통과
  - 신규: `cancelReservation` 4건 (404 / 정상 삭제 / calendarEventId 없음 / 캘린더 실패 swallow)
  - 신규: `updateSlot` 캘린더 동기화 3건 (시간 변경 시 동기화 / capacity 변경 시 미동기화 / 일부 실패해도 나머지 진행)
  - 신규: `env.validation` 조건부 검증 4건 (default console / google + ID 누락 / google + KEY 누락 / google + 모두 있음)

## 리뷰 포인트
- `src/interview/interface/admin.interview.controller.ts`: 신규 DELETE 라우트 경로(`reservations/:reservationId`) 가 기존 `:id` 파라미터와 충돌하지 않는지 확인 부탁드립니다 (`GET /:id` 는 슬롯 id, `DELETE /reservations/:reservationId` 는 예약 id 로 분리)
- `src/interview/application/interview.service.ts`: `updateSlot` 안에서 캘린더 호출이 트랜잭션 내부인 점 — 외부 HTTP 호출이 길어지면 락 점유 시간이 늘어나지만, 기존 `createReservation` 일관성을 위해 같은 패턴을 유지함. 트랜잭션 외부 분리는 후속 작업으로 제안
- `src/interview/infrastructure/google-calendar.client.ts`: 키/ID 누락 시 `throw` 로 변경 — env.validation 강화와 중복 같지만 안전망 차원으로 둠

## 리스크 / 후속 작업
- 기존 운영 환경 변수에서 `CALENDAR_PROVIDER=google` 인데 ID/KEY가 비어 있으면 앱 부팅 실패. `.env.production` 은 deploy.yml 에서 자동 주입되므로 영향 없을 것으로 보이지만 배포 시 한 번 확인 부탁
- 후속: 캘린더 호출을 트랜잭션 외부(`runOnTransactionCommit`) 로 이동, 캘린더 실패 시 슬랙/디스코드 알림 또는 outbox 재시도 큐
- 후속: `STORAGE_PROVIDER=gcs`, `EMAIL_PROVIDER=resend`, `DISCORD_PROVIDER=discord` 도 동일하게 `ValidateIf` 적용

## 관련 이슈
- 없음 (사내 점검 후 발견된 라이프사이클 누락 보강)