### PR TITLE
fix(storage): 콘솔 모드 fail-fast 및 도메인 예외 매핑 보강

### DIFF
--- a/src/config/env.validation.spec.ts
+++ b/src/config/env.validation.spec.ts
@@ -74,4 +74,28 @@ describe('env validation', () => {
       ).not.toThrow();
     });
   });
+
+  describe('STORAGE_PROVIDER 화이트리스트 검증', () => {
+    it('STORAGE_PROVIDER 미설정이면 기본값 console 로 통과한다', () => {
+      const result = validate(createValidConfig());
+
+      expect(result.STORAGE_PROVIDER).toBe('console');
+    });
+
+    it('STORAGE_PROVIDER=gcs 는 통과한다', () => {
+      expect(() => validate({ ...createValidConfig(), STORAGE_PROVIDER: 'gcs' })).not.toThrow();
+    });
+
+    it('알 수 없는 STORAGE_PROVIDER 값은 앱 시작 전에 실패한다', () => {
+      expect(() => {
+        validate({ ...createValidConfig(), STORAGE_PROVIDER: 'GCS' });
+      }).toThrow('STORAGE_PROVIDER');
+    });
+
+    it('대문자/오타 STORAGE_PROVIDER 도 거부한다', () => {
+      expect(() => {
+        validate({ ...createValidConfig(), STORAGE_PROVIDER: 'aws-s3' });
+      }).toThrow('STORAGE_PROVIDER');
+    });
+  });
 });

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -1,5 +1,6 @@
 import { plainToInstance } from 'class-transformer';
 import {
+  IsIn,
   IsNotEmpty,
   IsNumber,
   IsOptional,
@@ -10,6 +11,9 @@ import {
   ValidateIf,
   validateSync,
 } from 'class-validator';
+
+export const STORAGE_PROVIDERS = ['console', 'gcs'] as const;
+export type StorageProvider = (typeof STORAGE_PROVIDERS)[number];
 
 class EnvironmentVariables {
   @IsNumber()
@@ -96,9 +100,11 @@ class EnvironmentVariables {
   @IsOptional()
   DISCORD_INVITE_URL?: string;
 
-  @IsString()
+  @IsIn(STORAGE_PROVIDERS, {
+    message: `STORAGE_PROVIDER 는 ${STORAGE_PROVIDERS.join(' | ')} 중 하나여야 합니다.`,
+  })
   @IsOptional()
-  STORAGE_PROVIDER?: string = 'console';
+  STORAGE_PROVIDER?: StorageProvider = 'console';
 
   @IsString()
   @IsOptional()

--- a/src/storage/application/storage.service.spec.ts
+++ b/src/storage/application/storage.service.spec.ts
@@ -90,6 +90,16 @@ describe('StorageService', () => {
       ).rejects.toThrow(new AppException('FILE_UPLOAD_FAILED', HttpStatus.INTERNAL_SERVER_ERROR));
     });
 
+    it('GcsClient 비활성화 상태에서는 STORAGE_NOT_CONFIGURED(503)을 던지고 GCS를 호출하지 않는다', async () => {
+      mockGcsClient.isEnabled.mockReturnValue(false);
+      const file = buildFile();
+
+      await expect(
+        service.upload({ file, category: UploadCategory.PROJECT_THUMBNAIL }),
+      ).rejects.toThrow(new AppException('STORAGE_NOT_CONFIGURED', HttpStatus.SERVICE_UNAVAILABLE));
+      expect(mockGcsClient.upload).not.toHaveBeenCalled();
+    });
+
     it('정상 업로드 시 카테고리별 GCS 경로와 함께 URL을 반환한다', async () => {
       const file = buildFile();
       mockGcsClient.upload.mockResolvedValue('https://cdn.example.com/projects/thumbnails/abc.png');
@@ -166,6 +176,15 @@ describe('StorageService', () => {
         service.listFiles({ category: UploadCategory.PROJECT_THUMBNAIL }),
       ).rejects.toThrow(new AppException('FILE_LIST_FAILED', HttpStatus.INTERNAL_SERVER_ERROR));
     });
+
+    it('GcsClient 비활성화 상태에서는 STORAGE_NOT_CONFIGURED(503)을 던지고 GCS를 호출하지 않는다', async () => {
+      mockGcsClient.isEnabled.mockReturnValue(false);
+
+      await expect(
+        service.listFiles({ category: UploadCategory.PROJECT_THUMBNAIL }),
+      ).rejects.toThrow(new AppException('STORAGE_NOT_CONFIGURED', HttpStatus.SERVICE_UNAVAILABLE));
+      expect(mockGcsClient.list).not.toHaveBeenCalled();
+    });
   });
 
   describe('deleteFile', () => {
@@ -218,6 +237,15 @@ describe('StorageService', () => {
       await expect(service.deleteFile({ path: 'projects/thumbnails/abc.png' })).rejects.toThrow(
         new AppException('FILE_DELETE_FAILED', HttpStatus.INTERNAL_SERVER_ERROR),
       );
+    });
+
+    it('exists() 가 raw 에러를 던지면 FILE_DELETE_FAILED(500)로 매핑한다', async () => {
+      mockGcsClient.exists.mockRejectedValue(new Error('network'));
+
+      await expect(service.deleteFile({ path: 'projects/thumbnails/abc.png' })).rejects.toThrow(
+        new AppException('FILE_DELETE_FAILED', HttpStatus.INTERNAL_SERVER_ERROR),
+      );
+      expect(mockGcsClient.delete).not.toHaveBeenCalled();
     });
   });
 
@@ -292,6 +320,32 @@ describe('StorageService', () => {
         new AppException('SIGNED_URL_GENERATION_FAILED', HttpStatus.INTERNAL_SERVER_ERROR),
       );
     });
