### PR TITLE
fix(config): EMAIL/STORAGE/DISCORD provider 검증 강화 일시 revert (운영 부팅 차단 회복)

### DIFF
--- a/src/config/env.validation.spec.ts
+++ b/src/config/env.validation.spec.ts
@@ -82,16 +82,8 @@ describe('env validation', () => {
       expect(result.STORAGE_PROVIDER).toBe('console');
     });
 
-    it('STORAGE_PROVIDER=gcs + 필수 GCS 키가 모두 있으면 통과한다', () => {
-      expect(() =>
-        validate({
-          ...createValidConfig(),
-          STORAGE_PROVIDER: 'gcs',
-          GCS_BUCKET_NAME: 'ddd-bucket',
-          GCS_PROJECT_ID: 'ddd-project',
-          GCS_KEY_FILE_PATH: '/app/gcp-key.json',
-        }),
-      ).not.toThrow();
+    it('STORAGE_PROVIDER=gcs 는 통과한다', () => {
+      expect(() => validate({ ...createValidConfig(), STORAGE_PROVIDER: 'gcs' })).not.toThrow();
     });
 
     it('알 수 없는 STORAGE_PROVIDER 값은 앱 시작 전에 실패한다', () => {
@@ -104,133 +96,6 @@ describe('env validation', () => {
       expect(() => {
         validate({ ...createValidConfig(), STORAGE_PROVIDER: 'aws-s3' });
       }).toThrow('STORAGE_PROVIDER');
-    });
-  });
-
-  describe('EMAIL_PROVIDER 조건부 검증', () => {
-    it('EMAIL_PROVIDER=console(기본)이면 RESEND_API_KEY/EMAIL_FROM 없이 통과한다', () => {
-      expect(() => validate(createValidConfig())).not.toThrow();
-    });
-
-    it('EMAIL_PROVIDER=resend 인데 RESEND_API_KEY가 없으면 실패한다', () => {
-      expect(() => {
-        validate({
-          ...createValidConfig(),
-          EMAIL_PROVIDER: 'resend',
-          EMAIL_FROM: 'noreply@dddsite.co.kr',
-        });
-      }).toThrow('RESEND_API_KEY');
-    });
-
-    it('EMAIL_PROVIDER=resend 인데 EMAIL_FROM이 없으면 실패한다', () => {
-      expect(() => {
-        validate({
-          ...createValidConfig(),
-          EMAIL_PROVIDER: 'resend',
-          RESEND_API_KEY: 're_test_key',
-        });
-      }).toThrow('EMAIL_FROM');
-    });
-
-    it('EMAIL_PROVIDER=resend 이고 KEY/FROM 이 모두 있으면 통과한다', () => {
-      expect(() =>
-        validate({
-          ...createValidConfig(),
-          EMAIL_PROVIDER: 'resend',
-          RESEND_API_KEY: 're_test_key',
-          EMAIL_FROM: 'noreply@dddsite.co.kr',
-        }),
-      ).not.toThrow();
-    });
-  });
-
-  describe('STORAGE_PROVIDER 조건부 검증', () => {
-    it('STORAGE_PROVIDER=gcs 인데 GCS_BUCKET_NAME이 없으면 실패한다', () => {
-      expect(() => {
-        validate({
-          ...createValidConfig(),
-          STORAGE_PROVIDER: 'gcs',
-          GCS_PROJECT_ID: 'ddd-project',
-          GCS_KEY_FILE_PATH: '/app/gcp-key.json',
-        });
-      }).toThrow('GCS_BUCKET_NAME');
-    });
-
-    it('STORAGE_PROVIDER=gcs 인데 GCS_PROJECT_ID가 없으면 실패한다', () => {
-      expect(() => {
-        validate({
-          ...createValidConfig(),
-          STORAGE_PROVIDER: 'gcs',
-          GCS_BUCKET_NAME: 'ddd-bucket',
-          GCS_KEY_FILE_PATH: '/app/gcp-key.json',
-        });
-      }).toThrow('GCS_PROJECT_ID');
-    });
-
-    it('STORAGE_PROVIDER=gcs 인데 GCS_KEY_FILE_PATH가 없으면 실패한다', () => {
-      expect(() => {
-        validate({
-          ...createValidConfig(),
-          STORAGE_PROVIDER: 'gcs',
-          GCS_BUCKET_NAME: 'ddd-bucket',
-          GCS_PROJECT_ID: 'ddd-project',
-        });
-      }).toThrow('GCS_KEY_FILE_PATH');
-    });
-  });
-
-  describe('DISCORD_PROVIDER 조건부 검증', () => {
-    const buildDiscordConfig = (): Record<string, unknown> => ({
-      ...createValidConfig(),
-      DISCORD_PROVIDER: 'discord',
-      DISCORD_CLIENT_ID: 'discord-client',
-      DISCORD_CLIENT_SECRET: 'discord-secret',
-      DISCORD_CALLBACK_URL: 'https://api.dddsite.co.kr/discord/callback',
-      DISCORD_BOT_TOKEN: 'discord-bot-token',
-      DISCORD_GUILD_ID: 'discord-guild-id',
-    });
-
-    it('DISCORD_PROVIDER 미설정(기본 console)이면 DISCORD_* 없이 통과한다', () => {
-      expect(() => validate(createValidConfig())).not.toThrow();
-    });
-
-    it('DISCORD_PROVIDER=discord 이고 핵심 5개가 모두 있으면 통과한다', () => {
-      expect(() => validate(buildDiscordConfig())).not.toThrow();
-    });
-
-    it('DISCORD_PROVIDER=discord 인데 DISCORD_CLIENT_ID가 없으면 실패한다', () => {
-      const config = buildDiscordConfig();
-      delete config.DISCORD_CLIENT_ID;
-
-      expect(() => validate(config)).toThrow('DISCORD_CLIENT_ID');
-    });
-
-    it('DISCORD_PROVIDER=discord 인데 DISCORD_CLIENT_SECRET이 없으면 실패한다', () => {
-      const config = buildDiscordConfig();
-      delete config.DISCORD_CLIENT_SECRET;
-
-      expect(() => validate(config)).toThrow('DISCORD_CLIENT_SECRET');
-    });
-
-    it('DISCORD_PROVIDER=discord 인데 DISCORD_CALLBACK_URL이 없으면 실패한다', () => {
-      const config = buildDiscordConfig();
-      delete config.DISCORD_CALLBACK_URL;
-
-      expect(() => validate(config)).toThrow('DISCORD_CALLBACK_URL');
-    });
-
-    it('DISCORD_PROVIDER=discord 인데 DISCORD_BOT_TOKEN이 없으면 실패한다', () => {
-      const config = buildDiscordConfig();
-      delete config.DISCORD_BOT_TOKEN;
-
-      expect(() => validate(config)).toThrow('DISCORD_BOT_TOKEN');
-    });
-
-    it('DISCORD_PROVIDER=discord 인데 DISCORD_GUILD_ID가 없으면 실패한다', () => {
-      const config = buildDiscordConfig();
-      delete config.DISCORD_GUILD_ID;
-
-      expect(() => validate(config)).toThrow('DISCORD_GUILD_ID');
     });
   });
 });

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -80,14 +80,12 @@ class EnvironmentVariables {
   @IsOptional()
   EMAIL_PROVIDER: string = 'console';
 
-  @ValidateIf((env: EnvironmentVariables) => env.EMAIL_PROVIDER === 'resend')
-  @IsString({ message: 'EMAIL_PROVIDER=resend 일 때 RESEND_API_KEY는 필수입니다.' })
-  @IsNotEmpty({ message: 'EMAIL_PROVIDER=resend 일 때 RESEND_API_KEY는 필수입니다.' })
+  @IsString()
+  @IsOptional()
   RESEND_API_KEY?: string;
 
-  @ValidateIf((env: EnvironmentVariables) => env.EMAIL_PROVIDER === 'resend')
-  @IsString({ message: 'EMAIL_PROVIDER=resend 일 때 EMAIL_FROM은 필수입니다.' })
-  @IsNotEmpty({ message: 'EMAIL_PROVIDER=resend 일 때 EMAIL_FROM은 필수입니다.' })
+  @IsString()
+  @IsOptional()
   EMAIL_FROM?: string;
 
   @IsString()
@@ -108,19 +106,16 @@ class EnvironmentVariables {
   @IsOptional()
   STORAGE_PROVIDER?: StorageProvider = 'console';
 
-  @ValidateIf((env: EnvironmentVariables) => env.STORAGE_PROVIDER === 'gcs')
-  @IsString({ message: 'STORAGE_PROVIDER=gcs 일 때 GCS_BUCKET_NAME은 필수입니다.' })
-  @IsNotEmpty({ message: 'STORAGE_PROVIDER=gcs 일 때 GCS_BUCKET_NAME은 필수입니다.' })
+  @IsString()
+  @IsOptional()
   GCS_BUCKET_NAME?: string;
 
-  @ValidateIf((env: EnvironmentVariables) => env.STORAGE_PROVIDER === 'gcs')
-  @IsString({ message: 'STORAGE_PROVIDER=gcs 일 때 GCS_PROJECT_ID는 필수입니다.' })
-  @IsNotEmpty({ message: 'STORAGE_PROVIDER=gcs 일 때 GCS_PROJECT_ID는 필수입니다.' })
+  @IsString()
+  @IsOptional()
   GCS_PROJECT_ID?: string;
 
-  @ValidateIf((env: EnvironmentVariables) => env.STORAGE_PROVIDER === 'gcs')
-  @IsString({ message: 'STORAGE_PROVIDER=gcs 일 때 GCS_KEY_FILE_PATH는 필수입니다.' })
-  @IsNotEmpty({ message: 'STORAGE_PROVIDER=gcs 일 때 GCS_KEY_FILE_PATH는 필수입니다.' })
+  @IsString()
+  @IsOptional()
   GCS_KEY_FILE_PATH?: string;
 
   @IsString()
@@ -149,29 +144,24 @@ class EnvironmentVariables {
   @IsOptional()
   DISCORD_PROVIDER?: string = 'console';
 
-  @ValidateIf((env: EnvironmentVariables) => env.DISCORD_PROVIDER === 'discord')
-  @IsString({ message: 'DISCORD_PROVIDER=discord 일 때 DISCORD_CLIENT_ID는 필수입니다.' })
-  @IsNotEmpty({ message: 'DISCORD_PROVIDER=discord 일 때 DISCORD_CLIENT_ID는 필수입니다.' })
+  @IsString()
+  @IsOptional()
   DISCORD_CLIENT_ID?: string;
 
-  @ValidateIf((env: EnvironmentVariables) => env.DISCORD_PROVIDER === 'discord')
-  @IsString({ message: 'DISCORD_PROVIDER=discord 일 때 DISCORD_CLIENT_SECRET은 필수입니다.' })
-  @IsNotEmpty({ message: 'DISCORD_PROVIDER=discord 일 때 DISCORD_CLIENT_SECRET은 필수입니다.' })
+  @IsString()
+  @IsOptional()
   DISCORD_CLIENT_SECRET?: string;
 
-  @ValidateIf((env: EnvironmentVariables) => env.DISCORD_PROVIDER === 'discord')
-  @IsString({ message: 'DISCORD_PROVIDER=discord 일 때 DISCORD_CALLBACK_URL은 필수입니다.' })
-  @IsNotEmpty({ message: 'DISCORD_PROVIDER=discord 일 때 DISCORD_CALLBACK_URL은 필수입니다.' })
+  @IsString()
+  @IsOptional()
   DISCORD_CALLBACK_URL?: string;
 
-  @ValidateIf((env: EnvironmentVariables) => env.DISCORD_PROVIDER === 'discord')
-  @IsString({ message: 'DISCORD_PROVIDER=discord 일 때 DISCORD_BOT_TOKEN은 필수입니다.' })
-  @IsNotEmpty({ message: 'DISCORD_PROVIDER=discord 일 때 DISCORD_BOT_TOKEN은 필수입니다.' })
+  @IsString()
+  @IsOptional()
   DISCORD_BOT_TOKEN?: string;
 
-  @ValidateIf((env: EnvironmentVariables) => env.DISCORD_PROVIDER === 'discord')
-  @IsString({ message: 'DISCORD_PROVIDER=discord 일 때 DISCORD_GUILD_ID는 필수입니다.' })
-  @IsNotEmpty({ message: 'DISCORD_PROVIDER=discord 일 때 DISCORD_GUILD_ID는 필수입니다.' })
+  @IsString()
+  @IsOptional()
   DISCORD_GUILD_ID?: string;
 
   @IsString()


### PR DESCRIPTION
## 개요
PR #52 (provider 조건부 required 검증 강화) 머지 후 운영 배포가 부팅 단계에서 차단되어 즉시 revert 한다.

## 운영 장애 증상
\`\`\`
[Nest] ERROR [ExceptionHandler] Error: EMAIL_PROVIDER=resend 일 때 RESEND_API_KEY는 필수입니다.
    at Object.validate (/app/dist/config/env.validation.js:289:15)
    at ConfigModule.forRoot (...)
\`\`\`
헬스체크 12회 모두 실패 → 배포 step 1 으로 종료.

## 원인
- [.github/workflows/deploy.yml](.github/workflows/deploy.yml) 에서 `printf 'RESEND_API_KEY=%s\n' "$RESEND_API_KEY"` 가 GitHub Secret 빈 값을 그대로 \`.env.production\` 에 기록 → 부팅 시 `@IsNotEmpty` 위반으로 검증 실패
- PR #52 이전에는 `IsOptional` 이라 빈 값으로도 부팅이 통과되어 메일 호출 시점 fallback 으로 흘렀음
- 운영 측 GitHub Secret `RESEND_API_KEY` (및 `EMAIL_FROM`, `DISCORD_*`) 가 채워지지 않은 상태에서 검증을 강화한 것이 원인

## 변경 사항
- `git revert 889a612` (PR #52 squash 커밋 단일 revert)
- env.validation.ts / env.validation.spec.ts 모두 PR #52 직전 상태로 복원
- CALENDAR_PROVIDER 검증 (PR #44) 와 STORAGE_PROVIDER 화이트리스트 (사용자 별도 PR) 는 그대로 유지

## 테스트
- [x] `yarn jest src/config/env.validation.spec.ts` 통과
- [x] `yarn build` 통과

## 후속 작업 (재적용 조건)
- 운영 GitHub Secret 채우기:
  - `RESEND_API_KEY` (Resend 콘솔에서 발급)
  - `EMAIL_FROM` (예: noreply@dddsite.co.kr)
  - `DISCORD_CLIENT_ID` / `DISCORD_CLIENT_SECRET` / `DISCORD_CALLBACK_URL` / `DISCORD_BOT_TOKEN` / `DISCORD_GUILD_ID`
  - `GCS_BUCKET_NAME` 외 GCS 키 (이미 채워져 있을 가능성 높음)
- 채워졌음을 확인 후 PR #52 와 동일 변경을 다시 PR 로 올림
- 추가 권장: deploy.yml 에 secret 빈 값 가드 (`if [ -z "$RESEND_API_KEY" ]; then echo "..."; exit 1; fi`) 도입해 빈 값 배포 차단

## 리스크
- revert 자체는 운영 동작을 PR #52 머지 직전 상태로 되돌릴 뿐 새 위험 없음
- 메일/디스코드 silent fallback 위험은 PR #52 적용 직전 상태로 회귀 (운영 secret 채워지면 다시 강화 PR 가능)

## 관련
- 차단된 PR: #52
- 원인 워크플로우: .github/workflows/deploy.yml