### PR TITLE
fix(infra): 배포 후 caddy reload 추가로 Caddyfile 변경분 즉시 반영

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,6 +118,13 @@ jobs:
             printf 'DISCORD_ROLE_ID_AOS=%s\n' "$DISCORD_ROLE_ID_AOS" >> .env.production
             
             sudo APP_ENV_FILE=.env.production docker compose --env-file .env.production up -d
+
+            # Caddyfile 변경분 즉시 반영 (zero-downtime reload)
+            # docker compose up -d 는 이미지/마운트가 동일하면 caddy 컨테이너를 재생성하지 않으므로
+            # Caddyfile 만 바뀐 배포에서는 컨테이너 안 메모리 설정이 옛 상태로 남는다.
+            sudo docker exec ddd-be-caddy caddy reload \
+              --config /etc/caddy/Caddyfile --adapter caddyfile
+
             for i in $(seq 1 12); do
               curl -sf "http://localhost:${APP_PORT:-3000}/api/v1/health" && break
               if [ "$i" -eq 12 ]; then


### PR DESCRIPTION
## 개요
배포 워크플로에서 `docker compose up -d` 직후 `caddy reload` 를 명시적으로 호출해, Caddyfile 만 바뀐 배포에서도 변경분이 메모리에 즉시 반영되도록 합니다.

## 변경 이유
오늘 admin.dddstudy.kr 의 `/api/*` 요청 (`/api/v1/health`, `/api/api-docs`, OAuth 라우트 포함) 이 BE 로 가지 않고 SPA fallback HTML 을 반환하던 사고가 있었습니다.

원인은 다음과 같았습니다.
- 레포의 Caddyfile 에는 `handle /api/*` 분기가 이미 있었고, VM 디스크 (`/opt/ddd-be/Caddyfile`) 및 caddy 컨테이너 안 (`/etc/caddy/Caddyfile`) 둘 다 최신 상태였습니다.
- 그러나 `docker compose up -d` 는 이미지/마운트가 동일하면 컨테이너를 재생성하지 않으므로, caddy 프로세스는 옛 설정을 메모리에 그대로 들고 있었습니다.
- 그 결과 `/api/*` 가 라우팅되지 않고 SPA fallback 으로 떨어졌습니다.

수동으로 `docker exec ddd-be-caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile` 을 실행하면 즉시 정상화되는 것을 확인했습니다. 이 동작을 배포 파이프라인에 영구화합니다.

## 주요 변경 사항
- `.github/workflows/deploy.yml` 의 deploy 스크립트에서 `compose up -d` 와 health check 사이에 `docker exec ddd-be-caddy caddy reload` 한 단계 추가.
- 동일 트레이드오프 (zero-downtime, 실패 시 배포 중단) 를 의도하여 별도 fallback 없이 일반 명령으로 호출합니다.

## 아키텍처 영향
- 도메인 분리: 영향 없음
- 레이어 변경: 영향 없음
- 의존 방향 영향: 영향 없음
- 트랜잭션 경계 영향: 영향 없음
- 인프라/배포 워크플로 한정 변경입니다.

## 테스트
- [x] 운영 VM 에서 수동 `caddy reload` 동일 명령으로 `/api/*` 정상화 확인
  - `curl -ik https://admin.dddstudy.kr/api/v1/health` → 200 + JSON
  - `curl -ik https://admin.dddstudy.kr/api/api-docs` → 200 + Swagger UI
  - `curl -ik https://admin.dddstudy.kr/api/v1/auth/google` → 302 + accounts.google.com
- [ ] 다음 main 배포 시 워크플로 통과 확인 필요

## 리뷰 포인트
- caddy reload 가 실패할 때 배포가 멈추는 게 의도적입니다 (Caddyfile 문법 오류 등을 무시하면 동일 사고 재발). 만약 reload 실패 시에도 진행을 원한다면 `|| true` 를 붙이는 변형 가능성이 있습니다 — 현재는 의도적으로 추가하지 않았습니다.
- caddy 컨테이너 이름 `ddd-be-caddy` 가 `docker-compose.yml` 의 `container_name` 과 일치합니다. 컨테이너 이름이 변경되면 이 명령도 같이 갱신 필요.

## 리스크 / 후속 작업
- 컨테이너가 아직 ready 가 아닐 가능성은 낮지만 (caddy 가 매우 빨리 뜸), 향후 문제가 생기면 짧은 대기 또는 `--filter status=running` 가드 추가 검토.
- 초기 부트스트랩 (caddy 컨테이너가 처음 생성되는 배포) 시점에는 `docker exec` 가 이미 떠 있는 컨테이너에 붙으므로 정상 동작 예상.

## 관련 이슈
- 없음 (운영 사고 대응)