### PR TITLE
docs(swagger): 사전 알림 일괄 발송 응답 스키마 노출

### DIFF
--- a/src/notification/interface/admin.early-notification.controller.ts
+++ b/src/notification/interface/admin.early-notification.controller.ts
@@ -10,7 +10,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiExtraModels, ApiTags } from '@nestjs/swagger';
 import type { Response } from 'express';
 
 import { Roles } from '../../common/decorator/roles.decorator';
@@ -19,14 +19,19 @@ import { ApiResponse } from '../../common/response/api-response';
 import { ApiDoc } from '../../common/swagger/api-doc.decorator';
 import { UserRole } from '../../user/domain/user.role';
 import { EarlyNotificationService } from '../application/early-notification.service';
+import { AdminEarlyNotificationSwagger } from './admin.early-notification.swagger';
 import {
   ExportAdminEarlyNotificationsQueryDto,
   FindAdminEarlyNotificationsQueryDto,
   SendBulkEarlyNotificationRequestDto,
 } from './dto/admin-early-notification.request.dto';
-import { AdminEarlyNotificationResponseDto } from './dto/admin-early-notification.response.dto';
+import {
+  AdminEarlyNotificationResponseDto,
+  SendBulkEarlyNotificationResponseDto,
+} from './dto/admin-early-notification.response.dto';
 
 @ApiTags('Admin - Early Notification')
+@ApiExtraModels(SendBulkEarlyNotificationResponseDto)
 @Controller({ path: 'admin/early-notifications', version: '1' })
 @UseGuards(AuthGuard('jwt'), RolesGuard)
 @Roles(UserRole.계정관리, UserRole.운영자)
@@ -74,6 +79,10 @@ export class AdminEarlyNotificationController {
     description: '기수별 미발송 대상에게 사전 알림 이메일을 일괄 발송합니다.',
     operationId: 'earlyNotification_sendBulk',
     auth: true,
+    responses: [
+      AdminEarlyNotificationSwagger.sendBulk.success,
+      AdminEarlyNotificationSwagger.sendBulk.unauthorized,
+    ],
   })
   @HttpCode(HttpStatus.OK)
   @Post('send')

--- a/src/notification/interface/admin.early-notification.swagger.ts
+++ b/src/notification/interface/admin.early-notification.swagger.ts
@@ -1,0 +1,20 @@
+import {
+  CommonSwaggerResponses,
+  successResponseSchema,
+} from '../../common/swagger/response-schema';
+import { SendBulkEarlyNotificationResponseDto } from './dto/admin-early-notification.response.dto';
+
+/**
+ * AdminEarlyNotificationController Swagger 응답 스키마 정의
+ * 컨트롤러 가독성 보호를 위해 별도 파일로 분리
+ */
+export const AdminEarlyNotificationSwagger = {
+  sendBulk: {
+    success: {
+      status: 200,
+      description: '발송이 완료되었습니다. 부분 실패 여부는 failed 값으로 판단합니다.',
+      ...successResponseSchema(SendBulkEarlyNotificationResponseDto),
+    },
+    unauthorized: CommonSwaggerResponses.unauthorized('access_token 쿠키가 없거나 만료되었습니다.'),
+  },
+};


### PR DESCRIPTION
## 배경

`POST /api/v1/admin/early-notifications/send` 는 `{ total, success, failed }` 를 반환하지만 Swagger 에 응답 스키마가 등록되어 있지 않았습니다. 그래서 OpenAPI 산출물에 `content: never` 로 나갔고, 프론트는 생성 타입으로 발송 결과를 받을 수 없었습니다.

그 결과 어드민 일괄 발송에서 **일부 대상 발송이 실패해도 전량 성공으로 표시**되고 있었습니다.

## 변경

- `admin.early-notification.swagger.ts` 신규 — `interview` 모듈과 동일한 `{module}.swagger.ts` 패턴
- 컨트롤러에 `@ApiExtraModels(SendBulkEarlyNotificationResponseDto)` 추가
- `sendBulk` 에 200 / 401 응답 정의 연결

`SendBulkEarlyNotificationResponseDto` 는 이미 정의되어 있던 DTO 이고, 이번 변경은 이를 Swagger 에 노출하기만 합니다. **런타임 동작 변경은 없습니다.**

## 검증

- `tsc --noEmit` 통과 (`interview.service.spec.ts` 기존 오류 2건은 본 변경과 무관)
- `eslint --fix` 잔여 경고 없음
- 로컬 기동 후 `/api/api-docs-json` 확인
  - `components.schemas.SendBulkEarlyNotificationResponseDto` 등록됨
  - `200.content['application/json'].properties.data` 가 해당 스키마를 `$ref` 로 참조
- 프론트에서 `pnpm gen:api` 재생성 시 해당 엔드포인트만 변경됨 (43줄 추가)

## 후속

프론트 대응은 DDD_FE 에서 별도 진행합니다 (발송 결과 `failed > 0` 시 경고 토스트 분기).

기수 미지정 대기열(`general_early_notifications`) 의 **어드민 조회 엔드포인트가 없는 이슈**는 이번 PR 범위 밖입니다. 기수를 생성하기 전에는 대기자 수를 어드민에서 확인할 수 없습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)