### PR TITLE
feat(user): 현재 로그인 사용자 조회용 GET /users/me 엔드포인트 추가

### DIFF
--- a/src/user/interface/dto/me.response.dto.ts
+++ b/src/user/interface/dto/me.response.dto.ts
@@ -1,0 +1,38 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import type { User } from '../../domain/user.entity';
+import { UserRole } from '../../domain/user.role';
+
+export class MeResponseDto {
+  @ApiProperty({ description: '사용자 ID', example: 1 })
+  id: number;
+
+  @ApiProperty({ description: '이메일', example: 'user@example.com' })
+  email: string;
+
+  @ApiProperty({ description: '이름', example: '석' })
+  firstName: string;
+
+  @ApiProperty({ description: '성', example: '왕', required: false })
+  lastName?: string;
+
+  @ApiProperty({
+    description: '활성 권한 목록',
+    enum: UserRole,
+    isArray: true,
+    example: [UserRole.운영자],
+  })
+  roles: UserRole[];
+
+  static from(user: User): MeResponseDto {
+    const dto = new MeResponseDto();
+    dto.id = user.id;
+    dto.email = user.email;
+    dto.firstName = user.firstName;
+    dto.lastName = user.lastName;
+    dto.roles = (user.userRoles ?? [])
+      .filter((userRole) => !userRole.deletedAt)
+      .flatMap((userRole) => userRole.role ?? []);
+    return dto;
+  }
+}

--- a/src/user/interface/user.controller.ts
+++ b/src/user/interface/user.controller.ts
@@ -1,6 +1,6 @@
 import { Controller, Get, HttpStatus, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiExtraModels, ApiTags } from '@nestjs/swagger';
 
 import type { JwtUser } from '../../auth/application/auth.type';
 import { AuthUser } from '../../common/decorator/auth-user.decorator';
@@ -9,8 +9,10 @@ import { ApiResponse } from '../../common/response/api-response';
 import { ApiDoc } from '../../common/swagger/api-doc.decorator';
 import { UserService } from '../application/user.service';
 import { MeResponseDto } from './dto/me.response.dto';
+import { UserSwagger } from './user.swagger';
 
 @ApiTags('Users')
+@ApiExtraModels(MeResponseDto)
 @Controller({ path: 'users', version: '1' })
 export class UserController {
   constructor(private readonly userService: UserService) {}
@@ -20,6 +22,7 @@ export class UserController {
     description: '현재 로그인한 사용자의 식별 정보와 활성 권한을 반환합니다.',
     operationId: 'users_me',
     auth: true,
+    responses: [UserSwagger.me.success, UserSwagger.me.unauthorized],
   })
   @Get('me')
   @UseGuards(AuthGuard('jwt'))

