### PR TITLE
feat(notification): 사전 알림 캠페인 스케줄러 도입

### DIFF
--- a/src/common/error/error-message.ts
+++ b/src/common/error/error-message.ts
@@ -41,6 +41,9 @@ export const ErrorMessage = {
   EARLY_NOTIFICATION_CONFLICT: '사전 알림 처리 중 일시적인 충돌이 발생했습니다. 다시 시도해주세요.',
   GENERAL_EARLY_NOTIFICATION_CONFLICT:
     '대기열 사전 알림 처리 중 일시적인 충돌이 발생했습니다. 다시 시도해주세요.',
+  NOTIFICATION_CAMPAIGN_NOT_FOUND: '사전 알림 캠페인을 찾을 수 없습니다.',
+  NOTIFICATION_CAMPAIGN_INVALID_STATE: '현재 상태에서 허용되지 않는 캠페인 변경입니다.',
+  NOTIFICATION_CAMPAIGN_INVALID_SCHEDULE: '발송 예정 시각이 유효하지 않습니다.',
 
   FILE_NOT_PROVIDED: '업로드할 파일이 없습니다.',
   FILE_TYPE_NOT_ALLOWED: '허용되지 않는 파일 형식입니다.',

--- a/src/notification/application/notification-campaign.service.spec.ts
+++ b/src/notification/application/notification-campaign.service.spec.ts
@@ -1,0 +1,375 @@
+jest.mock('typeorm-transactional', () => ({
+  Transactional: () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) =>
+    descriptor,
+  initializeTransactionalContext: jest.fn(),
+}));
+
+import { HttpStatus } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+
+import { AuditLogService } from '../../audit/application/audit-log.service';
+import { CohortRepository } from '../../cohort/domain/cohort.repository';
+import { AppException } from '../../common/exception/app.exception';
+import { NotificationCampaignRepository } from '../domain/notification-campaign.repository';
+import { NotificationCampaignStatus } from '../domain/notification-campaign.status';
+import { EarlyNotificationService } from './early-notification.service';
+import { NotificationCampaignService } from './notification-campaign.service';
+
+const mockNotificationCampaignRepository = {
+  register: jest.fn(),
+  findById: jest.fn(),
+  findByCohort: jest.fn(),
+  findDueScheduled: jest.fn(),
+  transitionStatus: jest.fn(),
+};
+
+const mockCohortRepository = {
+  findById: jest.fn(),
+};
+
+const mockEarlyNotificationService = {
+  sendBulk: jest.fn(),
+};
+
+const mockAuditLogService = {
+  recordStatusChange: jest.fn(),
+};
+
+describe('NotificationCampaignService', () => {
+  let service: NotificationCampaignService;
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        NotificationCampaignService,
+        {
+          provide: NotificationCampaignRepository,
+          useValue: mockNotificationCampaignRepository,
+        },
+        { provide: CohortRepository, useValue: mockCohortRepository },
+        { provide: EarlyNotificationService, useValue: mockEarlyNotificationService },
+        { provide: AuditLogService, useValue: mockAuditLogService },
+      ],
+    }).compile();
+
+    service = moduleRef.get(NotificationCampaignService);
+    jest.clearAllMocks();
+  });
+
+  describe('createCampaign', () => {
+    const payload = {
+      cohortId: 1,
+      scheduledAt: new Date('2026-06-01T10:00:00Z'),
+      subject: '제목',
+      html: '<p>본문</p>',
+      text: '본문',
+    };
+
+    it('대상 기수가 없으면 COHORT_NOT_FOUND를 던진다', async () => {
+      // Given
+      mockCohortRepository.findById.mockResolvedValue(null);
+
+      // When & Then
+      await expect(service.createCampaign(payload)).rejects.toThrow(
+        new AppException('COHORT_NOT_FOUND', HttpStatus.NOT_FOUND),
+      );
+      expect(mockNotificationCampaignRepository.register).not.toHaveBeenCalled();
+    });
+
+    it('대상 기수가 있으면 캠페인을 등록하고 반환한다', async () => {
+      // Given
+      const created = { id: 10, ...payload, status: NotificationCampaignStatus.SCHEDULED };
+      mockCohortRepository.findById.mockResolvedValue({ id: 1 });
+      mockNotificationCampaignRepository.register.mockResolvedValue(created);
+
+      // When
+      const result = await service.createCampaign(payload);
+
+      // Then
+      expect(result).toBe(created);
+      expect(mockNotificationCampaignRepository.register).toHaveBeenCalledWith(payload);
+    });
+  });
+
+  describe('pauseCampaign', () => {
+    it('캠페인이 없으면 NOTIFICATION_CAMPAIGN_NOT_FOUND를 던진다', async () => {
+      // Given
+      mockNotificationCampaignRepository.findById.mockResolvedValue(null);
+
+      // When & Then
+      await expect(service.pauseCampaign({ id: 5 })).rejects.toThrow(
+        new AppException('NOTIFICATION_CAMPAIGN_NOT_FOUND', HttpStatus.NOT_FOUND),
+      );
+    });
+
+    it('SCHEDULED 상태가 아니면 INVALID_STATE를 던진다', async () => {
+      // Given
+      mockNotificationCampaignRepository.findById.mockResolvedValue({
+        id: 5,
+        status: NotificationCampaignStatus.RUNNING,
+      });
+
+      // When & Then
+      await expect(service.pauseCampaign({ id: 5 })).rejects.toThrow(
+        new AppException('NOTIFICATION_CAMPAIGN_INVALID_STATE', HttpStatus.CONFLICT),
+      );
+      expect(mockNotificationCampaignRepository.transitionStatus).not.toHaveBeenCalled();
+    });
+
+    it('SCHEDULED 상태면 PAUSED로 전이하고 audit 로그를 남긴다', async () => {
+      // Given
+      mockNotificationCampaignRepository.findById.mockResolvedValue({
+        id: 5,
+        status: NotificationCampaignStatus.SCHEDULED,
+      });
+      mockNotificationCampaignRepository.transitionStatus.mockResolvedValue(true);
+
+      // When
+      await service.pauseCampaign({ id: 5 });
+
+      // Then
+      expect(mockNotificationCampaignRepository.transitionStatus).toHaveBeenCalledWith({
+        id: 5,
+        fromStatus: NotificationCampaignStatus.SCHEDULED,
+        toStatus: NotificationCampaignStatus.PAUSED,
+      });
+      expect(mockAuditLogService.recordStatusChange).toHaveBeenCalledWith({
+        entityType: 'notification_campaign',
+        entityId: 5,
+        fromValue: NotificationCampaignStatus.SCHEDULED,
+        toValue: NotificationCampaignStatus.PAUSED,
+        adminId: 0,
+      });
+    });
+
+    it('상태 전이가 race로 실패하면 INVALID_STATE를 던진다', async () => {
+      // Given
+      mockNotificationCampaignRepository.findById.mockResolvedValue({
+        id: 5,
+        status: NotificationCampaignStatus.SCHEDULED,
+      });
+      mockNotificationCampaignRepository.transitionStatus.mockResolvedValue(false);
+
+      // When & Then
+      await expect(service.pauseCampaign({ id: 5 })).rejects.toThrow(
+        new AppException('NOTIFICATION_CAMPAIGN_INVALID_STATE', HttpStatus.CONFLICT),
+      );
+      expect(mockAuditLogService.recordStatusChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resumeCampaign', () => {
+    it('PAUSED 상태가 아니면 INVALID_STATE를 던진다', async () => {
+      // Given
+      mockNotificationCampaignRepository.findById.mockResolvedValue({
+        id: 5,
+        status: NotificationCampaignStatus.SCHEDULED,
+      });
+
+      // When & Then
+      await expect(service.resumeCampaign({ id: 5 })).rejects.toThrow(
+        new AppException('NOTIFICATION_CAMPAIGN_INVALID_STATE', HttpStatus.CONFLICT),
+      );
+    });
+
+    it('PAUSED 상태면 SCHEDULED로 복귀하고 audit 로그를 남긴다', async () => {
+      // Given
+      mockNotificationCampaignRepository.findById.mockResolvedValue({
+        id: 5,
+        status: NotificationCampaignStatus.PAUSED,
+      });
+      mockNotificationCampaignRepository.transitionStatus.mockResolvedValue(true);
+
+      // When
+      await service.resumeCampaign({ id: 5 });
+
+      // Then
+      expect(mockNotificationCampaignRepository.transitionStatus).toHaveBeenCalledWith({
+        id: 5,
+        fromStatus: NotificationCampaignStatus.PAUSED,
+        toStatus: NotificationCampaignStatus.SCHEDULED,
+      });
+      expect(mockAuditLogService.recordStatusChange).toHaveBeenCalledWith({
+        entityType: 'notification_campaign',
+        entityId: 5,
+        fromValue: NotificationCampaignStatus.PAUSED,
+        toValue: NotificationCampaignStatus.SCHEDULED,
+        adminId: 0,
+      });
+    });
+  });
+
+  describe('runDueCampaigns / executeCampaign', () => {
+    const baseCampaign = {
+      id: 100,
+      cohortId: 1,
+      subject: '제목',
+      html: '<p>본문</p>',
+      text: '본문',
+      scheduledAt: new Date('2026-06-01T10:00:00Z'),
+      status: NotificationCampaignStatus.SCHEDULED,
+    };
+
+    it('due 캠페인이 없으면 추가 호출이 없다', async () => {
+      // Given
+      mockNotificationCampaignRepository.findDueScheduled.mockResolvedValue([]);
+
+      // When
+      await service.runDueCampaigns();
+
+      // Then
+      expect(mockNotificationCampaignRepository.transitionStatus).not.toHaveBeenCalled();
+      expect(mockEarlyNotificationService.sendBulk).not.toHaveBeenCalled();
+    });
+
+    it('claim 실패 시 sendBulk를 호출하지 않고 다음으로 넘어간다', async () => {
+      // Given
+      mockNotificationCampaignRepository.findDueScheduled.mockResolvedValue([baseCampaign]);
+      mockNotificationCampaignRepository.transitionStatus.mockResolvedValueOnce(false);
+
+      // When
+      await service.runDueCampaigns();
+
+      // Then
+      expect(mockEarlyNotificationService.sendBulk).not.toHaveBeenCalled();
+      expect(mockAuditLogService.recordStatusChange).not.toHaveBeenCalled();
+    });
+
+    it('전송 성공(success>0) 시 RUNNING→DONE 전이 + audit', async () => {
+      // Given
+      mockNotificationCampaignRepository.findDueScheduled.mockResolvedValue([baseCampaign]);
+      mockNotificationCampaignRepository.transitionStatus
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(true);
+      mockEarlyNotificationService.sendBulk.mockResolvedValue({ total: 3, success: 3, failed: 0 });
+
+      // When
+      await service.runDueCampaigns();
+
+      // Then
+      expect(mockNotificationCampaignRepository.transitionStatus).toHaveBeenNthCalledWith(1, {
+        id: 100,
+        fromStatus: NotificationCampaignStatus.SCHEDULED,
+        toStatus: NotificationCampaignStatus.RUNNING,
+      });
+      expect(mockNotificationCampaignRepository.transitionStatus).toHaveBeenNthCalledWith(2, {
+        id: 100,
+        fromStatus: NotificationCampaignStatus.RUNNING,
+        toStatus: NotificationCampaignStatus.DONE,
+        patch: {
+          sentAt: expect.any(Date) as unknown,
+          result: { total: 3, success: 3, failed: 0 },
+        },
+      });
+      expect(mockAuditLogService.recordStatusChange).toHaveBeenCalledWith({
+        entityType: 'notification_campaign',
+        entityId: 100,
+        fromValue: NotificationCampaignStatus.RUNNING,
+        toValue: NotificationCampaignStatus.DONE,
+        adminId: 0,
+      });
+    });
+
+    it('대상이 없을 때(total=0)는 DONE으로 종료한다', async () => {
+      // Given
+      mockNotificationCampaignRepository.findDueScheduled.mockResolvedValue([baseCampaign]);
+      mockNotificationCampaignRepository.transitionStatus
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(true);
+      mockEarlyNotificationService.sendBulk.mockResolvedValue({ total: 0, success: 0, failed: 0 });
+
+      // When
+      await service.runDueCampaigns();
+
+      // Then
+      expect(mockNotificationCampaignRepository.transitionStatus).toHaveBeenNthCalledWith(2, {
+        id: 100,
+        fromStatus: NotificationCampaignStatus.RUNNING,
+        toStatus: NotificationCampaignStatus.DONE,
+        patch: {
+          sentAt: expect.any(Date) as unknown,
+          result: { total: 0, success: 0, failed: 0 },
+        },
+      });
+    });
+
+    it('전부 실패(success=0, total>0)면 FAILED로 종료한다', async () => {
+      // Given
+      mockNotificationCampaignRepository.findDueScheduled.mockResolvedValue([baseCampaign]);
+      mockNotificationCampaignRepository.transitionStatus
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(true);
+      mockEarlyNotificationService.sendBulk.mockResolvedValue({ total: 2, success: 0, failed: 2 });
+
+      // When
+      await service.runDueCampaigns();
+
+      // Then
+      expect(mockNotificationCampaignRepository.transitionStatus).toHaveBeenNthCalledWith(2, {
+        id: 100,
+        fromStatus: NotificationCampaignStatus.RUNNING,
+        toStatus: NotificationCampaignStatus.FAILED,
+        patch: {
+          sentAt: expect.any(Date) as unknown,
+          result: { total: 2, success: 0, failed: 2 },
+        },
+      });
+    });
+
+    it('sendBulk 자체가 throw하면 FAILED로 종료하고 result는 null로 둔다', async () => {
+      // Given
+      mockNotificationCampaignRepository.findDueScheduled.mockResolvedValue([baseCampaign]);
+      mockNotificationCampaignRepository.transitionStatus
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(true);
+      mockEarlyNotificationService.sendBulk.mockRejectedValue(new Error('SMTP down'));
+
+      // When
+      await service.runDueCampaigns();
+
+      // Then
+      expect(mockNotificationCampaignRepository.transitionStatus).toHaveBeenNthCalledWith(2, {
+        id: 100,
+        fromStatus: NotificationCampaignStatus.RUNNING,
+        toStatus: NotificationCampaignStatus.FAILED,
+        patch: { sentAt: expect.any(Date) as unknown, result: null },
+      });
+    });
+
+    it('finalize 단계의 transitionStatus가 실패하면 audit 로그를 남기지 않는다', async () => {
+      // Given
+      mockNotificationCampaignRepository.findDueScheduled.mockResolvedValue([baseCampaign]);
+      mockNotificationCampaignRepository.transitionStatus
+        .mockResolvedValueOnce(true) // claim 성공
+        .mockResolvedValueOnce(false); // finalize 실패
+      mockEarlyNotificationService.sendBulk.mockResolvedValue({ total: 1, success: 1, failed: 0 });
+
+      // When
+      await service.runDueCampaigns();
+
+      // Then
+      expect(mockAuditLogService.recordStatusChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('listByCohort', () => {
+    it('cohortId/status를 그대로 위임한다', async () => {
+      // Given
+      const records = [{ id: 1 }];
+      mockNotificationCampaignRepository.findByCohort.mockResolvedValue(records);
+
+      // When
+      const result = await service.listByCohort({
+        cohortId: 1,
+        status: NotificationCampaignStatus.SCHEDULED,
+      });
+
+      // Then
+      expect(result).toBe(records);
+      expect(mockNotificationCampaignRepository.findByCohort).toHaveBeenCalledWith({
+        cohortId: 1,
+        status: NotificationCampaignStatus.SCHEDULED,
+      });
+    });
+  });
+});

--- a/src/notification/application/notification-campaign.service.ts
+++ b/src/notification/application/notification-campaign.service.ts
@@ -1,0 +1,194 @@
+import { HttpStatus, Injectable, Logger } from '@nestjs/common';
+import { Transactional } from 'typeorm-transactional';
+
+import { AuditLogService } from '../../audit/application/audit-log.service';
+import { CohortRepository } from '../../cohort/domain/cohort.repository';
+import { AppException } from '../../common/exception/app.exception';
+import {
+  NotificationCampaign,
+  NotificationCampaignSendResult,
+} from '../domain/notification-campaign.entity';
+import { NotificationCampaignRepository } from '../domain/notification-campaign.repository';
+import { NotificationCampaignStatus } from '../domain/notification-campaign.status';
+import { EarlyNotificationService } from './early-notification.service';
+
+const AUDIT_ENTITY_TYPE = 'notification_campaign';
+const SYSTEM_ADMIN_ID = 0;
+
+type CreateCampaignPayload = {
+  cohortId: number;
+  scheduledAt: Date;
+  subject: string;
+  html: string;
+  text: string;
+};
+
+type ListByCohortPayload = {
+  cohortId: number;
+  status?: NotificationCampaignStatus;
+};
+
+@Injectable()
+export class NotificationCampaignService {
+  private readonly logger = new Logger(NotificationCampaignService.name);
+
+  constructor(
+    private readonly notificationCampaignRepository: NotificationCampaignRepository,
+    private readonly cohortRepository: CohortRepository,
+    private readonly earlyNotificationService: EarlyNotificationService,
+    private readonly auditLogService: AuditLogService,
+  ) {}
+
+  @Transactional()
+  async createCampaign({ cohortId, scheduledAt, subject, html, text }: CreateCampaignPayload) {
+    const cohort = await this.cohortRepository.findById({ id: cohortId });
+    if (!cohort) {
+      throw new AppException('COHORT_NOT_FOUND', HttpStatus.NOT_FOUND);
+    }
+    return this.notificationCampaignRepository.register({
+      cohortId,
+      scheduledAt,
+      subject,
+      html,
+      text,
+    });
+  }
+
+  async listByCohort({ cohortId, status }: ListByCohortPayload) {
+    return this.notificationCampaignRepository.findByCohort({ cohortId, status });
+  }
+
+  @Transactional()
+  async pauseCampaign({ id }: { id: number }): Promise<void> {
+    const found = await this.notificationCampaignRepository.findById({ id });
+    if (!found) {
+      throw new AppException('NOTIFICATION_CAMPAIGN_NOT_FOUND', HttpStatus.NOT_FOUND);
+    }
+    if (found.status !== NotificationCampaignStatus.SCHEDULED) {
+      throw new AppException('NOTIFICATION_CAMPAIGN_INVALID_STATE', HttpStatus.CONFLICT);
+    }
+    const transitioned = await this.notificationCampaignRepository.transitionStatus({
+      id,
+      fromStatus: NotificationCampaignStatus.SCHEDULED,
+      toStatus: NotificationCampaignStatus.PAUSED,
+    });
+    if (!transitioned) {
+      throw new AppException('NOTIFICATION_CAMPAIGN_INVALID_STATE', HttpStatus.CONFLICT);
+    }
+    await this.auditLogService.recordStatusChange({
+      entityType: AUDIT_ENTITY_TYPE,
+      entityId: id,
+      fromValue: NotificationCampaignStatus.SCHEDULED,
+      toValue: NotificationCampaignStatus.PAUSED,
+      adminId: SYSTEM_ADMIN_ID,
+    });
+  }
+
+  @Transactional()
+  async resumeCampaign({ id }: { id: number }): Promise<void> {
+    const found = await this.notificationCampaignRepository.findById({ id });
+    if (!found) {
+      throw new AppException('NOTIFICATION_CAMPAIGN_NOT_FOUND', HttpStatus.NOT_FOUND);
+    }
+    if (found.status !== NotificationCampaignStatus.PAUSED) {
+      throw new AppException('NOTIFICATION_CAMPAIGN_INVALID_STATE', HttpStatus.CONFLICT);
+    }
+    const transitioned = await this.notificationCampaignRepository.transitionStatus({
+      id,
+      fromStatus: NotificationCampaignStatus.PAUSED,
+      toStatus: NotificationCampaignStatus.SCHEDULED,
+    });
+    if (!transitioned) {
+      throw new AppException('NOTIFICATION_CAMPAIGN_INVALID_STATE', HttpStatus.CONFLICT);
+    }
+    await this.auditLogService.recordStatusChange({
+      entityType: AUDIT_ENTITY_TYPE,
+      entityId: id,
+      fromValue: NotificationCampaignStatus.PAUSED,
+      toValue: NotificationCampaignStatus.SCHEDULED,
+      adminId: SYSTEM_ADMIN_ID,
+    });
+  }
+
+  async runDueCampaigns(): Promise<void> {
+    const due = await this.notificationCampaignRepository.findDueScheduled({ now: new Date() });
+    for (const campaign of due) {
+      await this.executeCampaign(campaign);
+    }
+  }
+
+  async executeCampaign(campaign: NotificationCampaign): Promise<void> {
+    const claimed = await this.notificationCampaignRepository.transitionStatus({
+      id: campaign.id,
+      fromStatus: NotificationCampaignStatus.SCHEDULED,
+      toStatus: NotificationCampaignStatus.RUNNING,
+    });
+    if (!claimed) {
+      return;
+    }
+
+    let sendResult: NotificationCampaignSendResult;
+    try {
+      sendResult = await this.earlyNotificationService.sendBulk({
+        cohortId: campaign.cohortId,
+        subject: campaign.subject,
+        html: campaign.html,
+        text: campaign.text,
+      });
+    } catch (error: unknown) {
+      this.logger.error(`캠페인 발송 중 예외 발생 id=${campaign.id}`, error);
+      await this.finalizeCampaign({
+        id: campaign.id,
+        toStatus: NotificationCampaignStatus.FAILED,
+        result: null,
+      });
+      return;
+    }
+
+    const finalStatus = this.resolveFinalStatus(sendResult);
+    await this.finalizeCampaign({
+      id: campaign.id,
+      toStatus: finalStatus,
+      result: sendResult,
+    });
+  }
+
+  @Transactional()
+  async finalizeCampaign({
+    id,
+    toStatus,
+    result,
+  }: {
+    id: number;
+    toStatus: NotificationCampaignStatus;
+    result: NotificationCampaignSendResult | null;
+  }): Promise<void> {
+    const transitioned = await this.notificationCampaignRepository.transitionStatus({
+      id,
+      fromStatus: NotificationCampaignStatus.RUNNING,
+      toStatus,
+      patch: { sentAt: new Date(), result },
+    });
+    if (!transitioned) {
+      this.logger.warn(`캠페인 finalize 실패 - 상태 전이 미발생 id=${id}`);
+      return;
+    }
+    await this.auditLogService.recordStatusChange({
+      entityType: AUDIT_ENTITY_TYPE,
+      entityId: id,
+      fromValue: NotificationCampaignStatus.RUNNING,
+      toValue: toStatus,
+      adminId: SYSTEM_ADMIN_ID,
+    });
+  }
+
+  private resolveFinalStatus(result: NotificationCampaignSendResult): NotificationCampaignStatus {
+    if (result.total === 0) {
+      return NotificationCampaignStatus.DONE;
+    }
+    if (result.success > 0) {
+      return NotificationCampaignStatus.DONE;
+    }
+    return NotificationCampaignStatus.FAILED;
+  }
+}

--- a/src/notification/domain/notification-campaign.entity.ts
+++ b/src/notification/domain/notification-campaign.entity.ts
@@ -1,0 +1,73 @@
+import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
+
+import { Cohort } from '../../cohort/domain/cohort.entity';
+import { BaseEntity } from '../../common/core/base.entity';
+import { NotificationCampaignStatus } from './notification-campaign.status';
+
+export type NotificationCampaignSendResult = {
+  total: number;
+  success: number;
+  failed: number;
+};
+
+@Entity('notification_campaigns')
+@Index(['cohortId', 'status'])
+@Index(['status', 'scheduledAt'])
+export class NotificationCampaign extends BaseEntity {
+  @ManyToOne(() => Cohort, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'cohortId' })
+  cohort?: Cohort;
+
+  @Column()
+  cohortId: number;
+
+  @Column()
+  subject: string;
+
+  @Column({ type: 'text' })
+  html: string;
+
+  @Column({ type: 'text' })
+  text: string;
+
+  @Column({ type: 'timestamptz' })
+  scheduledAt: Date;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  sentAt: Date | null;
+
+  @Column({
+    type: 'enum',
+    enum: NotificationCampaignStatus,
+    default: NotificationCampaignStatus.SCHEDULED,
+  })
+  status: NotificationCampaignStatus;
+
+  @Column({ type: 'jsonb', nullable: true })
+  result: NotificationCampaignSendResult | null;
+
+  static create({
+    cohortId,
+    scheduledAt,
+    subject,
+    html,
+    text,
+  }: {
+    cohortId: number;
+    scheduledAt: Date;
+    subject: string;
+    html: string;
+    text: string;
+  }): NotificationCampaign {
+    const campaign = new NotificationCampaign();
+    campaign.cohortId = cohortId;
+    campaign.scheduledAt = scheduledAt;
+    campaign.subject = subject;
+    campaign.html = html;
+    campaign.text = text;
+    campaign.status = NotificationCampaignStatus.SCHEDULED;
+    campaign.sentAt = null;
+    campaign.result = null;
+    return campaign;
+  }
+}

--- a/src/notification/domain/notification-campaign.repository.ts
+++ b/src/notification/domain/notification-campaign.repository.ts
@@ -1,0 +1,64 @@
+import { Injectable } from '@nestjs/common';
+
+import { NotificationCampaignWriteRepository } from '../infrastructure/notification-campaign.write.repository';
+import {
+  NotificationCampaign,
+  NotificationCampaignSendResult,
+} from './notification-campaign.entity';
+import { NotificationCampaignStatus } from './notification-campaign.status';
+
+@Injectable()
+export class NotificationCampaignRepository {
+  constructor(private readonly writeRepository: NotificationCampaignWriteRepository) {}
+
+  async register({
+    cohortId,
+    scheduledAt,
+    subject,
+    html,
+    text,
+  }: {
+    cohortId: number;
+    scheduledAt: Date;
+    subject: string;
+    html: string;
+    text: string;
+  }) {
+    const campaign = NotificationCampaign.create({ cohortId, scheduledAt, subject, html, text });
+    return this.writeRepository.save({ campaign });
+  }
+
+  async findById({ id }: { id: number }) {
+    return this.writeRepository.findOne({ where: { id } });
+  }
+
+  async findByCohort({
+    cohortId,
+    status,
+  }: {
+    cohortId: number;
+    status?: NotificationCampaignStatus;
+  }) {
+    return this.writeRepository.findMany({ where: { cohortId, status } });
+  }
+
+  async findDueScheduled({ now }: { now: Date }) {
+    return this.writeRepository.findMany({
+      where: { status: NotificationCampaignStatus.SCHEDULED, scheduledAtLte: now },
+    });
+  }
+
+  async transitionStatus({
+    id,
+    fromStatus,
+    toStatus,
+    patch,
+  }: {
+    id: number;
+    fromStatus: NotificationCampaignStatus;
+    toStatus: NotificationCampaignStatus;
+    patch?: { sentAt?: Date | null; result?: NotificationCampaignSendResult | null };
+  }): Promise<boolean> {
+    return this.writeRepository.transitionStatus({ id, fromStatus, toStatus, patch });
+  }
+}

--- a/src/notification/domain/notification-campaign.status.ts
+++ b/src/notification/domain/notification-campaign.status.ts
@@ -1,0 +1,7 @@
+export enum NotificationCampaignStatus {
+  SCHEDULED = 'SCHEDULED',
+  RUNNING = 'RUNNING',
+  DONE = 'DONE',
+  PAUSED = 'PAUSED',
+  FAILED = 'FAILED',
+}

--- a/src/notification/infrastructure/notification-campaign.scheduler.ts
+++ b/src/notification/infrastructure/notification-campaign.scheduler.ts
@@ -1,0 +1,17 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+
+import { NotificationCampaignService } from '../application/notification-campaign.service';
+
+@Injectable()
+export class NotificationCampaignScheduler {
+  private readonly logger = new Logger(NotificationCampaignScheduler.name);
+
+  constructor(private readonly notificationCampaignService: NotificationCampaignService) {}
+
+  @Cron(CronExpression.EVERY_5_MINUTES)
+  async runDueCampaigns(): Promise<void> {
+    this.logger.log('사전 알림 캠페인 스케줄러 실행');
+    await this.notificationCampaignService.runDueCampaigns();
+  }
+}

--- a/src/notification/infrastructure/notification-campaign.write.repository.ts
+++ b/src/notification/infrastructure/notification-campaign.write.repository.ts
@@ -1,0 +1,73 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource, LessThanOrEqual, Repository } from 'typeorm';
+
+import {
+  NotificationCampaign,
+  NotificationCampaignSendResult,
+} from '../domain/notification-campaign.entity';
+import { NotificationCampaignStatus } from '../domain/notification-campaign.status';
+import type { NotificationCampaignFilter } from './notification-campaign.write.repository.type';
+
+@Injectable()
+export class NotificationCampaignWriteRepository {
+  private readonly repository: Repository<NotificationCampaign>;
+
+  constructor(dataSource: DataSource) {
+    this.repository = dataSource.getRepository(NotificationCampaign);
+  }
+
+  async save({ campaign }: { campaign: NotificationCampaign }) {
+    return this.repository.save(campaign);
+  }
+
+  async findOne({ where }: { where: NotificationCampaignFilter }) {
+    return this.repository.findOne({ where: this.buildWhere(where) });
+  }
+
+  async findMany({ where }: { where: NotificationCampaignFilter }) {
+    return this.repository.find({
+      where: this.buildWhere(where),
+      order: { scheduledAt: 'ASC' },
+    });
+  }
+
+  async transitionStatus({
+    id,
+    fromStatus,
+    toStatus,
+    patch,
+  }: {
+    id: number;
+    fromStatus: NotificationCampaignStatus;
+    toStatus: NotificationCampaignStatus;
+    patch?: { sentAt?: Date | null; result?: NotificationCampaignSendResult | null };
+  }): Promise<boolean> {
+    const updateResult = await this.repository.update(
+      { id, status: fromStatus },
+      { status: toStatus, ...patch },
+    );
+    return (updateResult.affected ?? 0) > 0;
+  }
+
+  private buildWhere(filter: NotificationCampaignFilter) {
+    const where: Record<string, unknown> = {};
+
+    if (filter.id !== undefined) {
+      where.id = filter.id;
+    }
+
+    if (filter.cohortId !== undefined) {
+      where.cohortId = filter.cohortId;
+    }
+
+    if (filter.status !== undefined) {
+      where.status = filter.status;
+    }
+
+    if (filter.scheduledAtLte !== undefined) {
+      where.scheduledAt = LessThanOrEqual(filter.scheduledAtLte);
+    }
+
+    return where;
+  }
+}

--- a/src/notification/infrastructure/notification-campaign.write.repository.type.ts
+++ b/src/notification/infrastructure/notification-campaign.write.repository.type.ts
@@ -1,0 +1,8 @@
+import type { NotificationCampaignStatus } from '../domain/notification-campaign.status';
+
+export type NotificationCampaignFilter = {
+  id?: number;
+  cohortId?: number;
+  status?: NotificationCampaignStatus;
+  scheduledAtLte?: Date;
+};

--- a/src/notification/interface/admin.notification-campaign.controller.ts
+++ b/src/notification/interface/admin.notification-campaign.controller.ts
@@ -1,0 +1,96 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { ApiTags } from '@nestjs/swagger';
+
+import { Roles } from '../../common/decorator/roles.decorator';
+import { RolesGuard } from '../../common/guard/roles.guard';
+import { ApiResponse } from '../../common/response/api-response';
+import { ApiDoc } from '../../common/swagger/api-doc.decorator';
+import { UserRole } from '../../user/domain/user.role';
+import { NotificationCampaignService } from '../application/notification-campaign.service';
+import {
+  CreateNotificationCampaignRequestDto,
+  FindAdminNotificationCampaignsQueryDto,
+} from './dto/admin-notification-campaign.request.dto';
+import { NotificationCampaignResponseDto } from './dto/admin-notification-campaign.response.dto';
+
+@ApiTags('Admin - Notification Campaign')
+@Controller({ path: 'admin/notification-campaigns', version: '1' })
+@UseGuards(AuthGuard('jwt'), RolesGuard)
+@Roles(UserRole.계정관리, UserRole.운영자)
+export class AdminNotificationCampaignController {
+  constructor(private readonly notificationCampaignService: NotificationCampaignService) {}
+
+  @ApiDoc({
+    summary: '사전 알림 캠페인 등록',
+    description:
+      '특정 기수에 대해 발송 예정 시각/본문을 가진 캠페인을 등록합니다. SCHEDULED 상태로 생성됩니다.',
+    operationId: 'notificationCampaign_createAdmin',
+    auth: true,
+  })
+  @Post()
+  async createCampaign(@Body() body: CreateNotificationCampaignRequestDto) {
+    const created = await this.notificationCampaignService.createCampaign({
+      cohortId: body.cohortId,
+      scheduledAt: new Date(body.scheduledAt),
+      subject: body.subject,
+      html: body.html,
+      text: body.text,
+    });
+    return ApiResponse.ok(
+      NotificationCampaignResponseDto.from(created),
+      '캠페인이 등록되었습니다.',
+    );
+  }
+
+  @ApiDoc({
+    summary: '사전 알림 캠페인 목록 조회',
+    description: '기수별 캠페인 목록을 조회합니다. 상태 필터 적용 가능.',
+    operationId: 'notificationCampaign_getAdminList',
+    auth: true,
+  })
+  @Get()
+  async listCampaigns(@Query() query: FindAdminNotificationCampaignsQueryDto) {
+    const records = await this.notificationCampaignService.listByCohort({
+      cohortId: query.cohortId,
+      status: query.status,
+    });
+    return ApiResponse.ok(records.map((record) => NotificationCampaignResponseDto.from(record)));
+  }
+
+  @ApiDoc({
+    summary: '캠페인 일시정지',
+    description: 'SCHEDULED 상태인 캠페인을 PAUSED로 전환합니다. 스케줄러가 발송하지 않습니다.',
+    operationId: 'notificationCampaign_pauseAdmin',
+    auth: true,
+  })
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @Patch(':id/pause')
+  async pauseCampaign(@Param('id', ParseIntPipe) id: number): Promise<void> {
+    await this.notificationCampaignService.pauseCampaign({ id });
+  }
+
+  @ApiDoc({
+    summary: '캠페인 재개',
+    description: 'PAUSED 상태인 캠페인을 SCHEDULED로 복귀시킵니다.',
+    operationId: 'notificationCampaign_resumeAdmin',
+    auth: true,
+  })
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @Patch(':id/resume')
+  async resumeCampaign(@Param('id', ParseIntPipe) id: number): Promise<void> {
+    await this.notificationCampaignService.resumeCampaign({ id });
+  }
+}

--- a/src/notification/interface/dto/admin-notification-campaign.request.dto.ts
+++ b/src/notification/interface/dto/admin-notification-campaign.request.dto.ts
@@ -1,0 +1,59 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsEnum,
+  IsInt,
+  IsISO8601,
+  IsOptional,
+  IsPositive,
+  IsString,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
+
+import { NotificationCampaignStatus } from '../../domain/notification-campaign.status';
+
+export class CreateNotificationCampaignRequestDto {
+  @ApiProperty({ description: '대상 기수 ID', example: 1 })
+  @IsInt()
+  @IsPositive()
+  cohortId: number;
+
+  @ApiProperty({
+    description: '발송 예정 시각 (ISO 8601)',
+    example: '2026-06-01T10:00:00.000Z',
+  })
+  @IsISO8601()
+  scheduledAt: string;
+
+  @ApiProperty({ description: '메일 제목', example: '[DDD] 16기 모집 시작' })
+  @IsString()
+  @MinLength(1)
+  @MaxLength(200)
+  subject: string;
+
+  @ApiProperty({ description: 'HTML 본문' })
+  @IsString()
+  @MinLength(1)
+  @MaxLength(50000)
+  html: string;
+
+  @ApiProperty({ description: '플레인텍스트 본문' })
+  @IsString()
+  @MinLength(1)
+  @MaxLength(20000)
+  text: string;
+}
+
+export class FindAdminNotificationCampaignsQueryDto {
+  @ApiProperty({ description: '대상 기수 ID', example: 1 })
+  @Type(() => Number)
+  @IsInt()
+  @IsPositive()
+  cohortId: number;
+
+  @ApiPropertyOptional({ description: '상태 필터', enum: NotificationCampaignStatus })
+  @IsOptional()
+  @IsEnum(NotificationCampaignStatus)
+  status?: NotificationCampaignStatus;
+}

--- a/src/notification/interface/dto/admin-notification-campaign.response.dto.ts
+++ b/src/notification/interface/dto/admin-notification-campaign.response.dto.ts
@@ -1,0 +1,57 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+import {
+  NotificationCampaign,
+  NotificationCampaignSendResult,
+} from '../../domain/notification-campaign.entity';
+import { NotificationCampaignStatus } from '../../domain/notification-campaign.status';
+
+export class NotificationCampaignResponseDto {
+  @ApiProperty({ description: 'ID', example: 1 })
+  id: number;
+
+  @ApiProperty({ description: '기수 ID', example: 1 })
+  cohortId: number;
+
+  @ApiProperty({ description: '메일 제목' })
+  subject: string;
+
+  @ApiProperty({ description: 'HTML 본문' })
+  html: string;
+
+  @ApiProperty({ description: '플레인텍스트 본문' })
+  text: string;
+
+  @ApiProperty({ description: '발송 예정 시각' })
+  scheduledAt: Date;
+
+  @ApiPropertyOptional({ description: '실제 발송 완료 시각', nullable: true })
+  sentAt: Date | null;
+
+  @ApiProperty({ description: '캠페인 상태', enum: NotificationCampaignStatus })
+  status: NotificationCampaignStatus;
+
+  @ApiPropertyOptional({
+    description: '발송 결과 통계 (total/success/failed)',
+    nullable: true,
+  })
+  result: NotificationCampaignSendResult | null;
+
+  @ApiProperty({ description: '생성 일시' })
+  createdAt: Date;
+
+  static from(record: NotificationCampaign): NotificationCampaignResponseDto {
+    const dto = new NotificationCampaignResponseDto();
+    dto.id = record.id;
+    dto.cohortId = record.cohortId;
+    dto.subject = record.subject;
+    dto.html = record.html;
+    dto.text = record.text;
+    dto.scheduledAt = record.scheduledAt;
+    dto.sentAt = record.sentAt;
+    dto.status = record.status;
+    dto.result = record.result;
+    dto.createdAt = record.createdAt;
+    return dto;
+  }
+}

--- a/src/notification/notification.module.ts
+++ b/src/notification/notification.module.ts
@@ -1,34 +1,48 @@
 import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { AuditModule } from '../audit/audit.module';
 import { CohortModule } from '../cohort/cohort.module';
 import { RolesGuard } from '../common/guard/roles.guard';
 import { EarlyNotificationService } from './application/early-notification.service';
 import { GeneralEarlyNotificationService } from './application/general-early-notification.service';
 import { NotificationService } from './application/notification.service';
+import { NotificationCampaignService } from './application/notification-campaign.service';
 import { EarlyNotification } from './domain/early-notification.entity';
 import { EarlyNotificationRepository } from './domain/early-notification.repository';
 import { EmailLog } from './domain/email-log.entity';
 import { GeneralEarlyNotification } from './domain/general-early-notification.entity';
 import { GeneralEarlyNotificationRepository } from './domain/general-early-notification.repository';
 import { NotificationRepository } from './domain/notification.repository';
+import { NotificationCampaign } from './domain/notification-campaign.entity';
+import { NotificationCampaignRepository } from './domain/notification-campaign.repository';
 import { EarlyNotificationWriteRepository } from './infrastructure/early-notification.write.repository';
 import { EmailLogWriteRepository } from './infrastructure/email-log.write.repository';
 import { GeneralEarlyNotificationWriteRepository } from './infrastructure/general-early-notification.write.repository';
 import { GmailEmailClient } from './infrastructure/gmail-email.client';
+import { NotificationCampaignScheduler } from './infrastructure/notification-campaign.scheduler';
+import { NotificationCampaignWriteRepository } from './infrastructure/notification-campaign.write.repository';
 import { AdminEarlyNotificationController } from './interface/admin.early-notification.controller';
+import { AdminNotificationCampaignController } from './interface/admin.notification-campaign.controller';
 import { PublicEarlyNotificationController } from './interface/public.early-notification.controller';
 import { PublicGeneralEarlyNotificationController } from './interface/public.general-early-notification.controller';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([EmailLog, EarlyNotification, GeneralEarlyNotification]),
+    TypeOrmModule.forFeature([
+      EmailLog,
+      EarlyNotification,
+      GeneralEarlyNotification,
+      NotificationCampaign,
+    ]),
     forwardRef(() => CohortModule),
+    AuditModule,
   ],
   controllers: [
     PublicEarlyNotificationController,
     PublicGeneralEarlyNotificationController,
     AdminEarlyNotificationController,
+    AdminNotificationCampaignController,
   ],
   providers: [
     NotificationService,
@@ -41,8 +55,17 @@ import { PublicGeneralEarlyNotificationController } from './interface/public.gen
     GeneralEarlyNotificationService,
     GeneralEarlyNotificationRepository,
     GeneralEarlyNotificationWriteRepository,
+    NotificationCampaignService,
+    NotificationCampaignRepository,
+    NotificationCampaignWriteRepository,
+    NotificationCampaignScheduler,
     RolesGuard,
   ],
-  exports: [NotificationService, EarlyNotificationService, GeneralEarlyNotificationService],
+  exports: [
+    NotificationService,
+    EarlyNotificationService,
+    GeneralEarlyNotificationService,
+    NotificationCampaignService,
+  ],
 })
 export class NotificationModule {}


### PR DESCRIPTION
## 개요
기존 사전 알림 발송은 어드민이 `POST /v1/admin/early-notifications/send`에 매번 본문(subject/html/text)을 직접 작성해 동기 호출하는 100% 휴먼 트리거 구조였습니다. 캠페인 단위 예약 발송 흐름을 도입해 운영자 누락 위험을 줄이고, 상태 머신과 감사 로그로 발송 결과를 추적 가능하게 만듭니다.

## 변경 이유
- 운영자가 발송 시점을 깜빡하면 사전 알림이 나가지 않음 (P1)
- 발송 결과(성공/실패 통계)가 텍스트 응답으로만 일회성 노출 — 추후 추적 불가
- 한 cohort에 여러 발송(모집 시작/마감 임박/합격 발표 등)이 필요할 때 매번 처음부터 입력해야 함

## 주요 변경 사항
- 신규 도메인 `notification_campaigns`
  - 엔티티: `cohortId`, `subject`, `html(text)`, `text(text)`, `scheduledAt`, `sentAt`, `status`, `result(jsonb)`
  - 상태 enum: `SCHEDULED → RUNNING → DONE | FAILED`, `PAUSED` 토글
  - 인덱스: `(cohortId, status)`, `(status, scheduledAt)`
  - Domain/Write Repository 분리 (CODE_RULES §4)
- `NotificationCampaignService`
  - `createCampaign` — cohort 존재 검증 후 SCHEDULED 등록 (`@Transactional`)
  - `listByCohort` — cohortId/status 필터 위임
  - `pauseCampaign` / `resumeCampaign` — `SCHEDULED ↔ PAUSED` (atomic CAS, audit)
  - `runDueCampaigns` — 스케줄러 진입점, due 캠페인 순회
  - `executeCampaign` — `SCHEDULED → RUNNING` 원자 전이(claim) → `EarlyNotificationService.sendBulk` 재사용 → `finalizeCampaign`
  - `finalizeCampaign` — `RUNNING → DONE/FAILED` + result jsonb + audit
- 어드민 API (`@Roles(UserRole.계정관리, UserRole.운영자)`)
  - `POST   /v1/admin/notification-campaigns`
  - `GET    /v1/admin/notification-campaigns?cohortId=...&status=...`
  - `PATCH  /v1/admin/notification-campaigns/:id/pause`   (204)
  - `PATCH  /v1/admin/notification-campaigns/:id/resume`  (204)
- 스케줄러 `NotificationCampaignScheduler` — `@Cron(EVERY_5_MINUTES)`로 `runDueCampaigns` 호출
- 신규 에러 코드 3종: `NOTIFICATION_CAMPAIGN_NOT_FOUND` (404), `NOTIFICATION_CAMPAIGN_INVALID_STATE` (409), `NOTIFICATION_CAMPAIGN_INVALID_SCHEDULE` (예비)
- AuditLog: status 전이마다 `recordStatusChange` 호출 (`entityType='notification_campaign'`)
- 단위 테스트 16건 추가

## 아키텍처 영향
- 도메인 분리: 기존 `early-notification`(개별 신청 row 관리) / `general-early-notification`(cohort 미지정 대기열)에 더해 `notification-campaign`(예약 발송 캠페인) 서브도메인 신설. 각각 독립된 책임.
- 레이어: Interface → Application → Domain ← Infrastructure 의존 방향 유지 (CODE_RULES §2)
- 의존 방향 변화: `NotificationModule`이 신규로 `AuditModule` import. `CohortModule ↔ NotificationModule` 양방향 forwardRef는 기존 그대로
- 트랜잭션 경계
  - `createCampaign`/`pauseCampaign`/`resumeCampaign`/`finalizeCampaign`: 각각 `@Transactional`
  - `executeCampaign`(claim → sendBulk → finalize)은 의도적으로 트랜잭션 외부 — claim 후 sendBulk(이메일 IO)가 길어질 수 있어 락 보유 시간 최소화. claim 자체가 atomic CAS이므로 race 안전.

## 테스트
- [x] 단위 테스트 (`notification-campaign.service.spec.ts` 16건)
- [x] 통합/e2e 테스트 — 별도 추가 없음 (기존 통합 테스트 영향 없음)
- [x] 수동 검증 — `yarn build` / `yarn jest` (32 suites, 253 passed) / `yarn lint:check` (0 errors, 0 warnings) 모두 그린
- 확인 내용
  - createCampaign: cohort 없을 때 404, 있을 때 정상 등록
  - pause/resume: 잘못된 상태에서 409, 정상 전이 시 audit 로그 생성, race 시 409
  - executeCampaign: claim 실패 noop / sendBulk 성공 → DONE / total=0 → DONE / 전부 실패 → FAILED / sendBulk throw → FAILED + result=null / finalize race 실패 시 audit 미호출

## 리뷰 포인트
1. **상태 전이 atomic CAS**: `repository.update({ id, status: fromStatus }, { status: toStatus })`로 affected rows 기반 race 차단. FOR UPDATE 락 없음. 단일 인스턴스 가정 시 충분 — 멀티 인스턴스에서도 안전(원자 UPDATE)이지만 stale RUNNING 복구는 후속 과제.
2. **finalize의 트랜잭션 경계**: claim/finalize가 분리된 짧은 트랜잭션. sendBulk(이메일 IO)가 트랜잭션 외부에서 실행되므로 DB 락 보유 시간이 최소화됨. 의도된 설계.
3. **finalStatus 정책**: `total=0 → DONE` (대상 없음 = 발송 완료로 간주), `success>0 → DONE` (부분 실패도 DONE), `success=0, total>0 → FAILED`. 부분 실패도 DONE으로 처리하는 정책이 OK인지 — `result.failed`는 jsonb로 보존되어 admin이 확인 가능.
4. **본문 길이 제한**: subject 200 / html 50000 / text 20000. HTML 50KB는 과한지 / 부족한지.
5. **API 경로 `/v1/admin/notification-campaigns`**: 리소스 중심 kebab-case (CODE_RULES §7).
6. **AuditLog adminId**: 현재 admin identity 추출 인프라가 없어 `SYSTEM_ADMIN_ID(0)` 사용 — 기존 cohort.service 패턴과 일관. 향후 admin 식별 인프라 도입 시 일괄 보강.

## 리스크 / 후속 작업
- **stale RUNNING 복구**: claim 후 finalize 사이에 프로세스가 죽으면 캠페인이 RUNNING으로 영원히 남음. 멀티 인스턴스 환경 도입 시 `findStaleRunning` + 임계 경과 후 SCHEDULED로 되돌리는 reaper 추가 필요.
- **자동 캠페인 생성** (2차): cohort 생성/상태 전이 시점에 기본 캠페인 자동 등록.
- **NotificationTemplate 라이브러리** (3차): 본문 재사용 가능한 템플릿 도입.
- **권한별 admin 식별**: 현재 audit adminId=0. JWT 컨텍스트에서 추출하는 데코레이터 도입은 별도 PR.
- 데이터 마이그레이션 불필요 (`synchronize: true` 환경에서 엔티티 자동 생성)

## 관련 이슈
- 별도 트랙으로 진행한 PR #47(general-early-notification-waitlist)와 호환. 자동 승격된 사전알림 대상이 캠페인 발송 시 자연스럽게 수신자에 포함됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)