### PR TITLE
feat(interview): 캘린더 호출을 트랜잭션 외부로 분리 + 운영 실패 알림 메일

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,9 @@ EMAIL_PROVIDER=console        # console | resend
 RESEND_API_KEY=
 EMAIL_FROM=                   # e.g. noreply@dddsite.co.kr
 
+# 운영 알림 수신 메일 (외부 연동 실패 시 발송, 미설정 시 logger.warn 만)
+OPS_ALERT_EMAIL=              # e.g. ops@dddsite.co.kr
+
 # ============================================================
 # Interview
 # ============================================================

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -86,6 +86,10 @@ class EnvironmentVariables {
 
   @IsString()
   @IsOptional()
+  OPS_ALERT_EMAIL?: string;
+
+  @IsString()
+  @IsOptional()
   INTERVIEW_BOOKING_URL?: string;
 
   @IsString()

--- a/src/interview/application/interview.service.spec.ts
+++ b/src/interview/application/interview.service.spec.ts
@@ -11,26 +11,20 @@ import type { InterviewSlot } from '../domain/interview-slot.entity';
 import { GoogleCalendarClient } from '../infrastructure/google-calendar.client';
 import { InterviewService } from './interview.service';
 
-const mockPostCommitTasks: Array<Promise<unknown>> = [];
-
 jest.mock('typeorm-transactional', () => ({
   Transactional: () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) =>
     descriptor,
-  runOnTransactionCommit: (callback: () => unknown) => {
-    const result = callback();
-    if (result && typeof (result as Promise<unknown>).then === 'function') {
-      mockPostCommitTasks.push(Promise.resolve(result).catch(() => undefined));
-    }
+  runOnTransactionCommit: (callback: () => void) => {
+    callback();
   },
   initializeTransactionalContext: jest.fn(),
 }));
 
-const flushPostCommitTasks = async (): Promise<void> => {
-  while (mockPostCommitTasks.length > 0) {
-    const task = mockPostCommitTasks.shift();
-    if (task) {
-      await task;
-    }
+const flushPostCommitTasks = async (target: InterviewService): Promise<void> => {
+  const pending = (target as unknown as { pendingPostCommitTasks: Set<Promise<unknown>> })
+    .pendingPostCommitTasks;
+  while (pending.size > 0) {
+    await Promise.all([...pending]);
   }
 };
 
@@ -106,7 +100,6 @@ describe('InterviewService', () => {
     service = module.get(InterviewService);
     jest.clearAllMocks();
     mockConfigService.get.mockReturnValue(undefined);
-    mockPostCommitTasks.length = 0;
   });
 
   describe('createSlot', () => {
@@ -199,7 +192,7 @@ describe('InterviewService', () => {
 
       // When
       const result = await service.createReservation({ input });
-      await flushPostCommitTasks();
+      await flushPostCommitTasks(service);
 
       // Then
       expect(result).toBe(saved);
@@ -219,7 +212,7 @@ describe('InterviewService', () => {
 
       // When
       await service.createReservation({ input });
-      await flushPostCommitTasks();
+      await flushPostCommitTasks(service);
 
       // Then
       expect(mockGoogleCalendarClient.createEvent).toHaveBeenCalledWith(
@@ -257,7 +250,7 @@ describe('InterviewService', () => {
 
       // When
       await service.createReservation({ input });
-      await flushPostCommitTasks();
+      await flushPostCommitTasks(service);
 
       // Then
       expect(mockNotificationService.sendEmail).toHaveBeenCalledWith(
@@ -280,7 +273,7 @@ describe('InterviewService', () => {
 
       // When
       await service.createReservation({ input });
-      await flushPostCommitTasks();
+      await flushPostCommitTasks(service);
 
       // Then — 안내 메일은 발송, 운영 알림(ops 도메인)은 미발송
       expect(mockNotificationService.sendEmail).not.toHaveBeenCalledWith(
@@ -307,7 +300,7 @@ describe('InterviewService', () => {
 
       // When
       await service.cancelReservation({ id: 100 });
-      await flushPostCommitTasks();
+      await flushPostCommitTasks(service);
 
       // Then
       expect(mockInterviewRepository.deleteReservation).toHaveBeenCalledWith({ id: 100 });
@@ -321,7 +314,7 @@ describe('InterviewService', () => {
 
       // When
       await service.cancelReservation({ id: 100 });
-      await flushPostCommitTasks();
+      await flushPostCommitTasks(service);
 
       // Then
       expect(mockInterviewRepository.deleteReservation).toHaveBeenCalledWith({ id: 100 });
@@ -336,7 +329,7 @@ describe('InterviewService', () => {
 
       // When
       await service.cancelReservation({ id: 100 });
-      await flushPostCommitTasks();
+      await flushPostCommitTasks(service);
 
       // Then
       expect(mockInterviewRepository.deleteReservation).toHaveBeenCalledWith({ id: 100 });
@@ -353,7 +346,7 @@ describe('InterviewService', () => {
 
       // When
       await service.cancelReservation({ id: 100 });
-      await flushPostCommitTasks();
+      await flushPostCommitTasks(service);
 
       // Then
       expect(mockNotificationService.sendEmail).toHaveBeenCalledWith(
@@ -383,7 +376,7 @@ describe('InterviewService', () => {
 
       // When
       await service.updateSlot({ id: 1, patch: { startAt: nextStartAt, endAt: nextEndAt } });
-      await flushPostCommitTasks();
+      await flushPostCommitTasks(service);
 
       // Then
       expect(mockInterviewRepository.updateSlot).toHaveBeenCalled();
@@ -402,7 +395,7 @@ describe('InterviewService', () => {
 
       // When
       await service.updateSlot({ id: 1, patch: { capacity: 2 } });
-      await flushPostCommitTasks();
+      await flushPostCommitTasks(service);
 
       // Then
       expect(mockInterviewRepository.updateSlot).toHaveBeenCalled();
@@ -418,7 +411,7 @@ describe('InterviewService', () => {
 
       // When
       await service.updateSlot({ id: 1, patch: { location: '판교' } });
-      await flushPostCommitTasks();
+      await flushPostCommitTasks(service);
 
       // Then
       expect(mockGoogleCalendarClient.updateEvent).toHaveBeenCalledTimes(2);
@@ -434,7 +427,7 @@ describe('InterviewService', () => {
 
       // When
       await service.updateSlot({ id: 1, patch: { location: '판교' } });
-      await flushPostCommitTasks();
+      await flushPostCommitTasks(service);
 
       // Then
       expect(mockNotificationService.sendEmail).toHaveBeenCalledWith(

--- a/src/interview/application/interview.service.spec.ts
+++ b/src/interview/application/interview.service.spec.ts
@@ -1,4 +1,5 @@
 import { HttpStatus } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { Test } from '@nestjs/testing';
 import { QueryFailedError } from 'typeorm';
 
@@ -10,11 +11,28 @@ import type { InterviewSlot } from '../domain/interview-slot.entity';
 import { GoogleCalendarClient } from '../infrastructure/google-calendar.client';
 import { InterviewService } from './interview.service';
 
+const mockPostCommitTasks: Array<Promise<unknown>> = [];
+
 jest.mock('typeorm-transactional', () => ({
   Transactional: () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) =>
     descriptor,
+  runOnTransactionCommit: (callback: () => unknown) => {
+    const result = callback();
+    if (result && typeof (result as Promise<unknown>).then === 'function') {
+      mockPostCommitTasks.push(Promise.resolve(result).catch(() => undefined));
+    }
+  },
   initializeTransactionalContext: jest.fn(),
 }));
+
+const flushPostCommitTasks = async (): Promise<void> => {
+  while (mockPostCommitTasks.length > 0) {
+    const task = mockPostCommitTasks.shift();
+    if (task) {
+      await task;
+    }
+  }
+};
 
 const mockInterviewRepository = {
   saveSlot: jest.fn(),
@@ -39,6 +57,10 @@ const mockGoogleCalendarClient = {
 
 const mockNotificationService = {
   sendEmail: jest.fn(),
+};
+
+const mockConfigService = {
+  get: jest.fn(),
 };
 
 const buildSlot = (overrides: Partial<InterviewSlot> = {}): InterviewSlot =>
@@ -77,11 +99,14 @@ describe('InterviewService', () => {
         { provide: InterviewRepository, useValue: mockInterviewRepository },
         { provide: GoogleCalendarClient, useValue: mockGoogleCalendarClient },
         { provide: NotificationService, useValue: mockNotificationService },
+        { provide: ConfigService, useValue: mockConfigService },
       ],
     }).compile();
 
     service = module.get(InterviewService);
     jest.clearAllMocks();
+    mockConfigService.get.mockReturnValue(undefined);
+    mockPostCommitTasks.length = 0;
   });
 
   describe('createSlot', () => {
@@ -174,36 +199,38 @@ describe('InterviewService', () => {
 
       // When
       const result = await service.createReservation({ input });
+      await flushPostCommitTasks();
 
       // Then
       expect(result).toBe(saved);
-      expect(mockInterviewRepository.saveReservation).toHaveBeenCalledTimes(1);
+      expect(mockGoogleCalendarClient.createEvent).toHaveBeenCalled();
     });
 
-    it('정상 시나리오: 예약 저장 → 캘린더 이벤트 ID 할당 → 재저장', async () => {
+    it('정상 시나리오: 예약 저장 → 캘린더 이벤트 생성 → 별도 트랜잭션으로 eventId 저장 → 안내 메일 발송', async () => {
       // Given
       const slot = buildSlot();
       const saved = buildReservation();
       mockInterviewRepository.findSlotById.mockResolvedValue(slot);
       mockInterviewRepository.countActiveReservationsBySlotId.mockResolvedValue(0);
       mockInterviewRepository.findReservationByApplicationFormId.mockResolvedValue(null);
-      mockInterviewRepository.saveReservation.mockResolvedValueOnce(saved);
-      mockInterviewRepository.saveReservation.mockResolvedValueOnce(saved);
+      mockInterviewRepository.saveReservation.mockResolvedValue(saved);
+      mockInterviewRepository.findReservationById.mockResolvedValue(saved);
       mockGoogleCalendarClient.createEvent.mockResolvedValue('event-123');
 
       // When
       await service.createReservation({ input });
+      await flushPostCommitTasks();
 
       // Then
       expect(mockGoogleCalendarClient.createEvent).toHaveBeenCalledWith(
-        expect.objectContaining({
-          summary: '[DDD] 면접 - 홍길동',
-        }),
+        expect.objectContaining({ summary: '[DDD] 면접 - 홍길동' }),
       );
       expect(mockGoogleCalendarClient.createEvent).not.toHaveBeenCalledWith(
         expect.objectContaining({ attendees: expect.anything() }),
       );
+      expect(mockInterviewRepository.findReservationById).toHaveBeenCalledWith({ id: saved.id });
       expect(mockInterviewRepository.saveReservation).toHaveBeenCalledTimes(2);
+      expect(saved.calendarEventId).toBe('event-123');
       expect(mockNotificationService.sendEmail).toHaveBeenCalledWith(
         expect.objectContaining({
           to: 'hong@example.com',
@@ -212,6 +239,52 @@ describe('InterviewService', () => {
             expect.objectContaining({ filename: 'interview.ics' }),
           ]),
         }),
+      );
+    });
+
+    it('캘린더 실패 + OPS_ALERT_EMAIL 설정 시 운영 알림 메일을 발송한다', async () => {
+      // Given
+      mockConfigService.get.mockImplementation((key: string) =>
+        key === 'OPS_ALERT_EMAIL' ? 'ops@dddsite.co.kr' : undefined,
+      );
+      const slot = buildSlot();
+      const saved = buildReservation();
+      mockInterviewRepository.findSlotById.mockResolvedValue(slot);
+      mockInterviewRepository.countActiveReservationsBySlotId.mockResolvedValue(0);
+      mockInterviewRepository.findReservationByApplicationFormId.mockResolvedValue(null);
+      mockInterviewRepository.saveReservation.mockResolvedValue(saved);
+      mockGoogleCalendarClient.createEvent.mockRejectedValue(new Error('calendar down'));
+
+      // When
+      await service.createReservation({ input });
+      await flushPostCommitTasks();
+
+      // Then
+      expect(mockNotificationService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: 'ops@dddsite.co.kr',
+          subject: expect.stringContaining('이벤트 생성'),
+        }),
+      );
+    });
+
+    it('캘린더 실패 + OPS_ALERT_EMAIL 미설정 시 운영 알림 메일은 발송하지 않는다', async () => {
+      // Given
+      const slot = buildSlot();
+      const saved = buildReservation();
+      mockInterviewRepository.findSlotById.mockResolvedValue(slot);
+      mockInterviewRepository.countActiveReservationsBySlotId.mockResolvedValue(0);
+      mockInterviewRepository.findReservationByApplicationFormId.mockResolvedValue(null);
+      mockInterviewRepository.saveReservation.mockResolvedValue(saved);
+      mockGoogleCalendarClient.createEvent.mockRejectedValue(new Error('calendar down'));
+
+      // When
+      await service.createReservation({ input });
+      await flushPostCommitTasks();
+
+      // Then — 안내 메일은 발송, 운영 알림(ops 도메인)은 미발송
+      expect(mockNotificationService.sendEmail).not.toHaveBeenCalledWith(
+        expect.objectContaining({ to: 'ops@dddsite.co.kr' }),
       );
     });
   });
@@ -234,6 +307,7 @@ describe('InterviewService', () => {
 
       // When
       await service.cancelReservation({ id: 100 });
+      await flushPostCommitTasks();
 
       // Then
       expect(mockInterviewRepository.deleteReservation).toHaveBeenCalledWith({ id: 100 });
@@ -247,6 +321,7 @@ describe('InterviewService', () => {
 
       // When
       await service.cancelReservation({ id: 100 });
+      await flushPostCommitTasks();
 
       // Then
       expect(mockInterviewRepository.deleteReservation).toHaveBeenCalledWith({ id: 100 });
@@ -259,9 +334,34 @@ describe('InterviewService', () => {
       mockInterviewRepository.findReservationById.mockResolvedValue(reservation);
       mockGoogleCalendarClient.deleteEvent.mockRejectedValue(new Error('calendar down'));
 
-      // When / Then
-      await expect(service.cancelReservation({ id: 100 })).resolves.toBeUndefined();
+      // When
+      await service.cancelReservation({ id: 100 });
+      await flushPostCommitTasks();
+
+      // Then
       expect(mockInterviewRepository.deleteReservation).toHaveBeenCalledWith({ id: 100 });
+    });
+
+    it('캘린더 삭제 실패 + OPS_ALERT_EMAIL 설정 시 운영 알림 메일을 발송한다', async () => {
+      // Given
+      mockConfigService.get.mockImplementation((key: string) =>
+        key === 'OPS_ALERT_EMAIL' ? 'ops@dddsite.co.kr' : undefined,
+      );
+      const reservation = buildReservation({ calendarEventId: 'event-123' });
+      mockInterviewRepository.findReservationById.mockResolvedValue(reservation);
+      mockGoogleCalendarClient.deleteEvent.mockRejectedValue(new Error('calendar down'));
+
+      // When
+      await service.cancelReservation({ id: 100 });
+      await flushPostCommitTasks();
+
+      // Then
+      expect(mockNotificationService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: 'ops@dddsite.co.kr',
+          subject: expect.stringContaining('이벤트 삭제'),
+        }),
+      );
     });
   });
 
@@ -283,6 +383,7 @@ describe('InterviewService', () => {
 
       // When
       await service.updateSlot({ id: 1, patch: { startAt: nextStartAt, endAt: nextEndAt } });
+      await flushPostCommitTasks();
 
       // Then
       expect(mockInterviewRepository.updateSlot).toHaveBeenCalled();
@@ -301,6 +402,7 @@ describe('InterviewService', () => {
 
       // When
       await service.updateSlot({ id: 1, patch: { capacity: 2 } });
+      await flushPostCommitTasks();
 
       // Then
       expect(mockInterviewRepository.updateSlot).toHaveBeenCalled();
@@ -316,9 +418,31 @@ describe('InterviewService', () => {
 
       // When
       await service.updateSlot({ id: 1, patch: { location: '판교' } });
+      await flushPostCommitTasks();
 
       // Then
       expect(mockGoogleCalendarClient.updateEvent).toHaveBeenCalledTimes(2);
+    });
+
+    it('캘린더 업데이트 실패 + OPS_ALERT_EMAIL 설정 시 운영 알림 메일을 발송한다', async () => {
+      // Given
+      mockConfigService.get.mockImplementation((key: string) =>
+        key === 'OPS_ALERT_EMAIL' ? 'ops@dddsite.co.kr' : undefined,
+      );
+      mockInterviewRepository.findSlotById.mockResolvedValue(baseSlot());
+      mockGoogleCalendarClient.updateEvent.mockRejectedValue(new Error('calendar down'));
+
+      // When
+      await service.updateSlot({ id: 1, patch: { location: '판교' } });
+      await flushPostCommitTasks();
+
+      // Then
+      expect(mockNotificationService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: 'ops@dddsite.co.kr',
+          subject: expect.stringContaining('이벤트 업데이트'),
+        }),
+      );
     });
   });
 

--- a/src/interview/application/interview.service.ts
+++ b/src/interview/application/interview.service.ts
@@ -1,5 +1,6 @@
 import { HttpStatus, Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { match } from 'ts-pattern';
 import { runOnTransactionCommit, Transactional } from 'typeorm-transactional';
 
 import { AppException } from '../../common/exception/app.exception';
@@ -27,6 +28,7 @@ type CalendarFailureContext = {
 @Injectable()
 export class InterviewService {
   private readonly logger = new Logger(InterviewService.name);
+  private readonly pendingPostCommitTasks = new Set<Promise<unknown>>();
 
   constructor(
     private readonly interviewRepository: InterviewRepository,
@@ -93,16 +95,18 @@ export class InterviewService {
     const nextLocation = patch.location ?? slot.location;
     const nextDescription = patch.description ?? slot.description;
 
-    runOnTransactionCommit(() =>
-      this.afterUpdateSlot({
-        slotId: id,
-        startAt: nextStartAt,
-        endAt: nextEndAt,
-        location: nextLocation,
-        description: nextDescription,
-        reservations: reservationsToSync,
-      }),
-    );
+    runOnTransactionCommit(() => {
+      this.schedulePostCommit(() =>
+        this.afterUpdateSlot({
+          slotId: id,
+          startAt: nextStartAt,
+          endAt: nextEndAt,
+          location: nextLocation,
+          description: nextDescription,
+          reservations: reservationsToSync,
+        }),
+      );
+    });
   }
 
   @Transactional()
@@ -152,14 +156,16 @@ export class InterviewService {
     try {
       const saved = await this.interviewRepository.saveReservation({ reservation });
 
-      runOnTransactionCommit(() =>
-        this.afterCreateReservation({
-          reservationId: saved.id,
-          applicantName: input.applicantName,
-          applicantEmail: input.applicantEmail,
-          slot,
-        }),
-      );
+      runOnTransactionCommit(() => {
+        this.schedulePostCommit(() =>
+          this.afterCreateReservation({
+            reservationId: saved.id,
+            applicantName: input.applicantName,
+            applicantEmail: input.applicantEmail,
+            slot,
+          }),
+        );
+      });
 
       return saved;
     } catch (error) {
@@ -188,7 +194,9 @@ export class InterviewService {
       return;
     }
 
-    runOnTransactionCommit(() => this.afterCancelReservation({ reservationId: id, eventId }));
+    runOnTransactionCommit(() => {
+      this.schedulePostCommit(() => this.afterCancelReservation({ reservationId: id, eventId }));
+    });
   }
 
   private async afterCreateReservation({
@@ -269,10 +277,7 @@ export class InterviewService {
           description,
         });
       } catch (error) {
-        this.logger.error(
-          `구글 캘린더 이벤트 업데이트 실패 (eventId=${eventId})`,
-          error,
-        );
+        this.logger.error(`구글 캘린더 이벤트 업데이트 실패 (eventId=${eventId})`, error);
         await this.notifyOpsCalendarFailure({
           context: { operation: 'update', reservationId: reservation.id, slotId, eventId },
           error,
@@ -309,9 +314,7 @@ export class InterviewService {
   }): Promise<void> {
     const opsEmail = this.configService.get<string>('OPS_ALERT_EMAIL');
     if (!opsEmail) {
-      this.logger.warn(
-        `OPS_ALERT_EMAIL 미설정으로 운영 알림을 건너뜁니다 (${context.operation}).`,
-      );
+      this.logger.warn(`OPS_ALERT_EMAIL 미설정으로 운영 알림을 건너뜁니다 (${context.operation}).`);
       return;
     }
 
@@ -343,13 +346,22 @@ export class InterviewService {
   }
 
   private formatOperation(operation: CalendarFailureContext['operation']): string {
-    if (operation === 'create') {
-      return '이벤트 생성';
-    }
-    if (operation === 'update') {
-      return '이벤트 업데이트';
-    }
-    return '이벤트 삭제';
+    return match(operation)
+      .with('create', () => '이벤트 생성')
+      .with('update', () => '이벤트 업데이트')
+      .with('delete', () => '이벤트 삭제')
+      .exhaustive();
+  }
+
+  private schedulePostCommit(task: () => Promise<void>): void {
+    const promise = task()
+      .catch((error: unknown) => {
+        this.logger.error('post-commit task failed', error);
+      })
+      .finally(() => {
+        this.pendingPostCommitTasks.delete(promise);
+      });
+    this.pendingPostCommitTasks.add(promise);
   }
 
   private validateSlotRange({ startAt, endAt }: { startAt: Date; endAt: Date }): void {

--- a/src/interview/application/interview.service.ts
+++ b/src/interview/application/interview.service.ts
@@ -1,5 +1,6 @@
 import { HttpStatus, Injectable, Logger } from '@nestjs/common';
-import { Transactional } from 'typeorm-transactional';
+import { ConfigService } from '@nestjs/config';
+import { runOnTransactionCommit, Transactional } from 'typeorm-transactional';
 
 import { AppException } from '../../common/exception/app.exception';
 import { hasDefinedValues } from '../../common/util/object-utils';
@@ -16,6 +17,13 @@ import { InterviewReservation } from '../domain/interview-reservation.entity';
 import { InterviewSlot } from '../domain/interview-slot.entity';
 import { GoogleCalendarClient } from '../infrastructure/google-calendar.client';
 
+type CalendarFailureContext = {
+  operation: 'create' | 'update' | 'delete';
+  reservationId?: number;
+  slotId?: number;
+  eventId?: string;
+};
+
 @Injectable()
 export class InterviewService {
   private readonly logger = new Logger(InterviewService.name);
@@ -24,6 +32,7 @@ export class InterviewService {
     private readonly interviewRepository: InterviewRepository,
     private readonly googleCalendarClient: GoogleCalendarClient,
     private readonly notificationService: NotificationService,
+    private readonly configService: ConfigService,
   ) {}
 
   @Transactional()
@@ -74,27 +83,26 @@ export class InterviewService {
       return;
     }
 
-    const nextLocation = patch.location ?? slot.location;
-    const nextDescription = patch.description ?? slot.description;
     const reservationsToSync = (slot.reservations ?? []).filter(
       (reservation) => reservation.calendarEventId,
     );
-    for (const reservation of reservationsToSync) {
-      try {
-        await this.googleCalendarClient.updateEvent({
-          eventId: reservation.calendarEventId as string,
-          startAt: nextStartAt,
-          endAt: nextEndAt,
-          location: nextLocation,
-          description: nextDescription,
-        });
-      } catch (error) {
-        this.logger.error(
-          `구글 캘린더 이벤트 업데이트 실패 (eventId=${reservation.calendarEventId})`,
-          error,
-        );
-      }
+    if (reservationsToSync.length === 0) {
+      return;
     }
+
+    const nextLocation = patch.location ?? slot.location;
+    const nextDescription = patch.description ?? slot.description;
+
+    runOnTransactionCommit(() =>
+      this.afterUpdateSlot({
+        slotId: id,
+        startAt: nextStartAt,
+        endAt: nextEndAt,
+        location: nextLocation,
+        description: nextDescription,
+        reservations: reservationsToSync,
+      }),
+    );
   }
 
   @Transactional()
@@ -144,25 +152,14 @@ export class InterviewService {
     try {
       const saved = await this.interviewRepository.saveReservation({ reservation });
 
-      try {
-        const eventId = await this.googleCalendarClient.createEvent({
-          summary: `[DDD] 면접 - ${input.applicantName}`,
-          startAt: slot.startAt,
-          endAt: slot.endAt,
-          location: slot.location,
-          description: slot.description,
-        });
-        saved.assignCalendarEvent(eventId);
-        await this.interviewRepository.saveReservation({ reservation: saved });
-      } catch (error) {
-        this.logger.error('구글 캘린더 이벤트 생성 실패 (예약은 저장됨)', error);
-      }
-
-      await this.sendInterviewInviteEmail({
-        applicantName: input.applicantName,
-        applicantEmail: input.applicantEmail,
-        slot,
-      });
+      runOnTransactionCommit(() =>
+        this.afterCreateReservation({
+          reservationId: saved.id,
+          applicantName: input.applicantName,
+          applicantEmail: input.applicantEmail,
+          slot,
+        }),
+      );
 
       return saved;
     } catch (error) {
@@ -186,18 +183,173 @@ export class InterviewService {
 
     await this.interviewRepository.deleteReservation({ id });
 
-    if (reservation.calendarEventId) {
+    const eventId = reservation.calendarEventId;
+    if (!eventId) {
+      return;
+    }
+
+    runOnTransactionCommit(() => this.afterCancelReservation({ reservationId: id, eventId }));
+  }
+
+  private async afterCreateReservation({
+    reservationId,
+    applicantName,
+    applicantEmail,
+    slot,
+  }: {
+    reservationId: number;
+    applicantName: string;
+    applicantEmail: string;
+    slot: InterviewSlot;
+  }): Promise<void> {
+    try {
+      const eventId = await this.googleCalendarClient.createEvent({
+        summary: `[DDD] 면접 - ${applicantName}`,
+        startAt: slot.startAt,
+        endAt: slot.endAt,
+        location: slot.location,
+        description: slot.description,
+      });
+      await this.persistReservationCalendarEvent({ reservationId, eventId });
+    } catch (error) {
+      this.logger.error('구글 캘린더 이벤트 생성 실패 (예약은 저장됨)', error);
+      await this.notifyOpsCalendarFailure({
+        context: { operation: 'create', reservationId, slotId: slot.id },
+        error,
+      });
+    }
+
+    await this.sendInterviewInviteEmail({ applicantName, applicantEmail, slot });
+  }
+
+  private async afterCancelReservation({
+    reservationId,
+    eventId,
+  }: {
+    reservationId: number;
+    eventId: string;
+  }): Promise<void> {
+    try {
+      await this.googleCalendarClient.deleteEvent({ eventId });
+    } catch (error) {
+      this.logger.error(`구글 캘린더 이벤트 삭제 실패 (eventId=${eventId})`, error);
+      await this.notifyOpsCalendarFailure({
+        context: { operation: 'delete', reservationId, eventId },
+        error,
+      });
+    }
+  }
+
+  private async afterUpdateSlot({
+    slotId,
+    startAt,
+    endAt,
+    location,
+    description,
+    reservations,
+  }: {
+    slotId: number;
+    startAt: Date;
+    endAt: Date;
+    location?: string;
+    description?: string;
+    reservations: InterviewReservation[];
+  }): Promise<void> {
+    for (const reservation of reservations) {
+      const eventId = reservation.calendarEventId;
+      if (!eventId) {
+        continue;
+      }
       try {
-        await this.googleCalendarClient.deleteEvent({
-          eventId: reservation.calendarEventId,
+        await this.googleCalendarClient.updateEvent({
+          eventId,
+          startAt,
+          endAt,
+          location,
+          description,
         });
       } catch (error) {
         this.logger.error(
-          `구글 캘린더 이벤트 삭제 실패 (eventId=${reservation.calendarEventId})`,
+          `구글 캘린더 이벤트 업데이트 실패 (eventId=${eventId})`,
           error,
         );
+        await this.notifyOpsCalendarFailure({
+          context: { operation: 'update', reservationId: reservation.id, slotId, eventId },
+          error,
+        });
       }
     }
+  }
+
+  @Transactional()
+  private async persistReservationCalendarEvent({
+    reservationId,
+    eventId,
+  }: {
+    reservationId: number;
+    eventId: string;
+  }): Promise<void> {
+    const reservation = await this.interviewRepository.findReservationById({ id: reservationId });
+    if (!reservation) {
+      this.logger.warn(
+        `캘린더 이벤트 ID 저장 대상 예약을 찾을 수 없습니다 (reservationId=${reservationId}).`,
+      );
+      return;
+    }
+    reservation.assignCalendarEvent(eventId);
+    await this.interviewRepository.saveReservation({ reservation });
+  }
+
+  private async notifyOpsCalendarFailure({
+    context,
+    error,
+  }: {
+    context: CalendarFailureContext;
+    error: unknown;
+  }): Promise<void> {
+    const opsEmail = this.configService.get<string>('OPS_ALERT_EMAIL');
+    if (!opsEmail) {
+      this.logger.warn(
+        `OPS_ALERT_EMAIL 미설정으로 운영 알림을 건너뜁니다 (${context.operation}).`,
+      );
+      return;
+    }
+
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    const subject = `[DDD][경고] 구글 캘린더 ${this.formatOperation(context.operation)} 실패`;
+    const detailLines = [
+      `작업: ${this.formatOperation(context.operation)}`,
+      context.reservationId ? `예약 ID: ${context.reservationId}` : null,
+      context.slotId ? `슬롯 ID: ${context.slotId}` : null,
+      context.eventId ? `이벤트 ID: ${context.eventId}` : null,
+      `에러: ${errorMessage}`,
+    ].filter((line): line is string => Boolean(line));
+
+    try {
+      await this.notificationService.sendEmail({
+        to: opsEmail,
+        subject,
+        html: `<pre style="font-family:'Apple SD Gothic Neo','Malgun Gothic',monospace;font-size:13px;line-height:1.6;color:#111;">${detailLines
+          .map((line) => this.escapeHtml(line))
+          .join('\n')}</pre>`,
+        text: detailLines.join('\n'),
+      });
+    } catch (notifyError) {
+      this.logger.error(
+        '운영 알림 메일 발송 실패 (캘린더 실패 알림)',
+        notifyError instanceof Error ? notifyError.stack : String(notifyError),
+      );
+    }
+  }
+
+  private formatOperation(operation: CalendarFailureContext['operation']): string {
+    if (operation === 'create') {
+      return '이벤트 생성';
+    }
+    if (operation === 'update') {
+      return '이벤트 업데이트';
+    }
+    return '이벤트 삭제';
   }
 
   private validateSlotRange({ startAt, endAt }: { startAt: Date; endAt: Date }): void {
@@ -258,7 +410,6 @@ export class InterviewService {
   }
 
   private buildGreeting(name: string): string {
-    // 이름에 Unicode replacement character(U+FFFD)가 있으면 인코딩 손상으로 보고 generic greeting 사용
     if (!name || name.includes('�')) {
       return '안녕하세요, 지원자님';
     }


### PR DESCRIPTION
## 개요
PR #44(면접 예약 취소/슬롯 변경 시 구글 캘린더 동기화) 위에 stack 된 후속 PR 입니다. 캘린더 라이프사이클 직후 발견된 잔여 P1 이슈 두 가지(트랜잭션 내 외부 호출 / 캘린더 실패 운영 가시성)를 동시에 해결합니다.

> Base 가 `feat/interview-calendar-lifecycle` 입니다. PR #44 가 머지되면 자동으로 `main` 으로 전환됩니다.

## 변경 이유
- (P1) 기존 `createReservation` / `cancelReservation` / `updateSlot` 은 모두 `@Transactional()` 안에서 구글 캘린더 외부 HTTP 를 호출하고 있었음 → API 지연 시 DB 트랜잭션 락 점유 시간이 길어져 동시 예약량이 늘어날 때 데드락/락 경합 위험이 있었음
- (P1) 캘린더 실패 시 `logger.error` 로만 기록되어 운영팀이 미연동 사실을 즉시 인지할 경로가 없었음 → 좀비 이벤트/시간 어긋남이 누적될 수 있음

## 주요 변경 사항
- `runOnTransactionCommit` 으로 캘린더 호출을 DB 트랜잭션 commit 후로 분리. 트랜잭션 자체는 DB 작업만 담고, 캘린더 호출은 commit 이후 백그라운드로 수행
- `afterCreateReservation` / `afterCancelReservation` / `afterUpdateSlot` 후처리 헬퍼 메서드 도입
- 캘린더 이벤트 ID 저장은 별도 `@Transactional` 메서드 `persistReservationCalendarEvent` 로 격리 — 메인 예약 트랜잭션이 commit 된 뒤에 짧은 별도 트랜잭션으로 ID 만 추가 저장
- `OPS_ALERT_EMAIL` 옵셔널 환경변수 추가(`.env.example`, `env.validation.ts`)
- `notifyOpsCalendarFailure` 헬퍼 추가 — 캘린더 작업 실패 시 운영팀 이메일로 작업 종류/예약 ID/슬롯 ID/이벤트 ID/에러 메시지 발송. `NotificationService.sendEmail` 재사용
- `OPS_ALERT_EMAIL` 미설정 시 `logger.warn` 으로 fallback — 현행 동작 보존
- 알림 메일 본문 자체 발송 실패 시에도 swallow 후 logger.error 로 기록(알림 실패가 본 작업을 깨뜨리지 않도록)

## 아키텍처 영향
- 도메인 분리: 변경 없음. 외부 호출은 여전히 `infrastructure/GoogleCalendarClient` 안에 격리
- 레이어 변경: 없음. Application 레이어 안에서 트랜잭션 경계 재배치만 수행
- 의존 방향 영향: `InterviewService` 가 `ConfigService` 를 추가 주입(ConfigModule 은 글로벌 등록되어 모듈 변경 불필요)
- 트랜잭션 경계 영향: **있음**. 기존 한 트랜잭션 안에서 처리되던 [DB 저장 + 캘린더 호출 + 캘린더 ID 저장] 이 이제 [DB 저장(트랜잭션 A) → commit → 캘린더 호출 → 캘린더 ID 저장(짧은 트랜잭션 B)] 으로 분리됨. 캘린더 호출이 실패해도 예약 자체는 이미 commit 된 상태라 보존

## 테스트
- [x] 단위 테스트
- [ ] 통합 테스트
- [x] 수동 테스트 (빌드 + jest)

확인 내용:
- `yarn build` 통과
- `yarn jest src/interview/application/interview.service.spec.ts src/config/env.validation.spec.ts` **26/26 통과**
- 신규 테스트:
  - `createReservation` 정상 시나리오: 별도 트랜잭션의 eventId 저장 + 안내 메일 발송 검증
  - `createReservation` 캘린더 실패 + `OPS_ALERT_EMAIL` 설정/미설정 분기 (운영 알림 발송/미발송)
  - `cancelReservation` 캘린더 삭제 실패 + `OPS_ALERT_EMAIL` 설정 시 운영 알림 발송
  - `updateSlot` 캘린더 업데이트 실패 + `OPS_ALERT_EMAIL` 설정 시 운영 알림 발송
- 테스트 인프라: `typeorm-transactional` mock 이 `runOnTransactionCommit` 콜백의 Promise 를 capture, `flushPostCommitTasks` 헬퍼로 commit 후 비동기 후처리까지 await 가능하도록 보강

## 리뷰 포인트
- `src/interview/application/interview.service.ts`: `runOnTransactionCommit(() => this.afterX(...))` 형태 — 내부 typeorm-transactional 시그니처는 `(cb: () => void) => void` 지만 콜백이 Promise 를 반환해도 무방(반환값 무시). 이 패턴이 테스트에서 Promise 추적을 가능케 함. 의도된 형태인지 확인 부탁
- `persistReservationCalendarEvent` 가 `private @Transactional` 메서드 — typeorm-transactional 은 클래스 외부 호출에서만 트랜잭션이 적용되는 구조이지만, NestJS DI 인스턴스를 통한 호출이라 `this.persistReservationCalendarEvent(...)` 로도 정상 동작. 별도 트랜잭션이 시작되는지(propagation 기본값 REQUIRED) 확인 권장
- 운영 알림 메일 본문은 단순 `<pre>` 형태로 발송 — Slack/Discord 웹훅 도입 전 임시 채널. 추후 채널 추가 시 `notifyOpsCalendarFailure` 가 자연스러운 확장 지점

## 리스크 / 후속 작업
- 캘린더 호출이 응답 후로 미뤄지므로 응답 시점에는 `calendarEventId` 가 아직 null. 클라이언트가 즉시 `calendarEventId` 를 사용하는 흐름이 없는지 확인 필요(현재 응답 DTO 는 nullable 로 정의되어 있음)
- `runOnTransactionCommit` 콜백의 unhandled rejection 은 mock 에서는 capture 되지만, 실제 런타임에서는 typeorm-transactional 이 무시. 콜백 내부 try/catch 로 모두 감싸 두었으나, 향후 outbox 큐로 이전 시 재시도 정책과 함께 정리 권장
- 후속(별도 PR): 운영 알림 채널을 Slack/Discord 웹훅으로 확장, 실패한 캘린더 작업의 재시도 큐(outbox 패턴)
- 별개로 발견한 점: `ReservationWriteRepository.countActiveBySlotId` 의 soft-delete 필터링은 `BaseEntity.@DeleteDateColumn` + TypeORM 0.3.x 의 자동 처리에 의존(별도 코드 변경 불필요). 통합 테스트 인프라(pg-mem 등) 도입 시 회귀 테스트 추가 권장

## 관련 이슈
- 없음 (PR #44 점검 후 발견된 잔여 P1 보강)