### PR TITLE
chore(config): EMAIL/STORAGE/DISCORD provider 조건부 required 검증 확장

### DIFF
--- a/src/config/env.validation.spec.ts
+++ b/src/config/env.validation.spec.ts
@@ -82,8 +82,16 @@ describe('env validation', () => {
       expect(result.STORAGE_PROVIDER).toBe('console');
     });
 
-    it('STORAGE_PROVIDER=gcs 는 통과한다', () => {
-      expect(() => validate({ ...createValidConfig(), STORAGE_PROVIDER: 'gcs' })).not.toThrow();
+    it('STORAGE_PROVIDER=gcs + 필수 GCS 키가 모두 있으면 통과한다', () => {
+      expect(() =>
+        validate({
+          ...createValidConfig(),
+          STORAGE_PROVIDER: 'gcs',
+          GCS_BUCKET_NAME: 'ddd-bucket',
+          GCS_PROJECT_ID: 'ddd-project',
+          GCS_KEY_FILE_PATH: '/app/gcp-key.json',
+        }),
+      ).not.toThrow();
     });
 
     it('알 수 없는 STORAGE_PROVIDER 값은 앱 시작 전에 실패한다', () => {
@@ -96,6 +104,133 @@ describe('env validation', () => {
       expect(() => {
         validate({ ...createValidConfig(), STORAGE_PROVIDER: 'aws-s3' });
       }).toThrow('STORAGE_PROVIDER');
+    });
+  });
+
+  describe('EMAIL_PROVIDER 조건부 검증', () => {
+    it('EMAIL_PROVIDER=console(기본)이면 RESEND_API_KEY/EMAIL_FROM 없이 통과한다', () => {
+      expect(() => validate(createValidConfig())).not.toThrow();
+    });
+
+    it('EMAIL_PROVIDER=resend 인데 RESEND_API_KEY가 없으면 실패한다', () => {
+      expect(() => {
+        validate({
+          ...createValidConfig(),
+          EMAIL_PROVIDER: 'resend',
+          EMAIL_FROM: 'noreply@dddsite.co.kr',
+        });
+      }).toThrow('RESEND_API_KEY');
+    });
+
+    it('EMAIL_PROVIDER=resend 인데 EMAIL_FROM이 없으면 실패한다', () => {
+      expect(() => {
+        validate({
+          ...createValidConfig(),
+          EMAIL_PROVIDER: 'resend',
+          RESEND_API_KEY: 're_test_key',
+        });
+      }).toThrow('EMAIL_FROM');
+    });
+
+    it('EMAIL_PROVIDER=resend 이고 KEY/FROM 이 모두 있으면 통과한다', () => {
+      expect(() =>
+        validate({
+          ...createValidConfig(),
+          EMAIL_PROVIDER: 'resend',
+          RESEND_API_KEY: 're_test_key',
+          EMAIL_FROM: 'noreply@dddsite.co.kr',
+        }),
+      ).not.toThrow();
+    });
+  });
+
+  describe('STORAGE_PROVIDER 조건부 검증', () => {
+    it('STORAGE_PROVIDER=gcs 인데 GCS_BUCKET_NAME이 없으면 실패한다', () => {
+      expect(() => {
+        validate({
+          ...createValidConfig(),
+          STORAGE_PROVIDER: 'gcs',
+          GCS_PROJECT_ID: 'ddd-project',
+          GCS_KEY_FILE_PATH: '/app/gcp-key.json',
+        });
+      }).toThrow('GCS_BUCKET_NAME');
+    });
+
+    it('STORAGE_PROVIDER=gcs 인데 GCS_PROJECT_ID가 없으면 실패한다', () => {
+      expect(() => {
+        validate({
+          ...createValidConfig(),
+          STORAGE_PROVIDER: 'gcs',
+          GCS_BUCKET_NAME: 'ddd-bucket',
+          GCS_KEY_FILE_PATH: '/app/gcp-key.json',
+        });
+      }).toThrow('GCS_PROJECT_ID');
+    });
+
+    it('STORAGE_PROVIDER=gcs 인데 GCS_KEY_FILE_PATH가 없으면 실패한다', () => {
+      expect(() => {
+        validate({
+          ...createValidConfig(),
+          STORAGE_PROVIDER: 'gcs',
+          GCS_BUCKET_NAME: 'ddd-bucket',
+          GCS_PROJECT_ID: 'ddd-project',
+        });
+      }).toThrow('GCS_KEY_FILE_PATH');
+    });
+  });
+
+  describe('DISCORD_PROVIDER 조건부 검증', () => {
+    const buildDiscordConfig = (): Record<string, unknown> => ({
+      ...createValidConfig(),
+      DISCORD_PROVIDER: 'discord',
+      DISCORD_CLIENT_ID: 'discord-client',
+      DISCORD_CLIENT_SECRET: 'discord-secret',
+      DISCORD_CALLBACK_URL: 'https://api.dddsite.co.kr/discord/callback',
+      DISCORD_BOT_TOKEN: 'discord-bot-token',
+      DISCORD_GUILD_ID: 'discord-guild-id',
+    });
+
+    it('DISCORD_PROVIDER 미설정(기본 console)이면 DISCORD_* 없이 통과한다', () => {
+      expect(() => validate(createValidConfig())).not.toThrow();
+    });
+
+    it('DISCORD_PROVIDER=discord 이고 핵심 5개가 모두 있으면 통과한다', () => {
+      expect(() => validate(buildDiscordConfig())).not.toThrow();
+    });
+
+    it('DISCORD_PROVIDER=discord 인데 DISCORD_CLIENT_ID가 없으면 실패한다', () => {
+      const config = buildDiscordConfig();
+      delete config.DISCORD_CLIENT_ID;
+
+      expect(() => validate(config)).toThrow('DISCORD_CLIENT_ID');
+    });
+
+    it('DISCORD_PROVIDER=discord 인데 DISCORD_CLIENT_SECRET이 없으면 실패한다', () => {
+      const config = buildDiscordConfig();
+      delete config.DISCORD_CLIENT_SECRET;
+
+      expect(() => validate(config)).toThrow('DISCORD_CLIENT_SECRET');
+    });
+
+    it('DISCORD_PROVIDER=discord 인데 DISCORD_CALLBACK_URL이 없으면 실패한다', () => {
+      const config = buildDiscordConfig();
+      delete config.DISCORD_CALLBACK_URL;
+
+      expect(() => validate(config)).toThrow('DISCORD_CALLBACK_URL');
+    });
+
+    it('DISCORD_PROVIDER=discord 인데 DISCORD_BOT_TOKEN이 없으면 실패한다', () => {
+      const config = buildDiscordConfig();
+      delete config.DISCORD_BOT_TOKEN;
+
+      expect(() => validate(config)).toThrow('DISCORD_BOT_TOKEN');
+    });
+
+    it('DISCORD_PROVIDER=discord 인데 DISCORD_GUILD_ID가 없으면 실패한다', () => {
+      const config = buildDiscordConfig();
+      delete config.DISCORD_GUILD_ID;
+
+      expect(() => validate(config)).toThrow('DISCORD_GUILD_ID');
     });
   });
 });

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -80,12 +80,14 @@ class EnvironmentVariables {
   @IsOptional()
   EMAIL_PROVIDER: string = 'console';
 
-  @IsString()
-  @IsOptional()
+  @ValidateIf((env: EnvironmentVariables) => env.EMAIL_PROVIDER === 'resend')
+  @IsString({ message: 'EMAIL_PROVIDER=resend 일 때 RESEND_API_KEY는 필수입니다.' })
+  @IsNotEmpty({ message: 'EMAIL_PROVIDER=resend 일 때 RESEND_API_KEY는 필수입니다.' })
   RESEND_API_KEY?: string;
 
-  @IsString()
-  @IsOptional()
+  @ValidateIf((env: EnvironmentVariables) => env.EMAIL_PROVIDER === 'resend')
+  @IsString({ message: 'EMAIL_PROVIDER=resend 일 때 EMAIL_FROM은 필수입니다.' })
+  @IsNotEmpty({ message: 'EMAIL_PROVIDER=resend 일 때 EMAIL_FROM은 필수입니다.' })
   EMAIL_FROM?: string;
 
   @IsString()
@@ -106,16 +108,19 @@ class EnvironmentVariables {
   @IsOptional()
   STORAGE_PROVIDER?: StorageProvider = 'console';
 
-  @IsString()
-  @IsOptional()
+  @ValidateIf((env: EnvironmentVariables) => env.STORAGE_PROVIDER === 'gcs')
+  @IsString({ message: 'STORAGE_PROVIDER=gcs 일 때 GCS_BUCKET_NAME은 필수입니다.' })
+  @IsNotEmpty({ message: 'STORAGE_PROVIDER=gcs 일 때 GCS_BUCKET_NAME은 필수입니다.' })
   GCS_BUCKET_NAME?: string;
 
-  @IsString()
-  @IsOptional()
+  @ValidateIf((env: EnvironmentVariables) => env.STORAGE_PROVIDER === 'gcs')
+  @IsString({ message: 'STORAGE_PROVIDER=gcs 일 때 GCS_PROJECT_ID는 필수입니다.' })
+  @IsNotEmpty({ message: 'STORAGE_PROVIDER=gcs 일 때 GCS_PROJECT_ID는 필수입니다.' })
   GCS_PROJECT_ID?: string;
 
-  @IsString()
-  @IsOptional()
+  @ValidateIf((env: EnvironmentVariables) => env.STORAGE_PROVIDER === 'gcs')
+  @IsString({ message: 'STORAGE_PROVIDER=gcs 일 때 GCS_KEY_FILE_PATH는 필수입니다.' })
+  @IsNotEmpty({ message: 'STORAGE_PROVIDER=gcs 일 때 GCS_KEY_FILE_PATH는 필수입니다.' })
   GCS_KEY_FILE_PATH?: string;
 
   @IsString()
@@ -144,24 +149,29 @@ class EnvironmentVariables {
   @IsOptional()
   DISCORD_PROVIDER?: string = 'console';
 
-  @IsString()
-  @IsOptional()
+  @ValidateIf((env: EnvironmentVariables) => env.DISCORD_PROVIDER === 'discord')
+  @IsString({ message: 'DISCORD_PROVIDER=discord 일 때 DISCORD_CLIENT_ID는 필수입니다.' })
+  @IsNotEmpty({ message: 'DISCORD_PROVIDER=discord 일 때 DISCORD_CLIENT_ID는 필수입니다.' })
   DISCORD_CLIENT_ID?: string;
 
-  @IsString()
-  @IsOptional()
+  @ValidateIf((env: EnvironmentVariables) => env.DISCORD_PROVIDER === 'discord')
+  @IsString({ message: 'DISCORD_PROVIDER=discord 일 때 DISCORD_CLIENT_SECRET은 필수입니다.' })
+  @IsNotEmpty({ message: 'DISCORD_PROVIDER=discord 일 때 DISCORD_CLIENT_SECRET은 필수입니다.' })
   DISCORD_CLIENT_SECRET?: string;
 
-  @IsString()
-  @IsOptional()
+  @ValidateIf((env: EnvironmentVariables) => env.DISCORD_PROVIDER === 'discord')
+  @IsString({ message: 'DISCORD_PROVIDER=discord 일 때 DISCORD_CALLBACK_URL은 필수입니다.' })
+  @IsNotEmpty({ message: 'DISCORD_PROVIDER=discord 일 때 DISCORD_CALLBACK_URL은 필수입니다.' })
   DISCORD_CALLBACK_URL?: string;
 
-  @IsString()
-  @IsOptional()
+  @ValidateIf((env: EnvironmentVariables) => env.DISCORD_PROVIDER === 'discord')
+  @IsString({ message: 'DISCORD_PROVIDER=discord 일 때 DISCORD_BOT_TOKEN은 필수입니다.' })
+  @IsNotEmpty({ message: 'DISCORD_PROVIDER=discord 일 때 DISCORD_BOT_TOKEN은 필수입니다.' })
   DISCORD_BOT_TOKEN?: string;
 
-  @IsString()
-  @IsOptional()
+  @ValidateIf((env: EnvironmentVariables) => env.DISCORD_PROVIDER === 'discord')
+  @IsString({ message: 'DISCORD_PROVIDER=discord 일 때 DISCORD_GUILD_ID는 필수입니다.' })
+  @IsNotEmpty({ message: 'DISCORD_PROVIDER=discord 일 때 DISCORD_GUILD_ID는 필수입니다.' })
   DISCORD_GUILD_ID?: string;
 
   @IsString()


### PR DESCRIPTION
## 개요
PR #44 에서 도입한 캘린더 provider 조건부 required 검증(`ValidateIf`) 패턴을 EMAIL/STORAGE/DISCORD provider 에도 동일하게 확장한다. 새 환경변수 추가는 없고, 기존 키의 검증 규칙만 강화한다.

## 변경 이유
- 운영 환경에서 `EMAIL_PROVIDER=resend` 인데 `RESEND_API_KEY`/`EMAIL_FROM` 누락, `STORAGE_PROVIDER=gcs` 인데 `GCS_*` 누락, `DISCORD_PROVIDER=discord` 인데 토큰/길드 ID 누락 시 부팅이 정상으로 끝나고 실제 호출 시점에 silent fallback / 런타임 에러로 늦게 발견되는 문제 차단
- 캘린더만 `ValidateIf` 강제되어 있던 비대칭 해소 (#44 와 일관성)
- 기존에 추가된 `STORAGE_PROVIDER` `IsIn` 화이트리스트는 그대로 두고, 자식 키의 조건부 required 만 보완 (양 방식 보완적)

## 주요 변경 사항
- `EMAIL_PROVIDER=resend` ⇒ `RESEND_API_KEY` / `EMAIL_FROM` 을 `ValidateIf + IsString + IsNotEmpty` 로 강제
- `STORAGE_PROVIDER=gcs` ⇒ `GCS_BUCKET_NAME` / `GCS_PROJECT_ID` / `GCS_KEY_FILE_PATH` 강제
- `DISCORD_PROVIDER=discord` ⇒ 핵심 5개 (`DISCORD_CLIENT_ID` / `DISCORD_CLIENT_SECRET` / `DISCORD_CALLBACK_URL` / `DISCORD_BOT_TOKEN` / `DISCORD_GUILD_ID`) 강제
- `DISCORD_INVITE_URL` 과 `DISCORD_ROLE_ID_*` 6개는 옵셔널 유지 (운영 코드 fallback 영역, 모집 파트별 ROLE_ID 미설정 케이스 보존)
- 기존 `STORAGE_PROVIDER='gcs' 단독 통과` 테스트는 의미 보존을 위해 GCS 자식 키 3개를 함께 제공하도록 갱신
- `env.validation.spec.ts` 분기 테스트 14건 추가 (총 24/24 통과)

## 아키텍처 영향
- 도메인 분리: 변경 없음
- 레이어 변경: 없음
- 의존 방향 영향: 없음 (`config/` 내부 검증 강화)
- 트랜잭션 경계 영향: 없음

## 테스트
- [x] 단위 테스트
- [ ] 통합 테스트 (해당 없음)
- [x] 수동 테스트 (빌드 + jest + lint)

확인 내용:
- `yarn build` 통과
- `yarn lint` 통과 (대상 파일 0 errors)
- `yarn jest src/config/env.validation.spec.ts` **24/24 통과**

## 리뷰 포인트
- `src/config/env.validation.ts`: 캘린더 검증과 동일한 데코레이터 순서(`@ValidateIf` → `@IsString` → `@IsNotEmpty`) 와 한국어 메시지 포맷 유지
- DISCORD `ROLE_ID_*` 옵셔널 유지가 적절한지 확인 부탁 — 모집 파트별 역할 매핑인데 일부 파트만 운영하는 시즌이 있을 수 있어 필수로 강제하지 않음
- `RESEND_API_KEY` 메시지가 한 곳에서 두 번 반복(`@IsString` 메시지 + `@IsNotEmpty` 메시지)되는 점은 캘린더 검증의 기존 컨벤션을 따른 형태

## 리스크 / 후속 작업
- 운영 `.env.production` 에서 위 키들이 비어 있으면 부팅 실패 (의도). 머지 직전 GitHub Secret 채워졌는지 확인 부탁
- 후속(별도): `OPS_ALERT_EMAIL` 도 `EMAIL_PROVIDER=resend` 일 때 권장값으로 안내하는 메시지 추가, Slack/Discord 웹훅 알림 채널 도입

## 관련 이슈
- 없음 (PR #44 캘린더 검증 일관성 확장)