+
+    it('WRITE 액션에서도 GcsClient 비활성화 상태면 STORAGE_NOT_CONFIGURED(503)을 던진다', async () => {
+      mockGcsClient.isEnabled.mockReturnValue(false);
+
+      await expect(
+        service.generateSignedUrl({
+          path: 'projects/thumbnails/new.png',
+          action: SignedUrlAction.WRITE,
+        }),
+      ).rejects.toThrow(new AppException('STORAGE_NOT_CONFIGURED', HttpStatus.SERVICE_UNAVAILABLE));
+      expect(mockGcsClient.getSignedUrl).not.toHaveBeenCalled();
+    });
+
+    it('READ 액션에서 exists() 가 raw 에러를 던지면 SIGNED_URL_GENERATION_FAILED(500)로 매핑한다', async () => {
+      mockGcsClient.exists.mockRejectedValue(new Error('network'));
+
+      await expect(
+        service.generateSignedUrl({
+          path: 'projects/thumbnails/abc.png',
+          action: SignedUrlAction.READ,
+        }),
+      ).rejects.toThrow(
+        new AppException('SIGNED_URL_GENERATION_FAILED', HttpStatus.INTERNAL_SERVER_ERROR),
+      );
+      expect(mockGcsClient.getSignedUrl).not.toHaveBeenCalled();
+    });
   });
 
   describe('download', () => {
@@ -343,6 +397,15 @@ describe('StorageService', () => {
       await expect(service.download({ path: 'projects/thumbnails/abc.png' })).rejects.toThrow(
         new AppException('FILE_DOWNLOAD_FAILED', HttpStatus.INTERNAL_SERVER_ERROR),
       );
+    });
+
+    it('exists() 가 raw 에러를 던지면 FILE_DOWNLOAD_FAILED(500)로 매핑한다', async () => {
+      mockGcsClient.exists.mockRejectedValue(new Error('network'));
+
+      await expect(service.download({ path: 'projects/thumbnails/abc.png' })).rejects.toThrow(
+        new AppException('FILE_DOWNLOAD_FAILED', HttpStatus.INTERNAL_SERVER_ERROR),
+      );
+      expect(mockGcsClient.download).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/storage/application/storage.service.ts
+++ b/src/storage/application/storage.service.ts
@@ -3,8 +3,6 @@ import { extname } from 'path';
 
 import { AppException } from '../../common/exception/app.exception';
 import type {
-  DownloadResult,
-  FilePayload,
   ListFilesOptions,
   ListFilesResult,
   SignedUrlResult,
@@ -18,6 +16,12 @@ import {
   UploadCategory,
 } from '../domain/storage.type';
 import { GcsClient } from '../infrastructure/gcs.client';
+import type {
+  DownloadResult,
+  GenerateSignedUrlInput,
+  StoragePathInput,
+  UploadInput,
+} from './storage.type';
 
 const DEFAULT_LIST_LIMIT = 20;
 const MAX_LIST_LIMIT = 100;
@@ -36,13 +40,7 @@ export class StorageService {
 
   constructor(private readonly gcsClient: GcsClient) {}
 
-  async upload({
-    file,
-    category,
-  }: {
-    file: FilePayload | null;
-    category: UploadCategory;
-  }): Promise<UploadResult> {
+  async upload({ file, category }: UploadInput): Promise<UploadResult> {
     if (!file) {
       throw new AppException('FILE_NOT_PROVIDED', HttpStatus.BAD_REQUEST);
     }
@@ -51,6 +49,7 @@ export class StorageService {
 
     this.validateMimeType({ mimeType: file.mimeType, allowed: config.allowedMimeTypes });
     this.validateFileSize({ size: file.size, maxSize: config.maxSizeBytes });
+    this.assertStorageEnabled();
 
     try {
       const url = await this.gcsClient.upload({
@@ -74,6 +73,7 @@ export class StorageService {
   }
 
   async listFiles({ category, cursor, limit }: ListFilesOptions): Promise<ListFilesResult> {
+    this.assertStorageEnabled();
     const prefix = `${UPLOAD_CATEGORY_CONFIG[category].gcsPath}/`;
     const maxResults = this.normalizeLimit({ limit });
 
@@ -96,12 +96,12 @@ export class StorageService {
     }
   }
 
-  async deleteFile({ path }: { path: string }): Promise<void> {
+  async deleteFile({ path }: StoragePathInput): Promise<void> {
     this.assertAllowedPath({ path });
     this.assertStorageEnabled();
-    await this.assertFileExists({ path });
 
     try {
+      await this.assertFileExists({ path });
       await this.gcsClient.delete({ path });
     } catch (error) {
       if (error instanceof AppException) throw error;
@@ -114,12 +114,9 @@ export class StorageService {
     path,
     action,
     expiresInSeconds,
-  }: {
-    path: string;
-    action: SignedUrlAction;
-    expiresInSeconds?: number;
-  }): Promise<SignedUrlResult> {
+  }: GenerateSignedUrlInput): Promise<SignedUrlResult> {
     this.assertAllowedPath({ path });
+    this.assertStorageEnabled();
 
     const category = findCategoryByPath({ path });
     if (!category) {
@@ -132,12 +129,10 @@ export class StorageService {
 
     const expires = this.normalizeExpiresInSeconds({ expiresInSeconds });
 
-    if (action === SignedUrlAction.READ) {
-      this.assertStorageEnabled();
-      await this.assertFileExists({ path });
-    }
-
     try {
+      if (action === SignedUrlAction.READ) {
+        await this.assertFileExists({ path });
+      }
       return await this.gcsClient.getSignedUrl({
         path,
         action,
@@ -150,12 +145,12 @@ export class StorageService {
     }
   }
 
-  async download({ path }: { path: string }): Promise<DownloadResult> {
+  async download({ path }: StoragePathInput): Promise<DownloadResult> {
     this.assertAllowedPath({ path });
     this.assertStorageEnabled();
-    await this.assertFileExists({ path });
 
     try {
+      await this.assertFileExists({ path });
       return await this.gcsClient.download({ path });
     } catch (error) {
       if (error instanceof AppException) throw error;

--- a/src/storage/application/storage.type.ts
+++ b/src/storage/application/storage.type.ts
@@ -1,0 +1,25 @@
+import type { Readable } from 'stream';
+
+import type { FilePayload, SignedUrlAction, UploadCategory } from '../domain/storage.type';
+
+export type DownloadResult = {
+  stream: Readable;
+  contentType: string;
+  contentLength: number | null;
+  fileName: string;
+};
+
+export type UploadInput = {
+  file: FilePayload | null;
+  category: UploadCategory;
+};
+
+export type GenerateSignedUrlInput = {
+  path: string;
+  action: SignedUrlAction;
+  expiresInSeconds?: number;
+};
+
+export type StoragePathInput = {
+  path: string;
+};

--- a/src/storage/domain/storage.type.ts
+++ b/src/storage/domain/storage.type.ts
@@ -1,5 +1,3 @@
-import type { Readable } from 'stream';
-
 export enum UploadCategory {
   PROJECT_THUMBNAIL = 'project-thumbnail',
   PROJECT_PDF = 'project-pdf',
@@ -109,11 +107,4 @@ export type SignedUrlOptions = {
 export type SignedUrlResult = {
   url: string;
   expiresAt: string;
-};
-
-export type DownloadResult = {
-  stream: Readable;
-  contentType: string;
-  contentLength: number | null;
-  fileName: string;
 };

--- a/src/storage/infrastructure/gcs.client.ts
+++ b/src/storage/infrastructure/gcs.client.ts
@@ -5,8 +5,9 @@ import { randomUUID } from 'crypto';
 import { extname } from 'path';
 import { Readable } from 'stream';
 
+import type { StorageProvider } from '../../config/env.validation';
+import { DownloadResult } from '../application/storage.type';
 import {
-  DownloadResult,
   SignedUrlAction,
   SignedUrlOptions,
   SignedUrlResult,
@@ -38,9 +39,7 @@ export class GcsClient {
   private readonly bucketName: string | null = null;
 
   constructor(private readonly configService: ConfigService) {
-    const provider = (
-      this.configService.get<string>('STORAGE_PROVIDER') ?? 'console'
-    ).toLowerCase();
+    const provider = this.configService.get<StorageProvider>('STORAGE_PROVIDER') ?? 'console';
 
     if (provider === 'gcs') {
       const projectId = this.configService.get<string>('GCS_PROJECT_ID');
@@ -163,9 +162,6 @@ export class GcsClient {
 
     const file = this.storage.bucket(this.bucketName).file(path);
     const [metadata] = await file.getMetadata();
-    const sizeRaw = metadata.size;
-    const contentLength =
-      typeof sizeRaw === 'string' ? Number(sizeRaw) : typeof sizeRaw === 'number' ? sizeRaw : null;
 
     return {
       stream: file.createReadStream(),
@@ -173,25 +169,34 @@ export class GcsClient {
         typeof metadata.contentType === 'string'
           ? metadata.contentType
           : 'application/octet-stream',
-      contentLength: Number.isFinite(contentLength) ? (contentLength as number) : null,
+      contentLength: this.parseFiniteNumber(metadata.size),
       fileName: path.split('/').pop() ?? 'file',
     };
   }
 
   private toStorageObject(file: File): StorageObject {
     const metadata = file.metadata;
-    const sizeRaw = metadata.size;
-    const size = typeof sizeRaw === 'string' ? Number(sizeRaw) : (sizeRaw ?? 0);
     const updated = typeof metadata.updated === 'string' ? metadata.updated : null;
     const contentType = typeof metadata.contentType === 'string' ? metadata.contentType : null;
 
     return {
       path: file.name,
-      size: Number.isFinite(size) ? size : 0,
+      size: this.parseFiniteNumber(metadata.size) ?? 0,
       contentType,
       updatedAt: updated,
       url: `https://storage.googleapis.com/${this.bucketName}/${file.name}`,
     };
+  }
+
+  private parseFiniteNumber(value: unknown): number | null {
+    if (typeof value === 'number') {
+      return Number.isFinite(value) ? value : null;
+    }
+    if (typeof value === 'string') {
+      const parsed = Number(value);
+      return Number.isFinite(parsed) ? parsed : null;
+    }
+    return null;
   }
 
   private extractPageToken(nextQuery: unknown): string | null {


### PR DESCRIPTION
운영 환경에서 STORAGE_PROVIDER 환경변수가 누락되어 console 모드로 동작할 때 upload/listFiles/generateSignedUrl(WRITE)이 가짜 미리보기 URL을 200 OK로 반환해 프론트가 실제로 저장되지 않은 URL을 그대로 사용하게 되는 결함을 수정한다.
또한 assertFileExists 호출이 try-catch 밖에 있어 GcsClient.exists 의 인프라 에러 (네트워크/권한)가 raw 5xx로 새는 문제를 도메인 예외 매핑으로 일원화한다.

- upload/listFiles/generateSignedUrl(WRITE) 진입부에 assertStorageEnabled 추가
- assertFileExists 호출을 try-catch 안으로 이동해 인프라 에러를 도메인 예외로 매핑
- DownloadResult 및 입력 타입을 application 레이어로 분리해 Domain 레이어의 Node Readable 의존성 제거 (CODE_RULES 2-1)
- gcs.client.ts 중첩 삼항을 parseFiniteNumber 헬퍼로 정리
- STORAGE_PROVIDER 환경변수에 IsIn(['console','gcs']) 화이트리스트 검증 추가
- 회귀 방지 테스트 10개 추가 (storage 6, env.validation 4)

## 📌 PR 제목

> ex: feat: 유저 로그인 API 구현

---

## ✅ PR 설명

- 어떤 기능/버그 수정인지 간단 설명
- 관련 이슈: #123 (있다면)

---

## 🧪 테스트 방법

- [ ] 로컬 테스트 완료
- [ ] 린트 및 빌드 통과

---

## 🔍 체크리스트

- [ ] 코드에 주석/불필요한 로그 제거
- [ ] 코드 리뷰어가 이해하기 쉽게 커밋 정리

---

## 📎 기타 참고 사항 (Optional)

- 디자인, 비즈니스 로직 논의 사항 등 자유롭게 추가