--- a/src/user/interface/user.controller.ts
+++ b/src/user/interface/user.controller.ts
@@ -1,0 +1,33 @@
+import { Controller, Get, HttpStatus, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { ApiTags } from '@nestjs/swagger';
+
+import type { JwtUser } from '../../auth/application/auth.type';
+import { AuthUser } from '../../common/decorator/auth-user.decorator';
+import { AppException } from '../../common/exception/app.exception';
+import { ApiResponse } from '../../common/response/api-response';
+import { ApiDoc } from '../../common/swagger/api-doc.decorator';
+import { UserService } from '../application/user.service';
+import { MeResponseDto } from './dto/me.response.dto';
+
+@ApiTags('Users')
+@Controller({ path: 'users', version: '1' })
+export class UserController {
+  constructor(private readonly userService: UserService) {}
+
+  @ApiDoc({
+    summary: '내 정보 조회',
+    description: '현재 로그인한 사용자의 식별 정보와 활성 권한을 반환합니다.',
+    operationId: 'users_me',
+    auth: true,
+  })
+  @Get('me')
+  @UseGuards(AuthGuard('jwt'))
+  async me(@AuthUser() jwtUser: JwtUser) {
+    const user = await this.userService.findById({ id: jwtUser.id });
+    if (!user) {
+      throw new AppException('USER_NOT_FOUND', HttpStatus.UNAUTHORIZED);
+    }
+    return ApiResponse.ok(MeResponseDto.from(user));
+  }
+}

--- a/src/user/interface/user.swagger.ts
+++ b/src/user/interface/user.swagger.ts
@@ -1,0 +1,22 @@
+import {
+  CommonSwaggerResponses,
+  successResponseSchema,
+} from '../../common/swagger/response-schema';
+import { MeResponseDto } from './dto/me.response.dto';
+
+/**
+ * UserController Swagger 응답 스키마 정의
+ * 컨트롤러 가독성 보호를 위해 별도 파일로 분리
+ */
+export const UserSwagger = {
+  me: {
+    success: {
+      status: 200,
+      description: '현재 로그인한 사용자의 식별 정보와 활성 권한을 반환합니다.',
+      ...successResponseSchema(MeResponseDto),
+    },
+    unauthorized: CommonSwaggerResponses.unauthorized(
+      'access_token 쿠키가 없거나 만료되었습니다.',
+    ),
+  },
+} as const;

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -9,10 +9,11 @@ import { UserRoleEntity } from './domain/user-role.entity';
 import { RoleWriteRepository } from './infrastructure/role.write.repository';
 import { WriteRepository } from './infrastructure/write.repository';
 import { BootstrapUserController } from './interface/bootstrap.user.controller';
+import { UserController } from './interface/user.controller';
 
 @Module({
   imports: [TypeOrmModule.forFeature([User, UserRoleEntity]), AuditModule],
-  controllers: [BootstrapUserController],
+  controllers: [BootstrapUserController, UserController],
   providers: [UserService, UserRepository, WriteRepository, RoleWriteRepository],
   exports: [UserService],
 })


### PR DESCRIPTION
  ## ✅ PR 설명

  - 클라이언트가 루트 진입 시 사용자 정보·활성 권한을 한 번에 받아 전역
  상태에 저장할 수 있도록 `GET /api/v1/users/me` 엔드포인트를 신규
  추가합니다.
  - `UserModule`에 신규 `UserController` 등록. 기존
  `BootstrapUserController`(최초 운영자 시드 전용, 비-JWT)는 책임이 달라
  그대로 분리 유지.
  - 응답은 식별 필드(`id`, `email`, `firstName`, `lastName`)와 활성
  `roles`만 포함하는 thin payload. 권한 펼치기(permissions)는 추후 권한
  분기가 늘어나면 도입.
  - 소프트삭제된 `user_role` row는 `MeResponseDto.from`에서 필터링.
  - 사용자가 소프트삭제됐거나 존재하지 않는 경우 `401 USER_NOT_FOUND` 반환
  (클라가 로그인 화면으로 라우팅).

  ---

  ## 🧪 테스트 방법

  - [x] `tsc --noEmit` 통과 (변경 파일 기준, 기존
  `interview.service.spec.ts` 에러는 본 PR과 무관)
  - [x] `eslint` 통과 (변경 파일 기준)
  - [ ] 로컬에서 Google 로그인 후 쿠키 보유 상태로 `GET /api/v1/users/me`
  호출 → `200 SUCCESS` 및 본인 정보 반환 확인
  - [ ] 쿠키 없는 상태로 호출 → `401` 확인
  - [ ] Swagger(`/api`)에서 `Users` 태그 아래 `users_me` operation 노출 확인

  ---

  ## 🔍 체크리스트

  - [x] 코드에 주석/불필요한 로그 제거
  - [x] 코드 리뷰어가 이해하기 쉽게 커밋 정리 (단일 커밋)

  ---

  ## 📎 기타 참고 사항 (Optional)

  - 응답 스펙 예시:
    ```json
    {
      "code": "SUCCESS",
      "message": "success",
      "data": {
        "id": 1,
        "email": "user@example.com",
        "firstName": "석",
        "lastName": "왕",
        "roles": ["운영자"]
      }
    }
  - 권한을 클라에서 라우팅/UI 게이팅에 사용해야 하면 추후 permissions:
  string[] 필드를 추가하는 것을 고려 (RolePermissionMap 도입 필요).
  - 직군(프론트/백엔드) 정보는 본 PR 범위에서 제외. 필요해지면 User 엔티티에
   별도 컬럼 추가가 선행되어야 함.