### PR TITLE
docs(interview): admin 면접 슬롯/예약 API Swagger 응답 스키마 추가

### DIFF
--- a/src/common/swagger/response-schema.ts
+++ b/src/common/swagger/response-schema.ts
@@ -26,12 +26,41 @@ export const successListResponseSchema = (model: Type<unknown>) => ({
   },
 });
 
+export const successNullResponseSchema = (message = 'success') => ({
+  schema: {
+    type: 'object',
+    properties: {
+      code: { type: 'string', example: 'SUCCESS' },
+      message: { type: 'string', example: message },
+      data: { type: 'object', nullable: true, example: null },
+    },
+  },
+});
+
 export const errorResponseSchema = (code: string, message: string) => ({
   schema: {
     type: 'object',
     properties: {
       code: { type: 'string', example: code },
       message: { type: 'string', example: message },
+      data: { type: 'object', nullable: true, example: null },
+    },
+  },
+});
+
+const errorOneOfSchema = (cases: Array<{ code: string; message: string }>) => ({
+  schema: {
+    type: 'object',
+    properties: {
+      code: {
+        type: 'string',
+        enum: cases.map((c) => c.code),
+        example: cases[0].code,
+      },
+      message: {
+        type: 'string',
+        example: cases[0].message,
+      },
       data: { type: 'object', nullable: true, example: null },
     },
   },
@@ -47,5 +76,13 @@ export const CommonSwaggerResponses = {
     status: 404 as const,
     description,
     ...errorResponseSchema(code, description),
+  }),
+  notFoundOneOf: (
+    description: string,
+    cases: Array<{ code: string; message: string }>,
+  ) => ({
+    status: 404 as const,
+    description,
+    ...errorOneOfSchema(cases),
   }),
 };

--- a/src/common/swagger/response-schema.ts
+++ b/src/common/swagger/response-schema.ts
@@ -12,6 +12,20 @@ export const successResponseSchema = (model: Type<unknown>) => ({
   },
 });
 
