### PR TITLE
chore(infra): Caddy 로 FE 정적 서빙 분기 + frontend/current 부트스트랩

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,11 +56,12 @@ jobs:
             cd /opt/ddd-be
             umask 077
 
-            # Frontend placeholder bootstrap (FE 첫 배포 전에 Caddy 가 404 나지 않도록)
-            mkdir -p /opt/ddd-be/frontend/current
-            if [ ! -f /opt/ddd-be/frontend/current/index.html ]; then
-              echo '<!doctype html><title>DDD</title><h1>Frontend not deployed yet</h1>' \
-                > /opt/ddd-be/frontend/current/index.html
+            # Frontend bootstrap precondition (FE 팀 release 패턴: /opt/admin/frontend/current 가 symlink 여야 함)
+            # 최초 1회 VM 부트스트랩이 누락되면 여기서 실패 — docs/admin-deploy.md §A 참고
+            if [ ! -e /opt/admin/frontend/current ]; then
+              echo "ERROR: /opt/admin/frontend/current 가 없습니다. VM 1회 부트스트랩이 필요합니다."
+              echo "  ssh dddstudy1@<VM> 후 docs/admin-deploy.md §A 의 5줄 실행"
+              exit 1
             fi
 
             # Create GCP Service Account Key file

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,14 @@ jobs:
             sudo docker pull "$APP_IMAGE"
             cd /opt/ddd-be
             umask 077
-            
+
+            # Frontend placeholder bootstrap (FE 첫 배포 전에 Caddy 가 404 나지 않도록)
+            mkdir -p /opt/ddd-be/frontend/current
+            if [ ! -f /opt/ddd-be/frontend/current/index.html ]; then
+              echo '<!doctype html><title>DDD</title><h1>Frontend not deployed yet</h1>' \
+                > /opt/ddd-be/frontend/current/index.html
+            fi
+
             # Create GCP Service Account Key file
             echo "$GCP_SERVICE_ACCOUNT_JSON" > gcp-key.json
             

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,3 +1,14 @@
 admin.dddstudy.kr {
-    reverse_proxy app:3000
+    # 백엔드: API + Swagger
+    @backend {
+        path /api/* /api-docs*
+    }
+    reverse_proxy @backend app:3000
+
+    # 프론트엔드: 정적 파일 + SPA fallback (history 모드 지원)
+    root * /srv/frontend
+    # SPA 라우팅, 새로고침 시 404 안나게하기위해
+    try_files {path} /index.html
+    # 정적 파일 서빙 핸들러를 활성화
+    file_server
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       - "443:443"
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
+      - ./frontend/current:/srv/frontend:ro
       - caddy_data:/data
       - caddy_config:/config
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       - "443:443"
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
-      - ./frontend/current:/srv/frontend:ro
+      - /opt/admin/frontend/current:/srv/frontend:ro
       - caddy_data:/data
       - caddy_config:/config
     depends_on:


### PR DESCRIPTION
## Summary
- Caddy 에서 `/api/*`, `/api-docs*` 는 백엔드(`app:3000`)로, 그 외 모든 요청은 `/srv/frontend` 정적 파일 + SPA fallback 으로 분기
- `docker-compose.yml` caddy 서비스에 `./frontend/current:/srv/frontend:ro` 볼륨 마운트 추가 — FE 빌드 산출물을 Caddy 컨테이너에서 read-only 로 서빙
- `deploy.yml` 에 `frontend/current/` 디렉토리 + placeholder `index.html` 부트스트랩 추가 — FE 첫 배포 전 Caddy 가 404 나지 않도록

## 배경
FE 가 `admin.dddstudy.kr` 도메인을 공유해서 배포되도록 BE 인프라에서 선행되어야 하는 작업. 현재는 모든 요청이 `app:3000` 으로 통째로 reverse_proxy 되는 상태라 FE 정적 서빙 경로가 없음.

## 변경 후 동작
- `GET /api/v1/...` → NestJS 앱 (3000)
- `GET /api-docs`, `/api-docs-json` → Swagger UI/JSON (3000)
- 그 외 `GET /*` → `/srv/frontend/{path}` 정적 파일, 없으면 `/index.html` 로 폴백 (SPA history 라우팅 지원)

## FE 측 후속 작업 (참고)
- FE 파이프라인이 빌드 산출물을 VM `/opt/ddd-be/frontend/current/` 로 업로드해야 함
- placeholder 가 이미 있으면 덮어쓰지 않는 가드를 두었으므로 (`if [ ! -f ... ]`), 이미 배포된 산출물을 BE 재배포가 망가뜨리진 않음

## 남은 환경변수 확인
- GitHub Secrets 의 `CLIENT_REDIRECT_URL` 이 `https://admin.dddstudy.kr/applications` 인지 확인 필요
- Google/Discord OAuth 콘솔의 redirect URI 가 `admin.dddstudy.kr` 도메인을 가리키는지 확인 필요

## Test plan
- [ ] PR 머지 후 deploy 워크플로 정상 통과 확인
- [ ] VM 에 `/opt/ddd-be/frontend/current/index.html` placeholder 생성 확인
- [ ] `curl https://admin.dddstudy.kr/api/v1/health` → 정상 응답 (백엔드 분기)
- [ ] `curl https://admin.dddstudy.kr/` → placeholder HTML 노출 (정적 서빙 분기)
- [ ] `curl https://admin.dddstudy.kr/some-random-path` → placeholder HTML (SPA fallback)
- [ ] FE 첫 배포 후 `current/index.html` 이 실제 빌드물로 교체되었는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)