### PR TITLE
feat(notification): 사전 알림 대기열 가시성 확보 및 승격·신청 가드 추가

### DIFF
--- a/src/common/error/error-message.ts
+++ b/src/common/error/error-message.ts
@@ -39,6 +39,7 @@ export const ErrorMessage = {
   PROJECT_NOT_FOUND: '프로젝트를 찾을 수 없습니다.',
 
   EARLY_NOTIFICATION_CONFLICT: '사전 알림 처리 중 일시적인 충돌이 발생했습니다. 다시 시도해주세요.',
+  EARLY_NOTIFICATION_COHORT_CLOSED: '모집이 종료된 기수에는 사전 알림을 신청할 수 없습니다.',
   GENERAL_EARLY_NOTIFICATION_CONFLICT:
     '대기열 사전 알림 처리 중 일시적인 충돌이 발생했습니다. 다시 시도해주세요.',
   NOTIFICATION_CAMPAIGN_NOT_FOUND: '사전 알림 캠페인을 찾을 수 없습니다.',

--- a/src/notification/application/early-notification.service.spec.ts
+++ b/src/notification/application/early-notification.service.spec.ts
@@ -9,6 +9,7 @@ import { Test } from '@nestjs/testing';
 import { QueryFailedError } from 'typeorm';
 
 import { CohortRepository } from '../../cohort/domain/cohort.repository';
+import { CohortStatus } from '../../cohort/domain/cohort.status';
 import { AppException } from '../../common/exception/app.exception';
 import { EarlyNotificationRepository } from '../domain/early-notification.repository';
 import { EarlyNotificationService } from './early-notification.service';
@@ -62,10 +63,30 @@ describe('EarlyNotificationService', () => {
       expect(mockCohortRepository.findById).toHaveBeenCalledWith({ id: 1 });
     });
 
+    it('CLOSED 기수면 EARLY_NOTIFICATION_COHORT_CLOSED 예외를 던진다', async () => {
+      // Given
+      mockCohortRepository.findById.mockResolvedValue({
+        id: 1,
+        name: '16기',
+        status: CohortStatus.CLOSED,
+      });
+
+      // When & Then
+      await expect(earlyNotificationService.subscribe(payload)).rejects.toThrow(
+        new AppException('EARLY_NOTIFICATION_COHORT_CLOSED', HttpStatus.BAD_REQUEST),
+      );
+      expect(mockEarlyNotificationRepository.findOne).not.toHaveBeenCalled();
+      expect(mockEarlyNotificationRepository.register).not.toHaveBeenCalled();
+    });
+
     it('이미 신청한 이메일이면 기존 레코드를 반환한다', async () => {
       // Given
       const found = { id: 10, cohortId: 1, email: 'test@example.com', notifiedAt: null };
-      mockCohortRepository.findById.mockResolvedValue({ id: 1, name: '16기' });
+      mockCohortRepository.findById.mockResolvedValue({
+        id: 1,
+        name: '16기',
+        status: CohortStatus.ACTIVE,
+      });
       mockEarlyNotificationRepository.findOne.mockResolvedValue(found);
 
       // When
@@ -76,28 +97,35 @@ describe('EarlyNotificationService', () => {
       expect(mockEarlyNotificationRepository.register).not.toHaveBeenCalled();
     });
 
-    it('신규 이메일이면 등록하고 반환한다', async () => {
-      // Given
-      const created = { id: 11, cohortId: 1, email: 'test@example.com', notifiedAt: null };
-      mockCohortRepository.findById.mockResolvedValue({ id: 1, name: '16기' });
-      mockEarlyNotificationRepository.findOne.mockResolvedValue(null);
-      mockEarlyNotificationRepository.register.mockResolvedValue(created);
+    it.each([CohortStatus.UPCOMING, CohortStatus.RECRUITING, CohortStatus.ACTIVE])(
+      '%s 기수면 신규 이메일을 등록하고 반환한다',
+      async (status) => {
+        // Given
+        const created = { id: 11, cohortId: 1, email: 'test@example.com', notifiedAt: null };
+        mockCohortRepository.findById.mockResolvedValue({ id: 1, name: '16기', status });
+        mockEarlyNotificationRepository.findOne.mockResolvedValue(null);
+        mockEarlyNotificationRepository.register.mockResolvedValue(created);
 
-      // When
-      const result = await earlyNotificationService.subscribe(payload);
+        // When
+        const result = await earlyNotificationService.subscribe(payload);
 
-      // Then
-      expect(result).toBe(created);
-      expect(mockEarlyNotificationRepository.register).toHaveBeenCalledWith({
-        cohortId: 1,
-        email: 'test@example.com',
-      });
-    });
+        // Then
+        expect(result).toBe(created);
+        expect(mockEarlyNotificationRepository.register).toHaveBeenCalledWith({
+          cohortId: 1,
+          email: 'test@example.com',
+        });
+      },
+    );
 
     it('동시 요청으로 unique 제약 위반 시 기존 레코드를 반환한다', async () => {
       // Given
       const record = { id: 12, cohortId: 1, email: 'test@example.com', notifiedAt: null };
-      mockCohortRepository.findById.mockResolvedValue({ id: 1, name: '16기' });
+      mockCohortRepository.findById.mockResolvedValue({
+        id: 1,
+        name: '16기',
+        status: CohortStatus.ACTIVE,
+      });
       mockEarlyNotificationRepository.findOne
         .mockResolvedValueOnce(null)
         .mockResolvedValueOnce(record);
@@ -118,7 +146,11 @@ describe('EarlyNotificationService', () => {
 
     it('unique 제약 위반 후 재조회 결과가 null이면 EARLY_NOTIFICATION_CONFLICT(409)를 던진다', async () => {
       // Given
-      mockCohortRepository.findById.mockResolvedValue({ id: 1, name: '16기' });
+      mockCohortRepository.findById.mockResolvedValue({
+        id: 1,
+        name: '16기',
+        status: CohortStatus.ACTIVE,
+      });
       mockEarlyNotificationRepository.findOne
         .mockResolvedValueOnce(null)
         .mockResolvedValueOnce(null);

--- a/src/notification/application/early-notification.service.ts
+++ b/src/notification/application/early-notification.service.ts
@@ -1,6 +1,7 @@
 import { HttpStatus, Injectable, Logger } from '@nestjs/common';
 
 import { CohortRepository } from '../../cohort/domain/cohort.repository';
+import { CohortStatus } from '../../cohort/domain/cohort.status';
 import { AppException } from '../../common/exception/app.exception';
 import { isPostgresUniqueViolation } from '../../common/util/postgres-error';
 import { EarlyNotificationRepository } from '../domain/early-notification.repository';
@@ -52,6 +53,9 @@ export class EarlyNotificationService {
     const cohort = await this.cohortRepository.findById({ id: cohortId });
     if (!cohort) {
       throw new AppException('COHORT_NOT_FOUND', HttpStatus.NOT_FOUND);
+    }
+    if (cohort.status === CohortStatus.CLOSED) {
+      throw new AppException('EARLY_NOTIFICATION_COHORT_CLOSED', HttpStatus.BAD_REQUEST);
     }
 
     const found = await this.earlyNotificationRepository.findOne({ cohortId, email });

--- a/src/notification/application/general-early-notification.service.spec.ts
+++ b/src/notification/application/general-early-notification.service.spec.ts
@@ -8,6 +8,8 @@ import { HttpStatus } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { QueryFailedError } from 'typeorm';
 
+import { CohortRepository } from '../../cohort/domain/cohort.repository';
+import { CohortStatus } from '../../cohort/domain/cohort.status';
 import { AppException } from '../../common/exception/app.exception';
 import { EarlyNotificationRepository } from '../domain/early-notification.repository';
 import { GeneralEarlyNotificationRepository } from '../domain/general-early-notification.repository';
@@ -15,6 +17,7 @@ import { GeneralEarlyNotificationService } from './general-early-notification.se
 
 const mockGeneralEarlyNotificationRepository = {
   register: jest.fn(),
+  findAll: jest.fn(),
   findUnpromotedByEmail: jest.fn(),
   findUnpromoted: jest.fn(),
   markManyPromoted: jest.fn(),
@@ -27,6 +30,10 @@ const mockEarlyNotificationRepository = {
   findOne: jest.fn(),
   findManyByIds: jest.fn(),
   markManyNotified: jest.fn(),
+};
+
+const mockCohortRepository = {
+  findById: jest.fn(),
 };
 
 const makeUniqueViolation = () => {
@@ -47,11 +54,16 @@ describe('GeneralEarlyNotificationService', () => {
           useValue: mockGeneralEarlyNotificationRepository,
         },
         { provide: EarlyNotificationRepository, useValue: mockEarlyNotificationRepository },
+        { provide: CohortRepository, useValue: mockCohortRepository },
       ],
     }).compile();
 
     service = moduleRef.get(GeneralEarlyNotificationService);
     jest.clearAllMocks();
+    mockCohortRepository.findById.mockResolvedValue({
+      id: 10,
+      status: CohortStatus.UPCOMING,
+    });
   });
 
   describe('subscribe', () => {
@@ -114,6 +126,38 @@ describe('GeneralEarlyNotificationService', () => {
     });
   });
 
+  describe('findForAdmin', () => {
+    it('onlyUnpromoted가 true면 미승격 필터를 전달한다', async () => {
+      // Given
+      const records = [{ id: 1, email: 'pending@example.com', promotedAt: null }];
+      mockGeneralEarlyNotificationRepository.findAll.mockResolvedValue(records);
+
+      // When
+      const result = await service.findForAdmin({ onlyUnpromoted: true });
+
+      // Then
+      expect(result).toBe(records);
+      expect(mockGeneralEarlyNotificationRepository.findAll).toHaveBeenCalledWith({
+        onlyUnpromoted: true,
+      });
+    });
+
+    it('onlyUnpromoted가 없으면 전체 조회 조건을 전달한다', async () => {
+      // Given
+      const records = [{ id: 2, email: 'all@example.com', promotedAt: new Date() }];
+      mockGeneralEarlyNotificationRepository.findAll.mockResolvedValue(records);
+
+      // When
+      const result = await service.findForAdmin({});
+
+      // Then
+      expect(result).toBe(records);
+      expect(mockGeneralEarlyNotificationRepository.findAll).toHaveBeenCalledWith({
+        onlyUnpromoted: undefined,
+      });
+    });
+  });
+
   describe('promoteToCohort', () => {
     it('대기열이 비어있으면 0건을 반환하고 추가 호출이 없다', async () => {
       // Given
@@ -129,7 +173,7 @@ describe('GeneralEarlyNotificationService', () => {
       expect(mockGeneralEarlyNotificationRepository.markManyPromoted).not.toHaveBeenCalled();
     });
 
-    it('모두 신규면 전부 등록하고 일괄 promoted 처리한다', async () => {
+    it('UPCOMING 기수이고 모두 신규면 전부 등록하고 일괄 promoted 처리한다', async () => {
       // Given
       const waitlist = [
         { id: 1, email: 'a@test.com' },
@@ -144,6 +188,7 @@ describe('GeneralEarlyNotificationService', () => {
 
       // Then
       expect(result).toEqual({ total: 2, promoted: 2, skippedDuplicate: 0 });
+      expect(mockCohortRepository.findById).toHaveBeenCalledWith({ id: 10 });
       expect(mockEarlyNotificationRepository.findByCohort).toHaveBeenCalledWith({ cohortId: 10 });
       expect(mockEarlyNotificationRepository.register).toHaveBeenCalledTimes(2);
       expect(mockEarlyNotificationRepository.register).toHaveBeenNthCalledWith(1, {
@@ -159,6 +204,78 @@ describe('GeneralEarlyNotificationService', () => {
         promotedAt: expect.any(Date) as unknown,
         cohortId: 10,
       });
+    });
+
+    it('RECRUITING 기수면 대기열을 승격한다', async () => {
+      // Given
+      const waitlist = [{ id: 1, email: 'a@test.com' }];
+      mockCohortRepository.findById.mockResolvedValue({
+        id: 10,
+        status: CohortStatus.RECRUITING,
+      });
+      mockGeneralEarlyNotificationRepository.findUnpromoted.mockResolvedValue(waitlist);
+      mockEarlyNotificationRepository.findByCohort.mockResolvedValue([]);
+      mockEarlyNotificationRepository.register.mockResolvedValue(undefined);
+
+      // When
+      const result = await service.promoteToCohort({ cohortId: 10 });
+
+      // Then
+      expect(result).toEqual({ total: 1, promoted: 1, skippedDuplicate: 0 });
+      expect(mockEarlyNotificationRepository.register).toHaveBeenCalledWith({
+        cohortId: 10,
+        email: 'a@test.com',
+      });
+      expect(mockGeneralEarlyNotificationRepository.markManyPromoted).toHaveBeenCalledWith({
+        ids: [1],
+        promotedAt: expect.any(Date) as unknown,
+        cohortId: 10,
+      });
+    });
+
+    it.each([CohortStatus.ACTIVE, CohortStatus.CLOSED])(
+      '%s 기수면 대기열을 보존하고 승격을 건너뛴다',
+      async (status) => {
+        // Given
+        const waitlist = [{ id: 1, email: 'a@test.com' }];
+        mockCohortRepository.findById.mockResolvedValue({ id: 10, status });
+        mockGeneralEarlyNotificationRepository.findUnpromoted.mockResolvedValue(waitlist);
+
+        // When
+        const result = await service.promoteToCohort({ cohortId: 10 });
+
+        // Then
+        expect(result).toEqual({
+          total: 1,
+          promoted: 0,
+          skippedDuplicate: 0,
+          skippedReason: 'COHORT_NOT_PROMOTABLE',
+        });
+        expect(mockEarlyNotificationRepository.findByCohort).not.toHaveBeenCalled();
+        expect(mockEarlyNotificationRepository.register).not.toHaveBeenCalled();
+        expect(mockGeneralEarlyNotificationRepository.markManyPromoted).not.toHaveBeenCalled();
+      },
+    );
+
+    it('대상 기수가 없으면 대기열을 보존하고 승격을 건너뛴다', async () => {
+      // Given
+      const waitlist = [{ id: 1, email: 'a@test.com' }];
+      mockCohortRepository.findById.mockResolvedValue(null);
+      mockGeneralEarlyNotificationRepository.findUnpromoted.mockResolvedValue(waitlist);
+
+      // When
+      const result = await service.promoteToCohort({ cohortId: 10 });
+
+      // Then
+      expect(result).toEqual({
+        total: 1,
+        promoted: 0,
+        skippedDuplicate: 0,
+        skippedReason: 'COHORT_NOT_PROMOTABLE',
+      });
+      expect(mockEarlyNotificationRepository.findByCohort).not.toHaveBeenCalled();
+      expect(mockEarlyNotificationRepository.register).not.toHaveBeenCalled();
+      expect(mockGeneralEarlyNotificationRepository.markManyPromoted).not.toHaveBeenCalled();
     });
 
     it('이미 그 기수에 등록된 이메일은 skippedDuplicate로 처리하고 register는 호출하지 않는다', async () => {

--- a/src/notification/application/general-early-notification.service.ts
+++ b/src/notification/application/general-early-notification.service.ts
@@ -1,6 +1,8 @@
-import { HttpStatus, Injectable } from '@nestjs/common';
+import { HttpStatus, Injectable, Logger } from '@nestjs/common';
 import { Transactional } from 'typeorm-transactional';
 
+import { CohortRepository } from '../../cohort/domain/cohort.repository';
+import { CohortStatus } from '../../cohort/domain/cohort.status';
 import { AppException } from '../../common/exception/app.exception';
 import { isPostgresUniqueViolation } from '../../common/util/postgres-error';
 import { EarlyNotificationRepository } from '../domain/early-notification.repository';
@@ -18,13 +20,17 @@ export type PromoteToCohortResult = {
   total: number;
   promoted: number;
   skippedDuplicate: number;
+  skippedReason?: 'COHORT_NOT_PROMOTABLE';
 };
 
 @Injectable()
 export class GeneralEarlyNotificationService {
+  private readonly logger = new Logger(GeneralEarlyNotificationService.name);
+
   constructor(
     private readonly generalEarlyNotificationRepository: GeneralEarlyNotificationRepository,
     private readonly earlyNotificationRepository: EarlyNotificationRepository,
+    private readonly cohortRepository: CohortRepository,
   ) {}
 
   async subscribe({ email }: SubscribePayload) {
@@ -49,9 +55,28 @@ export class GeneralEarlyNotificationService {
     }
   }
 
+  async findForAdmin({ onlyUnpromoted }: { onlyUnpromoted?: boolean }) {
+    return this.generalEarlyNotificationRepository.findAll({ onlyUnpromoted });
+  }
+
   @Transactional()
   async promoteToCohort({ cohortId }: PromoteToCohortPayload): Promise<PromoteToCohortResult> {
+    const cohort = await this.cohortRepository.findById({ id: cohortId });
     const waitlist = await this.generalEarlyNotificationRepository.findUnpromoted();
+
+    const isPromotable =
+      cohort?.status === CohortStatus.UPCOMING || cohort?.status === CohortStatus.RECRUITING;
+    if (!isPromotable) {
+      const status = cohort?.status ?? 'NOT_FOUND';
+      this.logger.warn(`대기열 승격 건너뜀: cohortId=${cohortId}, status=${status}`);
+      return {
+        total: waitlist.length,
+        promoted: 0,
+        skippedDuplicate: 0,
+        skippedReason: 'COHORT_NOT_PROMOTABLE',
+      };
+    }
+
     if (waitlist.length === 0) {
       return { total: 0, promoted: 0, skippedDuplicate: 0 };
     }

--- a/src/notification/domain/general-early-notification.repository.ts
+++ b/src/notification/domain/general-early-notification.repository.ts
@@ -24,6 +24,13 @@ export class GeneralEarlyNotificationRepository {
     });
   }
 
+  async findAll({ onlyUnpromoted }: { onlyUnpromoted?: boolean }) {
+    return this.writeRepository.findMany({
+      where: onlyUnpromoted ? { promotedAtIsNull: true } : {},
+      order: { createdAt: 'DESC', id: 'DESC' },
+    });
+  }
+
   async markManyPromoted({
     ids,
     promotedAt,

--- a/src/notification/infrastructure/general-early-notification.write.repository.spec.ts
+++ b/src/notification/infrastructure/general-early-notification.write.repository.spec.ts
@@ -1,0 +1,84 @@
+import type { DataSource, Repository } from 'typeorm';
+import { IsNull } from 'typeorm';
+
+import { GeneralEarlyNotification } from '../domain/general-early-notification.entity';
+import { GeneralEarlyNotificationWriteRepository } from './general-early-notification.write.repository';
+
+describe('GeneralEarlyNotificationWriteRepository', () => {
+  describe('findMany', () => {
+    it('미승격 필터와 복합 정렬을 적용해 조회한다', async () => {
+      const find = jest.fn();
+      const repository = {
+        find,
+      } as unknown as Repository<GeneralEarlyNotification>;
+      const dataSource = {
+        getRepository: jest.fn().mockReturnValueOnce(repository),
+      } as unknown as DataSource;
+      const writeRepository = new GeneralEarlyNotificationWriteRepository(dataSource);
+
+      await writeRepository.findMany({
+        where: { promotedAtIsNull: true },
+        order: { createdAt: 'DESC', id: 'DESC' },
+      });
+
+      expect(find).toHaveBeenCalledWith({
+        where: { promotedAt: IsNull() },
+        order: { createdAt: 'DESC', id: 'DESC' },
+      });
+    });
+
+    it('order가 없으면 빈 where와 undefined order로 조회한다', async () => {
+      const find = jest.fn();
+      const repository = {
+        find,
+      } as unknown as Repository<GeneralEarlyNotification>;
+      const dataSource = {
+        getRepository: jest.fn().mockReturnValueOnce(repository),
+      } as unknown as DataSource;
+      const writeRepository = new GeneralEarlyNotificationWriteRepository(dataSource);
+
+      await writeRepository.findMany({ where: {} });
+
+      expect(find).toHaveBeenCalledWith({ where: {}, order: undefined });
+    });
+
+    it('email 필터를 그대로 적용해 조회한다', async () => {
+      const find = jest.fn();
+      const repository = {
+        find,
+      } as unknown as Repository<GeneralEarlyNotification>;
+      const dataSource = {
+        getRepository: jest.fn().mockReturnValueOnce(repository),
+      } as unknown as DataSource;
+      const writeRepository = new GeneralEarlyNotificationWriteRepository(dataSource);
+
+      await writeRepository.findMany({ where: { email: 'a@b.com' } });
+
+      expect(find).toHaveBeenCalledWith({
+        where: { email: 'a@b.com' },
+        order: undefined,
+      });
+    });
+  });
+
+  describe('updatePromotion', () => {
+    it('ids가 빈 배열이면 update를 호출하지 않는다', async () => {
+      const update = jest.fn();
+      const repository = {
+        update,
+      } as unknown as Repository<GeneralEarlyNotification>;
+      const dataSource = {
+        getRepository: jest.fn().mockReturnValueOnce(repository),
+      } as unknown as DataSource;
+      const writeRepository = new GeneralEarlyNotificationWriteRepository(dataSource);
+
+      await writeRepository.updatePromotion({
+        ids: [],
+        promotedAt: new Date('2026-08-12T00:00:00.000Z'),
+        cohortId: 1,
+      });
+
+      expect(update).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/notification/infrastructure/general-early-notification.write.repository.ts
+++ b/src/notification/infrastructure/general-early-notification.write.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { DataSource, In, IsNull, Repository } from 'typeorm';
+import { DataSource, FindOptionsOrder, In, IsNull, Repository } from 'typeorm';
 
 import { GeneralEarlyNotification } from '../domain/general-early-notification.entity';
 import type { GeneralEarlyNotificationFilter } from './general-early-notification.write.repository.type';
@@ -20,8 +20,14 @@ export class GeneralEarlyNotificationWriteRepository {
     return this.repository.findOne({ where: this.buildWhere(where) });
   }
 
-  async findMany({ where }: { where: GeneralEarlyNotificationFilter }) {
-    return this.repository.find({ where: this.buildWhere(where) });
+  async findMany({
+    where,
+    order,
+  }: {
+    where: GeneralEarlyNotificationFilter;
+    order?: FindOptionsOrder<GeneralEarlyNotification>;
+  }) {
+    return this.repository.find({ where: this.buildWhere(where), order });
   }
 
   async exists({ where }: { where: GeneralEarlyNotificationFilter }) {

--- a/src/notification/interface/admin.general-early-notification.controller.ts
+++ b/src/notification/interface/admin.general-early-notification.controller.ts
@@ -1,0 +1,37 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { ApiTags } from '@nestjs/swagger';
+
+import { Roles } from '../../common/decorator/roles.decorator';
+import { RolesGuard } from '../../common/guard/roles.guard';
+import { ApiResponse } from '../../common/response/api-response';
+import { ApiDoc } from '../../common/swagger/api-doc.decorator';
+import { UserRole } from '../../user/domain/user.role';
+import { GeneralEarlyNotificationService } from '../application/general-early-notification.service';
+import { FindAdminGeneralEarlyNotificationsQueryDto } from './dto/admin-general-early-notification.request.dto';
+import { AdminGeneralEarlyNotificationResponseDto } from './dto/admin-general-early-notification.response.dto';
+
+@ApiTags('Admin - Early Notification')
+@Controller({ path: 'admin/early-notifications/general', version: '1' })
+@UseGuards(AuthGuard('jwt'), RolesGuard)
+@Roles(UserRole.계정관리, UserRole.운영자)
+export class AdminGeneralEarlyNotificationController {
+  constructor(private readonly generalEarlyNotificationService: GeneralEarlyNotificationService) {}
+
+  @ApiDoc({
+    summary: '대기열 사전 알림 목록 조회',
+    description: '기수 미지정 사전 알림 대기열(승격 전 신청자) 목록을 조회합니다.',
+    operationId: 'earlyNotification_getAdminGeneralList',
+    auth: true,
+  })
+  @Get()
+  async findList(@Query() query: FindAdminGeneralEarlyNotificationsQueryDto) {
+    const records = await this.generalEarlyNotificationService.findForAdmin({
+      onlyUnpromoted: query.onlyUnpromoted,
+    });
+
+    return ApiResponse.ok(
+      records.map((record) => AdminGeneralEarlyNotificationResponseDto.from(record)),
+    );
+  }
+}

--- a/src/notification/interface/dto/admin-general-early-notification.request.dto.ts
+++ b/src/notification/interface/dto/admin-general-early-notification.request.dto.ts
@@ -1,0 +1,21 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { IsBoolean, IsOptional } from 'class-validator';
+
+export class FindAdminGeneralEarlyNotificationsQueryDto {
+  @ApiPropertyOptional({ description: '미승격 대상만 조회', example: true })
+  @IsOptional()
+  @Transform(({ value }) => {
+    if (value === 'true' || value === true) {
+      return true;
+    }
+
+    if (value === 'false' || value === false) {
+      return false;
+    }
+
+    return value as boolean;
+  })
+  @IsBoolean()
+  onlyUnpromoted?: boolean;
+}

--- a/src/notification/interface/dto/admin-general-early-notification.response.dto.ts
+++ b/src/notification/interface/dto/admin-general-early-notification.response.dto.ts
@@ -1,0 +1,30 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+import { GeneralEarlyNotification } from '../../domain/general-early-notification.entity';
+
+export class AdminGeneralEarlyNotificationResponseDto {
+  @ApiProperty({ description: 'ID', example: 1 })
+  id: number;
+
+  @ApiProperty({ description: '이메일 주소', example: 'user@example.com' })
+  email: string;
+
+  @ApiProperty({ description: '생성 일시' })
+  createdAt: Date;
+
+  @ApiPropertyOptional({ description: '승격 일시', nullable: true })
+  promotedAt: Date | null;
+
+  @ApiPropertyOptional({ description: '승격 대상 기수 ID', nullable: true })
+  promotedToCohortId: number | null;
+
+  static from(record: GeneralEarlyNotification): AdminGeneralEarlyNotificationResponseDto {
+    const dto = new AdminGeneralEarlyNotificationResponseDto();
+    dto.id = record.id;
+    dto.email = record.email;
+    dto.createdAt = record.createdAt;
+    dto.promotedAt = record.promotedAt;
+    dto.promotedToCohortId = record.promotedToCohortId;
+    return dto;
+  }
+}

--- a/src/notification/notification.module.ts
+++ b/src/notification/notification.module.ts
@@ -23,6 +23,7 @@ import { GmailEmailClient } from './infrastructure/gmail-email.client';
 import { NotificationCampaignScheduler } from './infrastructure/notification-campaign.scheduler';
 import { NotificationCampaignWriteRepository } from './infrastructure/notification-campaign.write.repository';
 import { AdminEarlyNotificationController } from './interface/admin.early-notification.controller';
+import { AdminGeneralEarlyNotificationController } from './interface/admin.general-early-notification.controller';
 import { AdminNotificationCampaignController } from './interface/admin.notification-campaign.controller';
 import { PublicEarlyNotificationController } from './interface/public.early-notification.controller';
 import { PublicGeneralEarlyNotificationController } from './interface/public.general-early-notification.controller';
@@ -42,6 +43,7 @@ import { PublicGeneralEarlyNotificationController } from './interface/public.gen
     PublicEarlyNotificationController,
     PublicGeneralEarlyNotificationController,
     AdminEarlyNotificationController,
+    AdminGeneralEarlyNotificationController,
     AdminNotificationCampaignController,
   ],
   providers: [

--- a/test/general-early-notification-admin.e2e-spec.ts
+++ b/test/general-early-notification-admin.e2e-spec.ts
@@ -1,16 +1,32 @@
-import { INestApplication, ValidationPipe, VersioningType } from '@nestjs/common';
+import { ExecutionContext, INestApplication, ValidationPipe, VersioningType } from '@nestjs/common';
 import { APP_FILTER } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
 import { Test } from '@nestjs/testing';
 import type { Server } from 'http';
 import request from 'supertest';
 
+import type { JwtUser } from '../src/auth/application/auth.type';
 import { HttpExceptionFilter } from '../src/common/exception/http-exception.filter';
 import { RolesGuard } from '../src/common/guard/roles.guard';
 import { GeneralEarlyNotificationService } from '../src/notification/application/general-early-notification.service';
 import { AdminGeneralEarlyNotificationController } from '../src/notification/interface/admin.general-early-notification.controller';
+import { UserRole } from '../src/user/domain/user.role';
 
-const allowAll = { canActivate: () => true };
+let currentUser: JwtUser | undefined;
+
+const jwtAuthGuard = {
+  canActivate: (context: ExecutionContext) => {
+    const request = context.switchToHttp().getRequest<{ user?: JwtUser }>();
+    request.user = currentUser;
+    return true;
+  },
+};
+
+const createUser = (roles: UserRole[]): JwtUser => ({
+  id: 1,
+  email: 'admin@example.com',
+  roles,
+});
 
 describe('Admin General Early Notification API (e2e)', () => {
   let app: INestApplication;
@@ -26,13 +42,12 @@ describe('Admin General Early Notification API (e2e)', () => {
           provide: GeneralEarlyNotificationService,
           useValue: mockGeneralEarlyNotificationService,
         },
+        RolesGuard,
         { provide: APP_FILTER, useClass: HttpExceptionFilter },
       ],
     })
       .overrideGuard(AuthGuard('jwt'))
-      .useValue(allowAll)
-      .overrideGuard(RolesGuard)
-      .useValue(allowAll)
+      .useValue(jwtAuthGuard)
       .compile();
 
     app = module.createNestApplication();
@@ -48,6 +63,7 @@ describe('Admin General Early Notification API (e2e)', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    currentUser = createUser([UserRole.계정관리]);
   });
 
   it('GET /api/v1/admin/early-notifications/general: 전체 대기열을 반환한다', async () => {
@@ -104,6 +120,46 @@ describe('Admin General Early Notification API (e2e)', () => {
     await request(app.getHttpServer() as Server)
       .get('/api/v1/admin/early-notifications/general?onlyUnpromoted=xxx')
       .expect(400);
+
+    expect(mockGeneralEarlyNotificationService.findForAdmin).not.toHaveBeenCalled();
+  });
+
+  it('운영자 역할 유저에게 200을 반환한다', async () => {
+    // Given
+    currentUser = createUser([UserRole.운영자]);
+    mockGeneralEarlyNotificationService.findForAdmin.mockResolvedValue([]);
+
+    // When & Then
+    await request(app.getHttpServer() as Server)
+      .get('/api/v1/admin/early-notifications/general')
+      .expect(200);
+
+    expect(mockGeneralEarlyNotificationService.findForAdmin).toHaveBeenCalledTimes(1);
+  });
+
+  it('면접자 역할만 가진 유저에게 403을 반환하고 데이터를 조회하지 않는다', async () => {
+    // Given
+    currentUser = createUser([UserRole.면접자]);
+
+    // When & Then
+    await request(app.getHttpServer() as Server)
+      .get('/api/v1/admin/early-notifications/general')
+      .expect(403);
+
+    expect(mockGeneralEarlyNotificationService.findForAdmin).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['roles가 빈 배열인 유저', createUser([])],
+    ['user가 없는 요청', undefined],
+  ])('%s에게 403을 반환하고 데이터를 조회하지 않는다', async (_case, user) => {
+    // Given
+    currentUser = user;
+
+    // When & Then
+    await request(app.getHttpServer() as Server)
+      .get('/api/v1/admin/early-notifications/general')
+      .expect(403);
 
     expect(mockGeneralEarlyNotificationService.findForAdmin).not.toHaveBeenCalled();
   });

--- a/test/general-early-notification-admin.e2e-spec.ts
+++ b/test/general-early-notification-admin.e2e-spec.ts
@@ -1,0 +1,110 @@
+import { INestApplication, ValidationPipe, VersioningType } from '@nestjs/common';
+import { APP_FILTER } from '@nestjs/core';
+import { AuthGuard } from '@nestjs/passport';
+import { Test } from '@nestjs/testing';
+import type { Server } from 'http';
+import request from 'supertest';
+
+import { HttpExceptionFilter } from '../src/common/exception/http-exception.filter';
+import { RolesGuard } from '../src/common/guard/roles.guard';
+import { GeneralEarlyNotificationService } from '../src/notification/application/general-early-notification.service';
+import { AdminGeneralEarlyNotificationController } from '../src/notification/interface/admin.general-early-notification.controller';
+
+const allowAll = { canActivate: () => true };
+
+describe('Admin General Early Notification API (e2e)', () => {
+  let app: INestApplication;
+  const mockGeneralEarlyNotificationService = {
+    findForAdmin: jest.fn(),
+  };
+
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({
+      controllers: [AdminGeneralEarlyNotificationController],
+      providers: [
+        {
+          provide: GeneralEarlyNotificationService,
+          useValue: mockGeneralEarlyNotificationService,
+        },
+        { provide: APP_FILTER, useClass: HttpExceptionFilter },
+      ],
+    })
+      .overrideGuard(AuthGuard('jwt'))
+      .useValue(allowAll)
+      .overrideGuard(RolesGuard)
+      .useValue(allowAll)
+      .compile();
+
+    app = module.createNestApplication();
+    app.setGlobalPrefix('api');
+    app.enableVersioning({ type: VersioningType.URI });
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('GET /api/v1/admin/early-notifications/general: 전체 대기열을 반환한다', async () => {
+    // Given
+    mockGeneralEarlyNotificationService.findForAdmin.mockResolvedValue([
+      {
+        id: 1,
+        email: 'waitlist@example.com',
+        createdAt: new Date('2026-08-12T00:00:00.000Z'),
+        promotedAt: null,
+        promotedToCohortId: null,
+      },
+    ]);
+
+    // When
+    const response = await request(app.getHttpServer() as Server)
+      .get('/api/v1/admin/early-notifications/general')
+      .expect(200);
+
+    // Then
+    expect(response.body).toMatchObject({
+      code: 'SUCCESS',
+      data: [
+        {
+          id: 1,
+          email: 'waitlist@example.com',
+          createdAt: '2026-08-12T00:00:00.000Z',
+          promotedAt: null,
+          promotedToCohortId: null,
+        },
+      ],
+    });
+    expect(mockGeneralEarlyNotificationService.findForAdmin).toHaveBeenCalledWith({
+      onlyUnpromoted: undefined,
+    });
+  });
+
+  it('GET /api/v1/admin/early-notifications/general?onlyUnpromoted=true: 필터를 전달한다', async () => {
+    // Given
+    mockGeneralEarlyNotificationService.findForAdmin.mockResolvedValue([]);
+
+    // When
+    await request(app.getHttpServer() as Server)
+      .get('/api/v1/admin/early-notifications/general?onlyUnpromoted=true')
+      .expect(200);
+
+    // Then
+    expect(mockGeneralEarlyNotificationService.findForAdmin).toHaveBeenCalledWith({
+      onlyUnpromoted: true,
+    });
+  });
+
+  it('GET /api/v1/admin/early-notifications/general?onlyUnpromoted=xxx: 400을 반환한다', async () => {
+    await request(app.getHttpServer() as Server)
+      .get('/api/v1/admin/early-notifications/general?onlyUnpromoted=xxx')
+      .expect(400);
+
+    expect(mockGeneralEarlyNotificationService.findForAdmin).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 📌 PR 제목

feat(notification): 사전 알림 대기열 가시성 확보 및 승격·신청 가드 추가

---

## ✅ PR 설명

노션 이슈 "사전 알림 신청 저장 시, 어드민에 미노출되는 이슈"를 코드로 추적한 결과, 신청 데이터가 어드민에서 관측 불가능한 영역으로 흘러갈 수 있는 구조를 확인했습니다. 그 구멍 세 개를 막습니다.

### 무엇이 문제였나

홈페이지는 활성 기수 조회에 실패하면 기수 미지정 대기열 엔드포인트로 폴백해 신청을 저장합니다. 그런데 그 대기열(`general_early_notifications`)을 **조회하는 어드민 API가 존재하지 않았습니다.** 대기 인원이 몇 명인지 아무도 볼 수 없어서, 신청이 새고 있어도 감지할 방법이 없었습니다. 실제로 이번 이슈가 원인 파악에 시간이 걸린 이유가 이것입니다.

여기에 두 가지가 더 겹쳐 있었습니다.

- `promoteToCohort`가 대상 기수의 상태를 확인하지 않았습니다. 기수 생성 시 `status`는 클라이언트가 지정할 수 있고(`admin-cohort.request.dto.ts`), 중복 검사는 `UPCOMING`·`RECRUITING`만 막습니다. 따라서 지난 기수를 `CLOSED`로 뒤늦게 백필 생성하면 대기열 전체가 그 종료된 기수로 옮겨지고 `markManyPromoted`로 소진됩니다. 되돌리는 API가 없어 비가역입니다.
- `EarlyNotificationService.subscribe`가 기수의 존재만 확인하고 상태를 보지 않아, 종료된 기수 ID로도 신청이 저장됐습니다.

### 변경 사항

**1. 대기열 조회 어드민 API 추가**

`GET /api/v1/admin/early-notifications/general` — 계정관리·운영자 권한, `createdAt DESC, id DESC` 정렬, `onlyUnpromoted` 필터.

- `src/notification/interface/admin.general-early-notification.controller.ts` (신규)
- `src/notification/interface/dto/admin-general-early-notification.{request,response}.dto.ts` (신규)
- `GeneralEarlyNotificationService.findForAdmin`, `GeneralEarlyNotificationRepository.findAll` 추가
- `GeneralEarlyNotificationWriteRepository.findMany`에 옵셔널 `order` 추가 — 기존 `findUnpromoted()` 동작은 불변입니다

기존 `AdminEarlyNotificationController`에 라우트를 붙이지 않고 컨트롤러를 분리했습니다. 대기열은 `GeneralEarlyNotificationService`가 소유하는 별개 애그리거트이고, 한 컨트롤러에 서비스 둘을 주입하면 책임이 섞입니다.

**2. 승격 대상 기수 가드**

`promoteToCohort`가 대상 기수 상태를 검증해, `UPCOMING`·`RECRUITING`이 아니면 승격을 건너뛰고 대기열을 그대로 보존합니다(`promotedAt`을 채우지 않음). 스킵 시 `Logger.warn`으로 `cohortId`와 상태를 남기고, 반환값에 `skippedReason: 'COHORT_NOT_PROMOTABLE'`을 옵셔널 필드로 추가했습니다.

기수 생성 자체는 계속 성공합니다. 과거 기수 백필은 정당한 운영 작업이므로 예외를 던져 트랜잭션을 롤백시키지 않았습니다.

가드는 호출부가 아니라 **승격 서비스 내부**에 뒀습니다. 호출자가 늘어나도 우회되지 않아야 하기 때문입니다. 그래서 `CohortService`는 수정하지 않았습니다.

`ACTIVE`도 승격 대상에서 제외했습니다. 이미 모집이 끝난 기수의 알림 대상으로 옮겨지면 그 대기자는 다음 모집 알림을 영원히 받지 못합니다.

**3. 종료된 기수 사전 알림 신청 차단**

`CLOSED` 기수로 신청하면 400 `EARLY_NOTIFICATION_COHORT_CLOSED`를 반환합니다.

**허용 범위를 `CLOSED` 차단으로만 한정한 이유**를 리뷰 시 봐주시면 좋겠습니다. `UPCOMING`·`RECRUITING`만 허용하도록 좁히면 실동작 회귀가 발생합니다. 공개 API `GET /api/v1/cohorts/active`는 `RECRUITING > UPCOMING > ACTIVE` 우선순위로 기수를 고르므로(`cohort.service.ts`), 활동 중인 기수만 있는 기간에는 프론트가 `ACTIVE` 기수 ID를 보냅니다. 이를 400으로 막으면 지금 성공하던 신청이 실패하고, 프론트 폴백은 기수 ID가 없을 때만 동작하므로 대기열로도 저장되지 못합니다. 이 결정을 고정하기 위해 `ACTIVE` 허용 회귀 테스트를 추가했습니다.

---

## 🧪 테스트 방법

- [x] 로컬 테스트 완료
- [x] 린트 및 빌드 통과

| 명령 | 결과 |
| --- | --- |
| `yarn lint:check` | 0 errors / 19 warnings — 경고는 `response-schema.ts`, `admin.interview.swagger.ts`, `user.swagger.ts` 3개 파일에만 발생하며 이번 변경 이전부터 있던 Prettier 경고입니다. 변경 파일의 경고는 0건입니다 |
| `yarn test --runInBand` | 32 suites / 277 tests 통과 |
| `yarn test:e2e` | 5 suites / 20 tests 통과 |
| `yarn build` | 성공 |

추가한 테스트:

- 승격 가드: `UPCOMING`·`RECRUITING`은 승격, `ACTIVE`·`CLOSED`·기수 없음은 스킵. 스킵 시 `register`와 `markManyPromoted`가 호출되지 않아 대기열이 보존되는 것까지 검증합니다
- 신청 차단: `CLOSED`는 400, `UPCOMING`·`RECRUITING`·`ACTIVE`는 정상 저장(회귀 방지)
- `findForAdmin`의 필터 전달
- `test/general-early-notification-admin.e2e-spec.ts` (신규) — 기존 e2e 패턴대로 실제 `ValidationPipe` + 글로벌 prefix + URI 버저닝을 적용해 라우트와 쿼리 검증을 확인합니다

**검증하지 못한 것**: 실제 PostgreSQL에 붙인 통합 테스트와 실서버 동작 확인은 하지 않았습니다. e2e는 서비스를 mock한 컨트롤러 레벨입니다(레포 기존 e2e 방식과 동일). 신규 API의 정렬과 필터가 실제 DB에서 의도대로 동작하는지는 배포 후 확인이 필요합니다.

---

## 🔍 체크리스트

- [x] 코드에 주석/불필요한 로그 제거 — 승격 스킵 시의 `Logger.warn`은 의도적으로 남겼습니다. 대기열이 왜 승격되지 않았는지 추적할 수단이 없으면 이번과 같은 사고가 반복됩니다
- [x] 코드 리뷰어가 이해하기 쉽게 커밋 정리 — 커밋 2개로 정리했습니다. `general-early-notification.service.ts`가 변경 1·2에 함께 걸려 파일 단위 3분할이 불가능해, 대기열 관련(1+2)과 신청 차단(3)으로 나눴습니다

---

## 📎 기타 참고 사항 (Optional)

### 동작 변화 / 리스크

- **신규 API 추가**로 인한 기존 동작 변화는 없습니다. 응답 스키마 변경도 없습니다(`PromoteToCohortResult`에 옵셔널 필드만 추가)
- **동작이 바뀌는 지점 하나**: 종료된 기수 ID로 오던 사전 알림 신청이 이제 400으로 거부됩니다. 정상 플로우에서는 프론트가 활성 기수 ID만 보내므로 영향이 없어야 하지만, 외부에서 오래된 기수 ID로 호출하던 케이스가 있다면 실패합니다
- DB 스키마 변경이 없어 마이그레이션이 필요하지 않습니다

### 범위 밖 / 후속

- **어드민 화면 UI가 없습니다.** 이번 PR은 백엔드 API까지입니다. 대기 인원을 실제로 보려면 FE 작업이 필요합니다(현재는 Swagger나 직접 호출로만 확인 가능)
- 홈페이지의 폴백 로직이 활성 기수 조회 실패를 모두 삼켜 조용히 대기열로 넘기는 부분, 모달의 기수명이 하드코딩된 부분은 FE 레포 이슈로 별도 확인이 필요합니다
- 기수 목록 조회 API에 `ORDER BY`가 없는 문제는 이번 범위에서 제외했습니다. 어드민이 클라이언트에서 자체 정렬하고 있어 실제 영향이 없습니다

🤖 Generated with [Claude Code](https://claude.com/claude-code)