+export const successListResponseSchema = (model: Type<unknown>) => ({
+  schema: {
+    type: 'object',
+    properties: {
+      code: { type: 'string', example: 'SUCCESS' },
+      message: { type: 'string', example: 'success' },
+      data: {
+        type: 'array',
+        items: { $ref: getSchemaPath(model) },
+      },
+    },
+  },
+});
+
 export const errorResponseSchema = (code: string, message: string) => ({
   schema: {
     type: 'object',

--- a/src/interview/interface/admin.interview.controller.ts
+++ b/src/interview/interface/admin.interview.controller.ts
@@ -13,7 +13,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiExtraModels, ApiTags } from '@nestjs/swagger';
 
 import { ApplicationService } from '../../application/usecase/application.service';
 import { Roles } from '../../common/decorator/roles.decorator';
@@ -22,6 +22,7 @@ import { ApiResponse } from '../../common/response/api-response';
 import { ApiDoc } from '../../common/swagger/api-doc.decorator';
 import { UserRole } from '../../user/domain/user.role';
 import { InterviewService } from '../application/interview.service';
+import { AdminInterviewSwagger } from './admin.interview.swagger';
 import {
   InterviewReservationResponseDto,
   InterviewSlotResponseDto,
@@ -34,6 +35,7 @@ import {
 } from './dto/interview-slot.request.dto';
 
 @ApiTags('Admin - Interview')
+@ApiExtraModels(InterviewSlotResponseDto, InterviewReservationResponseDto)
 @Controller({ path: 'admin/interview-slots', version: '1' })
 @UseGuards(AuthGuard('jwt'), RolesGuard)
 @Roles(UserRole.계정관리, UserRole.운영자)
@@ -48,6 +50,10 @@ export class AdminInterviewController {
     description: '새로운 면접 슬롯을 생성합니다.',
     operationId: 'interview_createSlot',
     auth: true,
+    responses: [
+      AdminInterviewSwagger.createSlot.success,
+      AdminInterviewSwagger.createSlot.unauthorized,
+    ],
   })
   @Post()
   async createSlot(@Body() body: CreateInterviewSlotRequestDto) {
@@ -70,6 +76,10 @@ export class AdminInterviewController {
     description: '기수/파트 필터로 슬롯을 조회합니다.',
     operationId: 'interview_listSlots',
     auth: true,
+    responses: [
+      AdminInterviewSwagger.listSlots.success,
+      AdminInterviewSwagger.listSlots.unauthorized,
+    ],
   })
   @Get()
   async findSlots(@Query() query: InterviewSlotListQueryDto) {
@@ -84,6 +94,11 @@ export class AdminInterviewController {
     summary: '면접 슬롯 상세 조회',
     operationId: 'interview_getSlot',
     auth: true,
+    responses: [
+      AdminInterviewSwagger.getSlot.success,
+      AdminInterviewSwagger.getSlot.unauthorized,
+      AdminInterviewSwagger.getSlot.notFound,
+    ],
   })
   @Get(':id')
   async findSlotById(@Param('id', ParseIntPipe) id: number) {
@@ -95,6 +110,11 @@ export class AdminInterviewController {
     summary: '면접 슬롯 수정',
     operationId: 'interview_updateSlot',
     auth: true,
+    responses: [
+      AdminInterviewSwagger.updateSlot.success,
+      AdminInterviewSwagger.updateSlot.unauthorized,
+      AdminInterviewSwagger.updateSlot.notFound,
+    ],
   })
   @Patch(':id')
   async updateSlot(
@@ -118,6 +138,11 @@ export class AdminInterviewController {
     summary: '면접 슬롯 삭제',
     operationId: 'interview_deleteSlot',
     auth: true,
+    responses: [
+      AdminInterviewSwagger.deleteSlot.noContent,
+      AdminInterviewSwagger.deleteSlot.unauthorized,
+      AdminInterviewSwagger.deleteSlot.notFound,
+    ],
   })
   @Delete(':id')
   @HttpCode(HttpStatus.NO_CONTENT)
@@ -130,6 +155,11 @@ export class AdminInterviewController {
     description: '지원자를 특정 슬롯에 배정하고 구글 캘린더 이벤트를 생성합니다.',
     operationId: 'interview_createReservation',
     auth: true,
+    responses: [
+      AdminInterviewSwagger.createReservation.success,
+      AdminInterviewSwagger.createReservation.unauthorized,
+      AdminInterviewSwagger.createReservation.notFound,
+    ],
   })
   @Post(':slotId/reservations')
   async createReservation(
@@ -153,6 +183,11 @@ export class AdminInterviewController {
     description: '면접 예약을 취소하고 연동된 구글 캘린더 이벤트를 삭제합니다.',
     operationId: 'interview_cancelReservation',
     auth: true,
+    responses: [
+      AdminInterviewSwagger.cancelReservation.noContent,
+      AdminInterviewSwagger.cancelReservation.unauthorized,
+      AdminInterviewSwagger.cancelReservation.notFound,
+    ],
   })
   @Delete('reservations/:reservationId')
   @HttpCode(HttpStatus.NO_CONTENT)

--- a/src/interview/interface/admin.interview.swagger.ts
+++ b/src/interview/interface/admin.interview.swagger.ts
@@ -1,0 +1,109 @@
+import {
+  CommonSwaggerResponses,
+  successListResponseSchema,
+  successResponseSchema,
+} from '../../common/swagger/response-schema';
+import {
+  InterviewReservationResponseDto,
+  InterviewSlotResponseDto,
+} from './dto/interview.response.dto';
+
+/**
+ * AdminInterviewController Swagger 응답 스키마 정의
+ * 컨트롤러 가독성 보호를 위해 별도 파일로 분리
+ */
+export const AdminInterviewSwagger = {
+  createSlot: {
+    success: {
+      status: 201,
+      description: '면접 슬롯 생성 성공',
+      ...successResponseSchema(InterviewSlotResponseDto),
+    },
+    unauthorized: CommonSwaggerResponses.unauthorized(
+      'access_token 쿠키가 없거나 만료되었습니다.',
+    ),
+  },
+
+  listSlots: {
+    success: {
+      status: 200,
+      description: '면접 슬롯 목록 조회 성공',
+      ...successListResponseSchema(InterviewSlotResponseDto),
+    },
+    unauthorized: CommonSwaggerResponses.unauthorized(
+      'access_token 쿠키가 없거나 만료되었습니다.',
+    ),
+  },
+
+  getSlot: {
+    success: {
+      status: 200,
+      description: '면접 슬롯 상세 조회 성공',
+      ...successResponseSchema(InterviewSlotResponseDto),
+    },
+    unauthorized: CommonSwaggerResponses.unauthorized(
+      'access_token 쿠키가 없거나 만료되었습니다.',
+    ),
+    notFound: CommonSwaggerResponses.notFound(
+      '면접 슬롯을 찾을 수 없습니다.',
+      'INTERVIEW_SLOT_NOT_FOUND',
+    ),
+  },
+
+  updateSlot: {
+    success: {
+      status: 200,
+      description: '면접 슬롯이 수정되었습니다.',
+    },
+    unauthorized: CommonSwaggerResponses.unauthorized(
+      'access_token 쿠키가 없거나 만료되었습니다.',
+    ),
+    notFound: CommonSwaggerResponses.notFound(
+      '면접 슬롯을 찾을 수 없습니다.',
+      'INTERVIEW_SLOT_NOT_FOUND',
+    ),
+  },
+
+  deleteSlot: {
+    noContent: {
+      status: 204,
+      description: '면접 슬롯 삭제 성공',
+    },
+    unauthorized: CommonSwaggerResponses.unauthorized(
+      'access_token 쿠키가 없거나 만료되었습니다.',
+    ),
+    notFound: CommonSwaggerResponses.notFound(
+      '면접 슬롯을 찾을 수 없습니다.',
+      'INTERVIEW_SLOT_NOT_FOUND',
+    ),
+  },
+
+  createReservation: {
+    success: {
+      status: 201,
+      description: '면접 예약 생성 성공',
+      ...successResponseSchema(InterviewReservationResponseDto),
+    },
+    unauthorized: CommonSwaggerResponses.unauthorized(
+      'access_token 쿠키가 없거나 만료되었습니다.',
+    ),
+    notFound: CommonSwaggerResponses.notFound(
+      '슬롯 또는 지원서를 찾을 수 없습니다.',
+      'NOT_FOUND',
+    ),
+  },
+
+  cancelReservation: {
+    noContent: {
+      status: 204,
+      description: '면접 예약 취소 성공',
+    },
+    unauthorized: CommonSwaggerResponses.unauthorized(
+      'access_token 쿠키가 없거나 만료되었습니다.',
+    ),
+    notFound: CommonSwaggerResponses.notFound(
+      '면접 예약을 찾을 수 없습니다.',
+      'INTERVIEW_RESERVATION_NOT_FOUND',
+    ),
+  },
+} as const;

--- a/src/interview/interface/admin.interview.swagger.ts
+++ b/src/interview/interface/admin.interview.swagger.ts
@@ -1,6 +1,7 @@
 import {
   CommonSwaggerResponses,
   successListResponseSchema,
+  successNullResponseSchema,
   successResponseSchema,
 } from '../../common/swagger/response-schema';
 import {
@@ -54,6 +55,7 @@ export const AdminInterviewSwagger = {
     success: {
       status: 200,
       description: '면접 슬롯이 수정되었습니다.',
+      ...successNullResponseSchema('면접 슬롯이 수정되었습니다.'),
     },
     unauthorized: CommonSwaggerResponses.unauthorized(
       'access_token 쿠키가 없거나 만료되었습니다.',
@@ -87,9 +89,18 @@ export const AdminInterviewSwagger = {
     unauthorized: CommonSwaggerResponses.unauthorized(
       'access_token 쿠키가 없거나 만료되었습니다.',
     ),
-    notFound: CommonSwaggerResponses.notFound(
+    notFound: CommonSwaggerResponses.notFoundOneOf(
       '슬롯 또는 지원서를 찾을 수 없습니다.',
-      'NOT_FOUND',
+      [
+        {
+          code: 'INTERVIEW_SLOT_NOT_FOUND',
+          message: '면접 슬롯을 찾을 수 없습니다.',
+        },
+        {
+          code: 'APPLICATION_NOT_FOUND',
+          message: '해당 지원서를 찾을 수 없습니다.',
+        },
+      ],
     ),
   },
 


### PR DESCRIPTION
 ## ✅ PR 설명

  `AdminInterviewController` 의 `ApiDoc` 데코레이터가 `responses` 를 비워둔
  채로 등록되어 있어, OpenAPI 스펙상 success 응답 스키마가 누락되고 FE
  codegen 결과가 `void` 로 떨어지는 문제를 해결합니다.

  - `google-auth.swagger.ts` 패턴 따라 `AdminInterviewSwagger` 별도 파일로
  분리
  - 7개 엔드포인트 전체에 `success` / `unauthorized` / `notFound` 응답 연결
    - `interview_createSlot`
    - `interview_listSlots`
    - `interview_getSlot`
    - `interview_updateSlot`
    - `interview_deleteSlot`
    - `interview_createReservation`
    - `interview_cancelReservation`
  - 배열 응답 표현을 위해 `successListResponseSchema` 헬퍼 신규 추가
  (`src/common/swagger/response-schema.ts`)
  - 컨트롤러에 `@ApiExtraModels(InterviewSlotResponseDto,
  InterviewReservationResponseDto)` 추가하여 `$ref` 해석 보장

  > 동일한 문제로 `users/me` 도 별도 브랜치(`feat/users-me-endpoint`)에서
  먼저 수정 완료했고, 이 PR 은 interview 도메인만 다룹니다.

  ---

  ## 🧪 테스트 방법

  - [x] `npx tsc --noEmit` 통과 (기존 `interview.service.spec.ts` null 이슈
  외 신규 에러 없음)
  - [ ] 로컬에서 Swagger UI 열어 7개 엔드포인트 응답 스키마가
  `InterviewSlotResponseDto` / `InterviewReservationResponseDto` 로
  표시되는지 확인
  - [ ] FE 쪽 openapi codegen 재실행 시 `interviewListSlots` /
  `interviewGetSlot` / `interviewCreateReservation` 응답 타입이 더 이상
  `void` 가 아닌지 확인

  ---

  ## 🔍 체크리스트

  - [x] 코드에 주석/불필요한 로그 제거
  - [x] 코드 리뷰어가 이해하기 쉽게 커밋 정리

  ---

  ## 📎 기타 참고 사항

  - 런타임 동작 변경 없음 — 순수 Swagger 메타데이터만 추가
  - `successListResponseSchema` 는 향후 다른 목록형 엔드포인트에서도 재사용
  가능

