### PR TITLE
feat(notification): 캠페인 수정/삭제 + stale RUNNING 복구

### DIFF
--- a/src/notification/application/notification-campaign.service.spec.ts
+++ b/src/notification/application/notification-campaign.service.spec.ts
@@ -17,10 +17,13 @@ import { NotificationCampaignService } from './notification-campaign.service';
 
 const mockNotificationCampaignRepository = {
   register: jest.fn(),
+  save: jest.fn(),
   findById: jest.fn(),
   findByCohort: jest.fn(),
   findDueScheduled: jest.fn(),
+  findStaleRunning: jest.fn(),
   transitionStatus: jest.fn(),
+  deleteById: jest.fn(),
 };
 
 const mockCohortRepository = {
@@ -346,6 +349,175 @@ describe('NotificationCampaignService', () => {
 
       // When
       await service.runDueCampaigns();
+
+      // Then
+      expect(mockAuditLogService.recordStatusChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateCampaign', () => {
+    const editPayload = { id: 5, subject: '수정된 제목', html: '<p>수정</p>' };
+
+    it('캠페인이 없으면 NOTIFICATION_CAMPAIGN_NOT_FOUND를 던진다', async () => {
+      // Given
+      mockNotificationCampaignRepository.findById.mockResolvedValue(null);
+
+      // When & Then
+      await expect(service.updateCampaign(editPayload)).rejects.toThrow(
+        new AppException('NOTIFICATION_CAMPAIGN_NOT_FOUND', HttpStatus.NOT_FOUND),
+      );
+      expect(mockNotificationCampaignRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('SCHEDULED/PAUSED가 아니면 INVALID_STATE를 던진다', async () => {
+      // Given
+      mockNotificationCampaignRepository.findById.mockResolvedValue({
+        id: 5,
+        status: NotificationCampaignStatus.RUNNING,
+        applyEdits: jest.fn(),
+      });
+
+      // When & Then
+      await expect(service.updateCampaign(editPayload)).rejects.toThrow(
+        new AppException('NOTIFICATION_CAMPAIGN_INVALID_STATE', HttpStatus.CONFLICT),
+      );
+      expect(mockNotificationCampaignRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('SCHEDULED 상태면 applyEdits 후 저장하고 반환한다', async () => {
+      // Given
+      const applyEdits = jest.fn();
+      const found = {
+        id: 5,
+        status: NotificationCampaignStatus.SCHEDULED,
+        applyEdits,
+      };
+      const saved = { ...found, subject: '수정된 제목' };
+      mockNotificationCampaignRepository.findById.mockResolvedValue(found);
+      mockNotificationCampaignRepository.save.mockResolvedValue(saved);
+
+      // When
+      const result = await service.updateCampaign(editPayload);
+
+      // Then
+      expect(applyEdits).toHaveBeenCalledWith({
+        scheduledAt: undefined,
+        subject: '수정된 제목',
+        html: '<p>수정</p>',
+        text: undefined,
+      });
+      expect(mockNotificationCampaignRepository.save).toHaveBeenCalledWith({ campaign: found });
+      expect(result).toBe(saved);
+    });
+
+    it('PAUSED 상태에서도 수정 가능하다', async () => {
+      // Given
+      const applyEdits = jest.fn();
+      const found = {
+        id: 5,
+        status: NotificationCampaignStatus.PAUSED,
+        applyEdits,
+      };
+      mockNotificationCampaignRepository.findById.mockResolvedValue(found);
+      mockNotificationCampaignRepository.save.mockResolvedValue(found);
+
+      // When
+      await service.updateCampaign(editPayload);
+
+      // Then
+      expect(applyEdits).toHaveBeenCalled();
+      expect(mockNotificationCampaignRepository.save).toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteCampaign', () => {
+    it('캠페인이 없으면 NOTIFICATION_CAMPAIGN_NOT_FOUND를 던진다', async () => {
+      // Given
+      mockNotificationCampaignRepository.findById.mockResolvedValue(null);
+
+      // When & Then
+      await expect(service.deleteCampaign({ id: 5 })).rejects.toThrow(
+        new AppException('NOTIFICATION_CAMPAIGN_NOT_FOUND', HttpStatus.NOT_FOUND),
+      );
+      expect(mockNotificationCampaignRepository.deleteById).not.toHaveBeenCalled();
+    });
+
+    it('RUNNING 상태면 INVALID_STATE를 던진다', async () => {
+      // Given
+      mockNotificationCampaignRepository.findById.mockResolvedValue({
+        id: 5,
+        status: NotificationCampaignStatus.RUNNING,
+      });
+
+      // When & Then
+      await expect(service.deleteCampaign({ id: 5 })).rejects.toThrow(
+        new AppException('NOTIFICATION_CAMPAIGN_INVALID_STATE', HttpStatus.CONFLICT),
+      );
+      expect(mockNotificationCampaignRepository.deleteById).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      NotificationCampaignStatus.SCHEDULED,
+      NotificationCampaignStatus.PAUSED,
+      NotificationCampaignStatus.DONE,
+      NotificationCampaignStatus.FAILED,
+    ])('%s 상태에서는 soft delete 한다', async (status) => {
+      // Given
+      mockNotificationCampaignRepository.findById.mockResolvedValue({ id: 5, status });
+      mockNotificationCampaignRepository.deleteById.mockResolvedValue(undefined);
+
+      // When
+      await service.deleteCampaign({ id: 5 });
+
+      // Then
+      expect(mockNotificationCampaignRepository.deleteById).toHaveBeenCalledWith({ id: 5 });
+    });
+  });
+
+  describe('reapStaleRunning', () => {
+    it('stale 캠페인이 없으면 추가 호출이 없다', async () => {
+      // Given
+      mockNotificationCampaignRepository.findStaleRunning.mockResolvedValue([]);
+
+      // When
+      await service.reapStaleRunning();
+
+      // Then
+      expect(mockNotificationCampaignRepository.transitionStatus).not.toHaveBeenCalled();
+      expect(mockAuditLogService.recordStatusChange).not.toHaveBeenCalled();
+    });
+
+    it('stale 캠페인을 RUNNING→FAILED로 전이하고 audit 로그를 남긴다', async () => {
+      // Given
+      const stale = { id: 200 };
+      mockNotificationCampaignRepository.findStaleRunning.mockResolvedValue([stale]);
+      mockNotificationCampaignRepository.transitionStatus.mockResolvedValue(true);
+
+      // When
+      await service.reapStaleRunning();
+
+      // Then
+      expect(mockNotificationCampaignRepository.transitionStatus).toHaveBeenCalledWith({
+        id: 200,
+        fromStatus: NotificationCampaignStatus.RUNNING,
+        toStatus: NotificationCampaignStatus.FAILED,
+      });
+      expect(mockAuditLogService.recordStatusChange).toHaveBeenCalledWith({
+        entityType: 'notification_campaign',
+        entityId: 200,
+        fromValue: NotificationCampaignStatus.RUNNING,
+        toValue: NotificationCampaignStatus.FAILED,
+        adminId: 0,
+      });
+    });
+
+    it('전이가 race로 실패하면 audit 로그를 남기지 않는다', async () => {
+      // Given
+      mockNotificationCampaignRepository.findStaleRunning.mockResolvedValue([{ id: 201 }]);
+      mockNotificationCampaignRepository.transitionStatus.mockResolvedValue(false);
+
+      // When
+      await service.reapStaleRunning();
 
       // Then
       expect(mockAuditLogService.recordStatusChange).not.toHaveBeenCalled();

--- a/src/notification/application/notification-campaign.service.ts
+++ b/src/notification/application/notification-campaign.service.ts
@@ -14,6 +14,7 @@ import { EarlyNotificationService } from './early-notification.service';
 
 const AUDIT_ENTITY_TYPE = 'notification_campaign';
 const SYSTEM_ADMIN_ID = 0;
+const STALE_RUNNING_THRESHOLD_MS = 30 * 60 * 1000;
 
 type CreateCampaignPayload = {
   cohortId: number;
@@ -26,6 +27,14 @@ type CreateCampaignPayload = {
 type ListByCohortPayload = {
   cohortId: number;
   status?: NotificationCampaignStatus;
+};
+
+type UpdateCampaignPayload = {
+  id: number;
+  scheduledAt?: Date;
+  subject?: string;
+  html?: string;
+  text?: string;
 };
 
 @Injectable()
@@ -56,6 +65,34 @@ export class NotificationCampaignService {
 
   async listByCohort({ cohortId, status }: ListByCohortPayload) {
     return this.notificationCampaignRepository.findByCohort({ cohortId, status });
+  }
+
+  @Transactional()
+  async updateCampaign({ id, scheduledAt, subject, html, text }: UpdateCampaignPayload) {
+    const found = await this.notificationCampaignRepository.findById({ id });
+    if (!found) {
+      throw new AppException('NOTIFICATION_CAMPAIGN_NOT_FOUND', HttpStatus.NOT_FOUND);
+    }
+    if (
+      found.status !== NotificationCampaignStatus.SCHEDULED &&
+      found.status !== NotificationCampaignStatus.PAUSED
+    ) {
+      throw new AppException('NOTIFICATION_CAMPAIGN_INVALID_STATE', HttpStatus.CONFLICT);
+    }
+    found.applyEdits({ scheduledAt, subject, html, text });
+    return this.notificationCampaignRepository.save({ campaign: found });
+  }
+
+  @Transactional()
+  async deleteCampaign({ id }: { id: number }): Promise<void> {
+    const found = await this.notificationCampaignRepository.findById({ id });
+    if (!found) {
+      throw new AppException('NOTIFICATION_CAMPAIGN_NOT_FOUND', HttpStatus.NOT_FOUND);
+    }
+    if (found.status === NotificationCampaignStatus.RUNNING) {
+      throw new AppException('NOTIFICATION_CAMPAIGN_INVALID_STATE', HttpStatus.CONFLICT);
+    }
+    await this.notificationCampaignRepository.deleteById({ id });
   }
 
   @Transactional()
@@ -115,6 +152,36 @@ export class NotificationCampaignService {
     for (const campaign of due) {
       await this.executeCampaign(campaign);
     }
+  }
+
+  async reapStaleRunning(): Promise<void> {
+    const threshold = new Date(Date.now() - STALE_RUNNING_THRESHOLD_MS);
+    const stale = await this.notificationCampaignRepository.findStaleRunning({
+      updatedAtBefore: threshold,
+    });
+    for (const campaign of stale) {
+      await this.recoverStaleCampaign(campaign);
+    }
+  }
+
+  @Transactional()
+  async recoverStaleCampaign(campaign: NotificationCampaign): Promise<void> {
+    const recovered = await this.notificationCampaignRepository.transitionStatus({
+      id: campaign.id,
+      fromStatus: NotificationCampaignStatus.RUNNING,
+      toStatus: NotificationCampaignStatus.FAILED,
+    });
+    if (!recovered) {
+      return;
+    }
+    this.logger.warn(`stale RUNNING 캠페인 복구 id=${campaign.id}`);
+    await this.auditLogService.recordStatusChange({
+      entityType: AUDIT_ENTITY_TYPE,
+      entityId: campaign.id,
+      fromValue: NotificationCampaignStatus.RUNNING,
+      toValue: NotificationCampaignStatus.FAILED,
+      adminId: SYSTEM_ADMIN_ID,
+    });
   }
 
   async executeCampaign(campaign: NotificationCampaign): Promise<void> {

--- a/src/notification/domain/notification-campaign.entity.ts
+++ b/src/notification/domain/notification-campaign.entity.ts
@@ -70,4 +70,29 @@ export class NotificationCampaign extends BaseEntity {
     campaign.result = null;
     return campaign;
   }
+
+  applyEdits({
+    scheduledAt,
+    subject,
+    html,
+    text,
+  }: {
+    scheduledAt?: Date;
+    subject?: string;
+    html?: string;
+    text?: string;
+  }): void {
+    if (scheduledAt !== undefined) {
+      this.scheduledAt = scheduledAt;
+    }
+    if (subject !== undefined) {
+      this.subject = subject;
+    }
+    if (html !== undefined) {
+      this.html = html;
+    }
+    if (text !== undefined) {
+      this.text = text;
+    }
+  }
 }

--- a/src/notification/domain/notification-campaign.repository.ts
+++ b/src/notification/domain/notification-campaign.repository.ts
@@ -28,6 +28,10 @@ export class NotificationCampaignRepository {
     return this.writeRepository.save({ campaign });
   }
 
+  async save({ campaign }: { campaign: NotificationCampaign }) {
+    return this.writeRepository.save({ campaign });
+  }
+
   async findById({ id }: { id: number }) {
     return this.writeRepository.findOne({ where: { id } });
   }
@@ -46,6 +50,16 @@ export class NotificationCampaignRepository {
     return this.writeRepository.findMany({
       where: { status: NotificationCampaignStatus.SCHEDULED, scheduledAtLte: now },
     });
+  }
+
+  async findStaleRunning({ updatedAtBefore }: { updatedAtBefore: Date }) {
+    return this.writeRepository.findMany({
+      where: { status: NotificationCampaignStatus.RUNNING, updatedAtLt: updatedAtBefore },
+    });
+  }
+
+  async deleteById({ id }: { id: number }): Promise<void> {
+    return this.writeRepository.softDeleteById({ id });
   }
 
   async transitionStatus({

--- a/src/notification/infrastructure/notification-campaign.scheduler.ts
+++ b/src/notification/infrastructure/notification-campaign.scheduler.ts
@@ -12,6 +12,7 @@ export class NotificationCampaignScheduler {
   @Cron(CronExpression.EVERY_5_MINUTES)
   async runDueCampaigns(): Promise<void> {
     this.logger.log('사전 알림 캠페인 스케줄러 실행');
+    await this.notificationCampaignService.reapStaleRunning();
     await this.notificationCampaignService.runDueCampaigns();
   }
 }

--- a/src/notification/infrastructure/notification-campaign.write.repository.ts
+++ b/src/notification/infrastructure/notification-campaign.write.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { DataSource, LessThanOrEqual, Repository } from 'typeorm';
+import { DataSource, LessThan, LessThanOrEqual, Repository } from 'typeorm';
 
 import {
   NotificationCampaign,
@@ -49,6 +49,10 @@ export class NotificationCampaignWriteRepository {
     return (updateResult.affected ?? 0) > 0;
   }
 
+  async softDeleteById({ id }: { id: number }): Promise<void> {
+    await this.repository.softDelete({ id });
+  }
+
   private buildWhere(filter: NotificationCampaignFilter) {
     const where: Record<string, unknown> = {};
 
@@ -66,6 +70,10 @@ export class NotificationCampaignWriteRepository {
 
     if (filter.scheduledAtLte !== undefined) {
       where.scheduledAt = LessThanOrEqual(filter.scheduledAtLte);
+    }
+
+    if (filter.updatedAtLt !== undefined) {
+      where.updatedAt = LessThan(filter.updatedAtLt);
     }
 
     return where;

--- a/src/notification/infrastructure/notification-campaign.write.repository.type.ts
+++ b/src/notification/infrastructure/notification-campaign.write.repository.type.ts
@@ -5,4 +5,5 @@ export type NotificationCampaignFilter = {
   cohortId?: number;
   status?: NotificationCampaignStatus;
   scheduledAtLte?: Date;
+  updatedAtLt?: Date;
 };

--- a/src/notification/interface/admin.notification-campaign.controller.ts
+++ b/src/notification/interface/admin.notification-campaign.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   HttpCode,
   HttpStatus,
@@ -23,6 +24,7 @@ import { NotificationCampaignService } from '../application/notification-campaig
 import {
   CreateNotificationCampaignRequestDto,
   FindAdminNotificationCampaignsQueryDto,
+  UpdateNotificationCampaignRequestDto,
 } from './dto/admin-notification-campaign.request.dto';
 import { NotificationCampaignResponseDto } from './dto/admin-notification-campaign.response.dto';
 
@@ -68,6 +70,43 @@ export class AdminNotificationCampaignController {
       status: query.status,
     });
     return ApiResponse.ok(records.map((record) => NotificationCampaignResponseDto.from(record)));
+  }
+
+  @ApiDoc({
+    summary: '캠페인 수정',
+    description:
+      'SCHEDULED 또는 PAUSED 상태에서 본문/예약 시각을 수정합니다. RUNNING/DONE/FAILED 상태에서는 수정할 수 없습니다.',
+    operationId: 'notificationCampaign_updateAdmin',
+    auth: true,
+  })
+  @Patch(':id')
+  async updateCampaign(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() body: UpdateNotificationCampaignRequestDto,
+  ) {
+    const updated = await this.notificationCampaignService.updateCampaign({
+      id,
+      scheduledAt: body.scheduledAt !== undefined ? new Date(body.scheduledAt) : undefined,
+      subject: body.subject,
+      html: body.html,
+      text: body.text,
+    });
+    return ApiResponse.ok(
+      NotificationCampaignResponseDto.from(updated),
+      '캠페인이 수정되었습니다.',
+    );
+  }
+
+  @ApiDoc({
+    summary: '캠페인 삭제',
+    description: 'RUNNING 외 상태의 캠페인을 soft delete 합니다.',
+    operationId: 'notificationCampaign_deleteAdmin',
+    auth: true,
+  })
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @Delete(':id')
+  async deleteCampaign(@Param('id', ParseIntPipe) id: number): Promise<void> {
+    await this.notificationCampaignService.deleteCampaign({ id });
   }
 
   @ApiDoc({

--- a/src/notification/interface/dto/admin-notification-campaign.request.dto.ts
+++ b/src/notification/interface/dto/admin-notification-campaign.request.dto.ts
@@ -45,6 +45,37 @@ export class CreateNotificationCampaignRequestDto {
   text: string;
 }
 
+export class UpdateNotificationCampaignRequestDto {
+  @ApiPropertyOptional({
+    description: '발송 예정 시각 (ISO 8601)',
+    example: '2026-06-01T10:00:00.000Z',
+  })
+  @IsOptional()
+  @IsISO8601()
+  scheduledAt?: string;
+
+  @ApiPropertyOptional({ description: '메일 제목' })
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(200)
+  subject?: string;
+
+  @ApiPropertyOptional({ description: 'HTML 본문' })
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(50000)
+  html?: string;
+
+  @ApiPropertyOptional({ description: '플레인텍스트 본문' })
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(20000)
+  text?: string;
+}
+
 export class FindAdminNotificationCampaignsQueryDto {
   @ApiProperty({ description: '대상 기수 ID', example: 1 })
   @Type(() => Number)


### PR DESCRIPTION
## 개요
PR #49(캠페인 스케줄러) 후속. 운영자가 SCHEDULED 캠페인의 오타·일정을 정정하거나 불필요한 캠페인을 정리할 수 있도록 CRUD를 보강하고, claim 후 finalize 사이에 프로세스가 죽었을 때 stuck RUNNING이 영원히 남는 시나리오를 주기적으로 복구하는 reaper를 추가합니다.

> ⚠️ Base 브랜치가 `feat/notification-campaign-scheduler` (PR #49). PR #49 머지 후 main으로 자동 retarget 됩니다.

## 변경 이유
- (P1) PR #49 직후 운영자가 본문 오타를 발견하면 캠페인을 삭제·재생성 외 방법이 없었음 → 일정/본문 정정 흐름 부재
- (P1) RUNNING 상태에서 프로세스가 죽으면 캠페인이 영원히 RUNNING으로 stuck — 멀티 인스턴스 도입 시 더 빈번해질 가능성

## 주요 변경 사항
- **어드민 API**
  - `PATCH /v1/admin/notification-campaigns/:id` — SCHEDULED/PAUSED 상태에서만 본문/예약시각 수정 (이외 409)
  - `DELETE /v1/admin/notification-campaigns/:id` — RUNNING 외 상태에서 soft delete (RUNNING은 409, 204 반환)
- **Domain**
  - `NotificationCampaign.applyEdits({ scheduledAt?, subject?, html?, text? })` — undefined 필드는 그대로, defined 필드만 갱신
- **Application**
  - `updateCampaign` — 상태 가드 + `applyEdits` + `save` (`@Transactional`)
  - `deleteCampaign` — RUNNING 보호 + soft delete (`@Transactional`)
  - `reapStaleRunning` — `updatedAt < (now - 30분)` AND `status=RUNNING` 캠페인 조회
  - `recoverStaleCampaign` — atomic CAS `RUNNING → FAILED` + audit log (`@Transactional`)
- **Infrastructure**
  - `NotificationCampaignWriteRepository.softDeleteById`, filter `updatedAtLt` 추가
  - `NotificationCampaignScheduler` cron — `reapStaleRunning()` 호출 후 `runDueCampaigns()` 호출 (회수가 발송보다 먼저 실행)
- **Repository (Domain)**
  - `findStaleRunning({ updatedAtBefore })`, `save({ campaign })`, `deleteById({ id })`
- 단위 테스트 +13건 추가 (29 total)
  - updateCampaign: 4건 (NOT_FOUND / wrong state / SCHEDULED / PAUSED)
  - deleteCampaign: 6건 (NOT_FOUND / RUNNING 보호 / `it.each`로 4개 허용 상태 검증)
  - reapStaleRunning: 3건 (empty / 정상 회수 / race 실패)

## 아키텍처 영향
- 도메인 분리: 변동 없음 — 기존 `notification-campaign` 서브도메인 안에서 책임 추가
- 레이어: Interface → Application → Domain ← Infrastructure 의존 방향 유지
- 의존 방향 변화: 없음
- 트랜잭션 경계
  - `updateCampaign`/`deleteCampaign`: 단일 트랜잭션 내 가드 → 영속화
  - `recoverStaleCampaign`: atomic CAS + audit log 동일 트랜잭션
  - `reapStaleRunning` 자체는 트랜잭션 외부 — 내부에서 캠페인별로 짧은 트랜잭션 반복 (락 보유 시간 최소화)

## 테스트
- [x] 단위 테스트 (`notification-campaign.service.spec.ts` 29건)
- [x] 통합 테스트 — 별도 추가 없음
- [x] 수동 검증 — `yarn build` / `yarn jest` (32 suites, 266 passed) / `yarn lint:check` 모두 그린
- 확인 내용
  - update: NOT_FOUND / RUNNING 등 잘못된 상태 / SCHEDULED+PAUSED 정상 경로 / applyEdits 인자 검증
  - delete: NOT_FOUND / RUNNING 보호 / SCHEDULED·PAUSED·DONE·FAILED 모두 soft delete 허용
  - reaper: empty / 정상 회수 + audit / race 시 audit 미호출

## 리뷰 포인트
1. **stale 판정 기준 (`updatedAt`)**: BaseEntity의 `@UpdateDateColumn`을 활용. RUNNING 전이 시 UPDATE statement가 일어나면서 `updatedAt`이 자동 갱신되므로 별도 `startedAt` 컬럼 없이 stuck 검출 가능. 다른 status 전이(SCHEDULED→PAUSED 등)도 `updatedAt`을 갱신하지만, `status=RUNNING` 필터가 있어 충돌 없음.
2. **threshold 30분**: 일반 sendBulk가 수초~수분 내 끝나는 것을 고려해 보수적 값. 환경 변수로 빼지 않은 이유는 이 값이 운영 튜닝 대상이기보다는 시스템 안전 가드 성격이라 코드 상수로 둠. 의견 환영.
3. **본문 수정 audit 미기록**: status 변경이 없는 본문 수정은 audit 로그에 남기지 않음. 기존 `CohortService.updateCohort` 패턴(상태 변경 시에만 audit)과 일관. 본문 변경 이력이 필요하면 별도 audit-content-change action으로 확장 가능.
4. **RUNNING 캠페인 삭제 차단**: 발송 중인 캠페인을 admin이 실수로 지우는 것을 막기 위함. 강제 삭제가 필요하면 `forceDelete` 같은 별도 엔드포인트로 분리 권장 (이번 PR 범위 외).
5. **Soft delete된 캠페인 재조회**: TypeORM 기본 동작상 `findOne`/`find`가 deleted를 제외하므로 admin 목록에서도 사라짐. 휴지통 기능이 필요하면 별도 endpoint.

## 리스크 / 후속 작업
- **stale RUNNING 의 result jsonb**: 회수된 캠페인은 `result=null` 인 채로 FAILED로 남음. 운영자가 "어떻게 실패했는지" 모를 수 있음 — 향후 `result.recoveredAt`/`reason` 같은 필드 도입 가능
- **자동 캠페인 생성 (2차)**: cohort 생성/상태 전이 시점에 기본 캠페인 자동 등록 — 별도 PR
- **NotificationTemplate (3차)**: 본문 재사용 — 별도 PR
- **admin 식별 데코레이터**: 현재 audit `adminId=0`. JWT 컨텍스트에서 추출 — 별도 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)