### PR TITLE
fix(ci): EMAIL_PROVIDER 를 console 로 고정해 RESEND 비활성화

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,10 +77,8 @@ jobs:
             printf 'CLIENT_REDIRECT_URL=%s\n' "$CLIENT_REDIRECT_URL" >> .env.production
             printf 'ENCRYPTION_KEY=%s\n'     "$ENCRYPTION_KEY"       >> .env.production
             
-            # Email
-            printf 'EMAIL_PROVIDER=%s\n'     "resend"                >> .env.production
-            printf 'EMAIL_FROM=%s\n'         "$EMAIL_FROM"           >> .env.production
-            printf 'RESEND_API_KEY=%s\n'     "$RESEND_API_KEY"       >> .env.production
+            # Email (console 모드 - Resend 미사용)
+            printf 'EMAIL_PROVIDER=%s\n'     "console"               >> .env.production
             
             # Interview & Calendar
             printf 'INTERVIEW_BOOKING_URL=%s\n' "https://admin.dddstudy.kr/interview" >> .env.production


### PR DESCRIPTION
## 개요
운영에서 Resend 메일 발송을 사용하지 않기로 하여(사용자 결정), `.github/workflows/deploy.yml` 이 `.env.production` 을 작성할 때 `EMAIL_PROVIDER=console` 로 고정한다. 직전 배포에서 빈 `RESEND_API_KEY` 가 `EMAIL_PROVIDER=resend` 와 결합해 부팅 검증을 통과하지 못한 문제도 함께 해소된다.

## 변경 사항
- deploy.yml 의 .env.production 작성 단계에서 `EMAIL_PROVIDER=console` 로 박음
- `RESEND_API_KEY` / `EMAIL_FROM` 의 printf 줄 제거 (.env.production 에 더 이상 기록되지 않음)
- envs / env 매핑의 RESEND_API_KEY, EMAIL_FROM 선언은 동작 영향 없는 잔여물이라 이번 PR 에서는 그대로 둠 (필요 시 별도 청소 PR)

## 테스트
- [x] 수동 검토 (yml diff 확인)
- 부팅 검증은 머지 후 자동 트리거되는 deploy 워크플로우의 헬스체크로 확인

## 리스크
- `EMAIL_PROVIDER=console` 인 동안 운영에서 면접 안내 / 디스코드 합격 안내 등의 메일이 실제로 발송되지 않음 (예약·디스코드 자동 가입 자체는 동작)
- Resend 외 다른 메일 서비스 도입 시 EMAIL_PROVIDER 분기 / 대응 클라이언트 추가 필요

## 관련
- 직전 배포 실패: PR #52 머지 후 (현재 #53 으로 revert 된 상태) 부팅에서 RESEND_API_KEY 검증 차단