### PR TITLE
fix(infra): 배포 실패를 성공으로 보고하던 파이프라인 교정 (3개월 무배포 사고)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -45,8 +45,10 @@ jobs:
         with:
           context: .
           push: true
+          build-args: |
+            GIT_SHA=${{ github.event.workflow_run.head_sha }}
           tags: |
             ${{ steps.image.outputs.name }}:latest
-            ${{ steps.image.outputs.name }}:${{ github.sha }}
+            ${{ steps.image.outputs.name }}:${{ github.event.workflow_run.head_sha }}
           cache-from: type=registry,ref=${{ steps.image.outputs.name }}:latest
           cache-to: type=inline

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,9 +10,14 @@ on:
   workflow_dispatch:
     inputs:
       sha:
-        description: '배포할 커밋 SHA (비우면 main HEAD)'
+        description: '배포할 커밋 SHA 40자 (비우면 main HEAD)'
         required: false
         type: string
+      skip_version_check:
+        description: '버전 엔드포인트가 없는 구버전으로 롤백할 때만 체크'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: deploy-${{ github.ref }}
@@ -26,12 +31,26 @@ jobs:
     steps:
       # 배포 대상 커밋을 한 곳에서 확정한다.
       # workflow_run 재실행은 원래 이벤트의 head_sha 에 묶이므로, 무엇이 배포되는지 로그에 남겨야 한다.
+      # 사용자 입력은 셸에 직접 보간하지 않고 env 로 받는다.
       - name: Resolve target commit
         id: target
+        env:
+          INPUT_SHA: ${{ inputs.sha }}
+          RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+          FALLBACK_SHA: ${{ github.sha }}
         run: |
-          SHA="${{ github.event.inputs.sha }}"
-          [ -n "$SHA" ] || SHA="${{ github.event.workflow_run.head_sha }}"
-          [ -n "$SHA" ] || SHA="${{ github.sha }}"
+          set -euo pipefail
+          SHA="$INPUT_SHA"
+          [ -n "$SHA" ] || SHA="$RUN_SHA"
+          [ -n "$SHA" ] || SHA="$FALLBACK_SHA"
+          # 40자 hex 가 아니면 이미지 태그가 존재할 수 없다. 오타를 여기서 잡는다.
+          case "$SHA" in
+            *[!0-9a-f]*) echo "::error::커밋 SHA 는 소문자 hex 여야 합니다: '$SHA'"; exit 1 ;;
+          esac
+          if [ "${#SHA}" -ne 40 ]; then
+            echo "::error::커밋 SHA 는 40자여야 합니다 (입력 ${#SHA}자: '$SHA'). short SHA 는 이미지 태그와 맞지 않습니다."
+            exit 1
+          fi
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           echo "배포 대상 커밋: $SHA"
 
@@ -45,8 +64,29 @@ jobs:
       - name: Set image name
         id: image
         run: |
+          set -euo pipefail
           OWNER="${{ github.repository_owner }}"
+          echo "owner_lc=${OWNER,,}" >> "$GITHUB_OUTPUT"
+          echo "repo=ghcr.io/${OWNER,,}/ddd-be" >> "$GITHUB_OUTPUT"
           echo "name=ghcr.io/${OWNER,,}/ddd-be:${{ steps.target.outputs.sha }}" >> "$GITHUB_OUTPUT"
+
+      # VM 을 건드리기 전에 태그 존재를 먼저 확인한다.
+      # CI -> CD -> Deploy 로 workflow_run 이 두 번 연쇄되는 구조라 SHA 가 어긋날 수 있는데,
+      # scp 로 VM 파일을 덮어쓴 뒤 pull 에서 죽으면 상태만 어중간해진다.
+      - name: Verify image exists in GHCR
+        env:
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+          IMAGE: ${{ steps.image.outputs.name }}
+          TARGET_SHA: ${{ steps.target.outputs.sha }}
+        run: |
+          set -euo pipefail
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          if ! docker manifest inspect "$IMAGE" > /dev/null 2>&1; then
+            echo "::error::$IMAGE 태그가 GHCR 에 없습니다."
+            echo "CD 워크플로가 커밋 $TARGET_SHA 를 빌드했는지 확인하세요."
+            exit 1
+          fi
+          echo "이미지 확인 완료: $IMAGE"
 
       - name: Upload docker-compose
         uses: appleboy/scp-action@v0.1.7
@@ -65,10 +105,11 @@ jobs:
           username: ${{ secrets.GCP_VM_USER }}
           key: ${{ secrets.GCP_VM_SSH_KEY }}
           envs: >
-            GHCR_TOKEN,GITHUB_ACTOR,APP_IMAGE,GIT_SHA,APP_PORT,DB_PORT,DB_USERNAME,DB_PASSWORD,DB_NAME,
+            GHCR_TOKEN,GITHUB_ACTOR,APP_IMAGE,IMAGE_REPO,GIT_SHA,SKIP_VERSION_CHECK,APP_PORT,
+            DB_PORT,DB_USERNAME,DB_PASSWORD,DB_NAME,
             JWT_SECRET,JWT_EXPIRES_IN,ADMIN_BOOTSTRAP_TOKEN,ADMIN_BOOTSTRAP_TOKEN_EXPIRES_AT,
             GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_CALLBACK_URL,
-            CLIENT_REDIRECT_URL,ENCRYPTION_KEY,EMAIL_FROM,RESEND_API_KEY,GOOGLE_CALENDAR_ID,
+            CLIENT_REDIRECT_URL,ENCRYPTION_KEY,GOOGLE_CALENDAR_ID,
             GCS_BUCKET_NAME,GCP_SERVICE_ACCOUNT_JSON,DISCORD_CLIENT_ID,DISCORD_CLIENT_SECRET,
             DISCORD_CALLBACK_URL,DISCORD_BOT_TOKEN,DISCORD_GUILD_ID,DISCORD_INVITE_URL,
             DISCORD_ROLE_ID_PM,DISCORD_ROLE_ID_PD,DISCORD_ROLE_ID_BE,DISCORD_ROLE_ID_FE,
@@ -76,12 +117,20 @@ jobs:
           script: |
             # 어떤 명령이 실패해도 즉시 중단한다.
             # 이 한 줄이 없어서 2026-08-09 배포가 실패하고도 초록불로 보고됐고, 3개월간 아무도 몰랐다.
-            # 원격 셸은 bash 5.2 이므로 pipefail 과 간접 참조를 모두 쓸 수 있다.
             set -euo pipefail
 
+            # pipefail 은 bash 전용이다. 로그인 셸이 dash 로 바뀌면 set 자체가 실패해
+            # -e/-u 까지 통째로 적용되지 않은 채(=사고 이전 상태로) 스크립트가 진행된다.
+            if [ -z "${BASH_VERSION:-}" ]; then
+              echo "ERROR: bash 가 아닙니다. set -euo pipefail 이 적용되지 않아 배포를 중단합니다."
+              exit 1
+            fi
+            echo "shell: bash ${BASH_VERSION}"
+
             # drone-ssh(appleboy/ssh-action) 는 envs 에 나열된 변수라도 값이 비어 있으면
-            # 원격에 export 하지 않는다. set -u 하에서는 참조하는 순간 배포가 죽으므로,
+            # 원격에 export 하지 않을 수 있다. set -u 하에서는 참조 즉시 배포가 죽으므로,
             # 앱이 선택적으로 취급하는 값은 여기서 기본값을 채워 둔다.
+            : "${SKIP_VERSION_CHECK:=false}"
             : "${JWT_EXPIRES_IN:=1d}"
             : "${ADMIN_BOOTSTRAP_TOKEN:=}"
             : "${ADMIN_BOOTSTRAP_TOKEN_EXPIRES_AT:=}"
@@ -100,9 +149,9 @@ jobs:
             : "${DISCORD_ROLE_ID_AOS:=}"
 
             # 반대로 이게 비면 앱이 부팅조차 못 한다(env.validation 의 필수 항목 + 배포 필수값).
-            # 2분 뒤 헬스체크 실패로 알게 되는 대신, 여기서 이름을 찍고 즉시 멈춘다.
+            # set -e 는 "명령 실패" 만 잡고 "값의 부재" 는 잡지 못하므로 여기서 양성 검증한다.
             MISSING=""
-            for required in GHCR_TOKEN APP_IMAGE GIT_SHA \
+            for required in GHCR_TOKEN APP_IMAGE IMAGE_REPO GIT_SHA \
                             DB_PORT DB_USERNAME DB_PASSWORD DB_NAME \
                             JWT_SECRET ENCRYPTION_KEY \
                             GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET GOOGLE_CALLBACK_URL \
@@ -121,30 +170,60 @@ jobs:
             BASE="http://localhost:${APP_PORT}"
             echo "==> 배포 대상: $APP_IMAGE"
 
-            echo "==> [1/7] 디스크 정리 및 가드"
-            # 이미지는 여기서 건드리지 않는다. 배포가 실패했을 때 되돌아갈 대상이기 때문이다.
-            # 상한 없이 자라기만 하는 것들만 먼저 정리한다.
+            echo "==> [1/8] 디스크 정리 및 가드"
+            # 상한 없이 자라기만 하는 것들만 먼저 정리한다. 이미지는 여기서 건드리지 않는다.
             sudo sh -c 'truncate -s 0 /var/lib/docker/containers/*/*-json.log' || true
             sudo journalctl --vacuum-size=200M >/dev/null 2>&1 || true
 
-            AVAIL_MB=$(df -BM --output=avail / | tail -1 | tr -dc '0-9')
+            measure_avail() {
+              df -BM --output=avail / | tail -1 | tr -dc '0-9'
+            }
+            AVAIL_MB="$(measure_avail)" || AVAIL_MB=""
+            if [ -z "$AVAIL_MB" ]; then
+              echo "ERROR: 디스크 여유 공간을 측정하지 못했습니다."
+              df -h /
+              exit 1
+            fi
             echo "여유 공간: ${AVAIL_MB}MB"
+
+            # 가드에 걸렸다고 곧바로 포기하면, 정리 단계([8/8])에 영원히 도달하지 못해
+            # 디스크가 한 번 차는 순간 Actions 만으로는 빠져나올 수 없는 상태가 된다.
+            # 롤백 창(168h) 밖의 우리 앱 이미지만 비파괴적으로 회수한 뒤 재측정한다.
             if [ "$AVAIL_MB" -lt 2048 ]; then
-              echo "ERROR: 여유 공간이 ${AVAIL_MB}MB 로 2048MB 미만입니다. 배포를 중단합니다."
+              echo "여유 부족 - 비파괴 회수 시도"
+              sudo docker image prune -f >/dev/null 2>&1 || true
+              sudo docker builder prune -af --filter "until=24h" >/dev/null 2>&1 || true
+              sudo docker image prune -af \
+                --filter "until=168h" \
+                --filter "label=org.opencontainers.image.revision" >/dev/null 2>&1 || true
+              AVAIL_MB="$(measure_avail)"
+              echo "회수 후 여유 공간: ${AVAIL_MB:-측정실패}MB"
+            fi
+            if [ -z "$AVAIL_MB" ] || [ "$AVAIL_MB" -lt 2048 ]; then
+              echo "ERROR: 여유 공간이 ${AVAIL_MB:-?}MB 로 2048MB 미만입니다. 배포를 중단합니다."
               echo "       이미지 pull 이 남은 공간을 소진하면 DB 까지 함께 죽습니다."
               df -h /
               sudo docker system df
               exit 1
             fi
 
-            echo "==> [2/7] 이미지 받기"
+            echo "==> [2/8] 이미지 받기"
             echo "$GHCR_TOKEN" | sudo docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
             sudo docker pull "$APP_IMAGE"
+
+            # 태그와 실제 빌드 커밋이 일치하는지 컨테이너를 띄우기 전에 확인한다.
+            # workflow_run 이 CI -> CD -> Deploy 로 두 번 연쇄되므로 SHA 가 미끄러질 수 있다.
+            BUILT_SHA="$(sudo docker inspect --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' "$APP_IMAGE" 2>/dev/null || echo "")"
+            if [ -n "$BUILT_SHA" ] && [ "$BUILT_SHA" != "$GIT_SHA" ]; then
+              echo "ERROR: 이미지 라벨($BUILT_SHA) 이 배포 대상($GIT_SHA) 과 다릅니다."
+              exit 1
+            fi
+            echo "이미지 라벨 확인: ${BUILT_SHA:-(라벨 없음 - 이 PR 이전 빌드)}"
 
             cd /opt/ddd-be
             umask 077
 
-            echo "==> [3/7] 프론트엔드 부트스트랩 확인"
+            echo "==> [3/8] 프론트엔드 부트스트랩 확인"
             if [ ! -e /opt/admin/frontend/current ]; then
               echo "ERROR: /opt/admin/frontend/current 가 없습니다. VM 1회 부트스트랩이 필요합니다."
               echo "  sudo mkdir -p /opt/admin/frontend/releases"
@@ -153,129 +232,189 @@ jobs:
               exit 1
             fi
 
-            echo "==> [4/7] 설정 파일 생성"
-            echo "$GCP_SERVICE_ACCOUNT_JSON" > gcp-key.json
-
-            printf 'PORT=%s\n'        "$APP_PORT"    > .env.production
-            printf 'NODE_ENV=%s\n'    "production"   >> .env.production
-            printf 'DB_HOST=%s\n'     "postgres"     >> .env.production
-            printf 'DB_PORT=%s\n'     "$DB_PORT"     >> .env.production
-            printf 'DB_USERNAME=%s\n' "$DB_USERNAME" >> .env.production
-            printf 'DB_PASSWORD=%s\n' "$DB_PASSWORD" >> .env.production
-            printf 'DB_NAME=%s\n'     "$DB_NAME"     >> .env.production
-            printf 'APP_IMAGE=%s\n'   "$APP_IMAGE"   >> .env.production
-            # APP_VERSION 은 여기에 쓰지 않는다.
-            # 이미지에 각인된 값(Dockerfile 의 ENV)만 읽어야 "이미지가 실제로 갱신됐는가" 를
-            # 검증할 수 있다. env 파일에 써넣으면 우리가 쓴 값을 우리가 되읽어 항상 통과한다.
-            printf 'JWT_SECRET=%s\n'         "$JWT_SECRET"           >> .env.production
-            printf 'JWT_EXPIRES_IN=%s\n'     "$JWT_EXPIRES_IN"       >> .env.production
-            printf 'ADMIN_BOOTSTRAP_TOKEN=%s\n'           "$ADMIN_BOOTSTRAP_TOKEN"           >> .env.production
-            printf 'ADMIN_BOOTSTRAP_TOKEN_EXPIRES_AT=%s\n' "$ADMIN_BOOTSTRAP_TOKEN_EXPIRES_AT" >> .env.production
-            printf 'GOOGLE_CLIENT_ID=%s\n'   "$GOOGLE_CLIENT_ID"     >> .env.production
-            printf 'GOOGLE_CLIENT_SECRET=%s\n' "$GOOGLE_CLIENT_SECRET" >> .env.production
-            printf 'GOOGLE_CALLBACK_URL=%s\n' "$GOOGLE_CALLBACK_URL" >> .env.production
-            printf 'CLIENT_REDIRECT_URL=%s\n' "$CLIENT_REDIRECT_URL" >> .env.production
-            printf 'ENCRYPTION_KEY=%s\n'     "$ENCRYPTION_KEY"       >> .env.production
-
-            # Email (console 모드 - Resend 미사용)
-            printf 'EMAIL_PROVIDER=%s\n'     "console"               >> .env.production
-
-            # Interview & Calendar
-            printf 'INTERVIEW_BOOKING_URL=%s\n' "https://admin.dddstudy.kr/interview" >> .env.production
-            printf 'CALENDAR_PROVIDER=%s\n'  "google"                >> .env.production
-            printf 'GOOGLE_CALENDAR_ID=%s\n' "$GOOGLE_CALENDAR_ID"   >> .env.production
-            printf 'GOOGLE_CALENDAR_KEY_FILE_PATH=%s\n' "/app/gcp-key.json" >> .env.production
-
-            # Storage
-            printf 'STORAGE_PROVIDER=%s\n'   "gcs"                   >> .env.production
-            printf 'GCS_PROJECT_ID=%s\n'     "ddd-project-450002"    >> .env.production
-            printf 'GCS_BUCKET_NAME=%s\n'    "$GCS_BUCKET_NAME"      >> .env.production
-            printf 'GCS_KEY_FILE_PATH=%s\n'  "/app/gcp-key.json"     >> .env.production
-
-            # Discord
-            printf 'DISCORD_PROVIDER=%s\n'   "discord"               >> .env.production
-            printf 'DISCORD_CLIENT_ID=%s\n'  "$DISCORD_CLIENT_ID"    >> .env.production
-            printf 'DISCORD_CLIENT_SECRET=%s\n' "$DISCORD_CLIENT_SECRET" >> .env.production
-            printf 'DISCORD_CALLBACK_URL=%s\n' "$DISCORD_CALLBACK_URL" >> .env.production
-            printf 'DISCORD_BOT_TOKEN=%s\n'  "$DISCORD_BOT_TOKEN"    >> .env.production
-            printf 'DISCORD_GUILD_ID=%s\n'   "$DISCORD_GUILD_ID"     >> .env.production
-            printf 'DISCORD_INVITE_URL=%s\n' "$DISCORD_INVITE_URL"   >> .env.production
-
-            # Discord Role IDs
-            printf 'DISCORD_ROLE_ID_PM=%s\n'  "$DISCORD_ROLE_ID_PM"  >> .env.production
-            printf 'DISCORD_ROLE_ID_PD=%s\n'  "$DISCORD_ROLE_ID_PD"  >> .env.production
-            printf 'DISCORD_ROLE_ID_BE=%s\n'  "$DISCORD_ROLE_ID_BE"  >> .env.production
-            printf 'DISCORD_ROLE_ID_FE=%s\n'  "$DISCORD_ROLE_ID_FE"  >> .env.production
-            printf 'DISCORD_ROLE_ID_IOS=%s\n' "$DISCORD_ROLE_ID_IOS" >> .env.production
-            printf 'DISCORD_ROLE_ID_AOS=%s\n' "$DISCORD_ROLE_ID_AOS" >> .env.production
-
-            echo "==> [5/7] 설정 파일 검증"
-            # 디스크가 가득 차면 printf 가 0바이트 파일을 남긴다. 2026-08-09 에 실제로 그렇게 됐다.
-            # 빈 env 로 컨테이너를 띄우면 getOrThrow 가 던져서 앱이 무한 크래시 루프에 빠진다.
-            if [ ! -s .env.production ]; then
-              echo "ERROR: .env.production 이 비어 있습니다. 디스크 여유를 확인하세요."
+            echo "==> [4/8] 설정 파일 생성"
+            # gcp-key.json 은 docker-compose 가 실행 중인 컨테이너에 단일 파일로 바인드 마운트한다.
+            # '>' 는 쓰기 전에 truncate 하므로, 쓰기가 실패하면 아직 교체되지도 않은 구 컨테이너가
+            # 0바이트 키를 보게 된다(2026-08-09 에 실제로 그렇게 됐다).
+            # 임시 파일에 먼저 쓰고 검증한 뒤, inode 를 보존한 채 내용만 치환한다(mv 를 쓰면 안 된다).
+            printf '%s' "$GCP_SERVICE_ACCOUNT_JSON" > gcp-key.json.tmp
+            if [ "$(wc -c < gcp-key.json.tmp)" -lt 500 ] || ! grep -q '"private_key"' gcp-key.json.tmp; then
+              echo "ERROR: gcp-key.json 이 유효한 서비스 계정 JSON 이 아닙니다 ($(wc -c < gcp-key.json.tmp)바이트)."
+              rm -f gcp-key.json.tmp
               df -h /
               exit 1
             fi
-            ENV_LINES=$(wc -l < .env.production)
-            if [ "$ENV_LINES" -lt 30 ]; then
-              echo "ERROR: .env.production 이 ${ENV_LINES}줄뿐입니다. 생성이 중단된 것으로 보입니다."
-              exit 1
-            fi
-            if [ ! -s gcp-key.json ]; then
-              echo "ERROR: gcp-key.json 이 비어 있습니다. GCS/캘린더 연동이 조용히 깨집니다."
-              exit 1
-            fi
-            grep -q '^APP_IMAGE=..*' .env.production
-            echo "설정 파일 정상 (.env.production ${ENV_LINES}줄)"
+            cat gcp-key.json.tmp > gcp-key.json
+            rm -f gcp-key.json.tmp
 
-            echo "==> [6/7] 컨테이너 기동"
+            ENV_TMP=.env.production.tmp
+            printf 'PORT=%s\n'        "$APP_PORT"    > "$ENV_TMP"
+            printf 'NODE_ENV=%s\n'    "production"   >> "$ENV_TMP"
+            printf 'DB_HOST=%s\n'     "postgres"     >> "$ENV_TMP"
+            printf 'DB_PORT=%s\n'     "$DB_PORT"     >> "$ENV_TMP"
+            printf 'DB_USERNAME=%s\n' "$DB_USERNAME" >> "$ENV_TMP"
+            printf 'DB_PASSWORD=%s\n' "$DB_PASSWORD" >> "$ENV_TMP"
+            printf 'DB_NAME=%s\n'     "$DB_NAME"     >> "$ENV_TMP"
+            printf 'APP_IMAGE=%s\n'   "$APP_IMAGE"   >> "$ENV_TMP"
+            # APP_VERSION 은 여기에 쓰지 않는다.
+            # env_file 은 이미지 ENV 를 덮어쓰므로, 여기에 쓰면 우리가 써넣은 값을 우리가 되읽어
+            # 버전 검증이 항상 통과한다. 값은 반드시 이미지에 각인된 ENV 에서만 와야 한다.
+            printf 'JWT_SECRET=%s\n'         "$JWT_SECRET"           >> "$ENV_TMP"
+            printf 'JWT_EXPIRES_IN=%s\n'     "$JWT_EXPIRES_IN"       >> "$ENV_TMP"
+            printf 'ADMIN_BOOTSTRAP_TOKEN=%s\n'           "$ADMIN_BOOTSTRAP_TOKEN"           >> "$ENV_TMP"
+            printf 'ADMIN_BOOTSTRAP_TOKEN_EXPIRES_AT=%s\n' "$ADMIN_BOOTSTRAP_TOKEN_EXPIRES_AT" >> "$ENV_TMP"
+            printf 'GOOGLE_CLIENT_ID=%s\n'   "$GOOGLE_CLIENT_ID"     >> "$ENV_TMP"
+            printf 'GOOGLE_CLIENT_SECRET=%s\n' "$GOOGLE_CLIENT_SECRET" >> "$ENV_TMP"
+            printf 'GOOGLE_CALLBACK_URL=%s\n' "$GOOGLE_CALLBACK_URL" >> "$ENV_TMP"
+            printf 'CLIENT_REDIRECT_URL=%s\n' "$CLIENT_REDIRECT_URL" >> "$ENV_TMP"
+            printf 'ENCRYPTION_KEY=%s\n'     "$ENCRYPTION_KEY"       >> "$ENV_TMP"
+
+            # Email (console 모드 - Resend 미사용)
+            printf 'EMAIL_PROVIDER=%s\n'     "console"               >> "$ENV_TMP"
+
+            # Interview & Calendar
+            printf 'INTERVIEW_BOOKING_URL=%s\n' "https://admin.dddstudy.kr/interview" >> "$ENV_TMP"
+            printf 'CALENDAR_PROVIDER=%s\n'  "google"                >> "$ENV_TMP"
+            printf 'GOOGLE_CALENDAR_ID=%s\n' "$GOOGLE_CALENDAR_ID"   >> "$ENV_TMP"
+            printf 'GOOGLE_CALENDAR_KEY_FILE_PATH=%s\n' "/app/gcp-key.json" >> "$ENV_TMP"
+
+            # Storage
+            printf 'STORAGE_PROVIDER=%s\n'   "gcs"                   >> "$ENV_TMP"
+            printf 'GCS_PROJECT_ID=%s\n'     "ddd-project-450002"    >> "$ENV_TMP"
+            printf 'GCS_BUCKET_NAME=%s\n'    "$GCS_BUCKET_NAME"      >> "$ENV_TMP"
+            printf 'GCS_KEY_FILE_PATH=%s\n'  "/app/gcp-key.json"     >> "$ENV_TMP"
+
+            # Discord
+            printf 'DISCORD_PROVIDER=%s\n'   "discord"               >> "$ENV_TMP"
+            printf 'DISCORD_CLIENT_ID=%s\n'  "$DISCORD_CLIENT_ID"    >> "$ENV_TMP"
+            printf 'DISCORD_CLIENT_SECRET=%s\n' "$DISCORD_CLIENT_SECRET" >> "$ENV_TMP"
+            printf 'DISCORD_CALLBACK_URL=%s\n' "$DISCORD_CALLBACK_URL" >> "$ENV_TMP"
+            printf 'DISCORD_BOT_TOKEN=%s\n'  "$DISCORD_BOT_TOKEN"    >> "$ENV_TMP"
+            printf 'DISCORD_GUILD_ID=%s\n'   "$DISCORD_GUILD_ID"     >> "$ENV_TMP"
+            printf 'DISCORD_INVITE_URL=%s\n' "$DISCORD_INVITE_URL"   >> "$ENV_TMP"
+
+            # Discord Role IDs
+            printf 'DISCORD_ROLE_ID_PM=%s\n'  "$DISCORD_ROLE_ID_PM"  >> "$ENV_TMP"
+            printf 'DISCORD_ROLE_ID_PD=%s\n'  "$DISCORD_ROLE_ID_PD"  >> "$ENV_TMP"
+            printf 'DISCORD_ROLE_ID_BE=%s\n'  "$DISCORD_ROLE_ID_BE"  >> "$ENV_TMP"
+            printf 'DISCORD_ROLE_ID_FE=%s\n'  "$DISCORD_ROLE_ID_FE"  >> "$ENV_TMP"
+            printf 'DISCORD_ROLE_ID_IOS=%s\n' "$DISCORD_ROLE_ID_IOS" >> "$ENV_TMP"
+            printf 'DISCORD_ROLE_ID_AOS=%s\n' "$DISCORD_ROLE_ID_AOS" >> "$ENV_TMP"
+
+            # 완결성 센티널. 줄 수 임계값 같은 매직 넘버는 항목이 늘면 곧바로 거짓말을 하므로,
+            # "마지막 줄까지 실제로 기록됐다" 를 구조적으로 증명하는 방식을 쓴다.
+            printf 'ENV_WRITE_COMPLETE=1\n' >> "$ENV_TMP"
+
+            echo "==> [5/8] 설정 파일 검증"
+            if ! grep -q '^ENV_WRITE_COMPLETE=1$' "$ENV_TMP"; then
+              echo "ERROR: .env.production 생성이 중간에 끊겼습니다(센티널 없음)."
+              echo "       기록된 줄 수: $(wc -l < "$ENV_TMP")"
+              df -h /
+              rm -f "$ENV_TMP"
+              exit 1
+            fi
+            if ! grep -q '^APP_IMAGE=..*' "$ENV_TMP"; then
+              echo "ERROR: .env.production 에 APP_IMAGE 라인이 없거나 값이 비었습니다."
+              rm -f "$ENV_TMP"
+              exit 1
+            fi
+            # 미래에 누가 APP_VERSION 을 다시 넣으면 버전 검증이 통째로 무력화된다. 기계적으로 막는다.
+            if grep -q '^APP_VERSION=' "$ENV_TMP"; then
+              echo "ERROR: .env.production 에 APP_VERSION 이 있으면 버전 검증이 무력화됩니다."
+              echo "       이 값은 이미지의 ENV 에서만 와야 합니다."
+              rm -f "$ENV_TMP"
+              exit 1
+            fi
+            mv "$ENV_TMP" .env.production
+            echo "설정 파일 정상 ($(wc -l < .env.production)줄, 센티널 확인)"
+
+            echo "==> [6/8] 컨테이너 기동"
             sudo APP_ENV_FILE=.env.production docker compose --env-file .env.production up -d
 
-            # Caddyfile 만 바뀐 배포에서는 compose 가 caddy 를 재생성하지 않으므로 명시적으로 reload 한다.
-            sudo docker exec ddd-be-caddy caddy reload \
-              --config /etc/caddy/Caddyfile --adapter caddyfile
-
-            echo "==> [7/7] 헬스체크 + 버전 검증"
-            for i in $(seq 1 24); do
+            echo "==> [7/8] 헬스체크 + 버전 검증"
+            # postgres 재생성 + 자동 DDL 이 겹치는 첫 배포는 평소보다 느리다. 3분까지 기다린다.
+            for i in $(seq 1 36); do
               if curl -sf "${BASE}/api/v1/health" > /dev/null 2>&1; then
                 echo "헬스체크 통과 (${i}회차)"
                 break
               fi
-              if [ "$i" -eq 24 ]; then
+              if [ "$i" -eq 36 ]; then
                 echo "ERROR: 헬스체크 실패. 앱 로그:"
-                sudo docker logs --tail 100 ddd-be-app
+                sudo docker logs --tail 100 ddd-be-app || true
+                echo "--- postgres 로그 (DB 인증 실패를 놓치지 않기 위해 함께 덤프) ---"
+                sudo docker logs --tail 50 ddd-be-postgres || true
                 exit 1
               fi
               sleep 5
             done
 
             # 헬스체크 200 만으로는 배포 성공을 판정할 수 없다.
-            # 갱신되지 않은 옛 컨테이너도 200 을 돌려주기 때문이다 (2026-08-09 가짜 성공의 원인).
+            # 갱신되지 않은 옛 컨테이너도 200 을 돌려주기 때문이다(2026-08-09 가짜 성공의 원인).
             # 실행 중인 컨테이너가 실제로 이번 커밋인지 직접 확인한다.
-            DEPLOYED=$(curl -sf "${BASE}/api/v1/health/version" 2>/dev/null \
-              | sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p') || DEPLOYED=""
-            echo "배포 요청 커밋: $GIT_SHA"
-            echo "실행 중인 커밋: ${DEPLOYED:-(응답 없음)}"
-            if [ "$DEPLOYED" != "$GIT_SHA" ]; then
-              echo "ERROR: 버전 불일치 - 컨테이너가 갱신되지 않았습니다."
-              echo "       배포는 실패로 처리합니다. 컨테이너 상태:"
-              sudo docker ps -a
-              exit 1
+            if [ "$SKIP_VERSION_CHECK" = "true" ]; then
+              echo "WARN: 버전 검증을 건너뜁니다(구버전 롤백 모드)."
+            else
+              DEPLOYED="$(curl -sf "${BASE}/api/v1/health/version" 2>/dev/null \
+                | sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')" || DEPLOYED=""
+              echo "배포 요청 커밋: $GIT_SHA"
+              echo "실행 중인 커밋: ${DEPLOYED:-(응답 없음)}"
+              # 양쪽이 모두 빈 문자열이면 != 비교가 거짓이 되어 그대로 통과한다. 개별로 막는다.
+              if [ -z "$GIT_SHA" ]; then
+                echo "ERROR: GIT_SHA 가 확정되지 않았습니다."
+                exit 1
+              fi
+              if [ -z "$DEPLOYED" ]; then
+                echo "ERROR: /api/v1/health/version 이 응답하지 않습니다."
+                echo "       구버전 이미지로 롤백하는 중이라면 skip_version_check 를 사용하세요."
+                sudo docker ps -a
+                exit 1
+              fi
+              if [ "$DEPLOYED" != "$GIT_SHA" ]; then
+                echo "ERROR: 버전 불일치 - 컨테이너가 갱신되지 않았습니다."
+                sudo docker ps -a
+                echo "롤백: gh workflow run 'Deploy to GCP VM' -f sha=<직전 성공 SHA>"
+                sudo docker images "$IMAGE_REPO" --format '  {{.Repository}}:{{.Tag}}' | head -5
+                exit 1
+              fi
+              echo "배포 검증 완료: $GIT_SHA"
             fi
-            echo "배포 검증 완료: $GIT_SHA"
 
-            # 검증이 끝난 뒤에만 오래된 이미지를 정리한다.
-            # 실패 시 되돌아갈 이미지를 미리 지우지 않기 위해 순서가 중요하다.
-            # 이미지마다 커밋 SHA 태그가 붙으므로 최근 7일치는 롤백용으로 남는다.
-            echo "==> 오래된 이미지 정리"
-            sudo docker image prune -af --filter "until=168h" 2>&1 | tail -2 || true
+            echo "==> [8/8] 마무리"
+            # Caddyfile 만 바뀐 배포에서는 compose 가 caddy 를 재생성하지 않으므로 명시적으로 reload 한다.
+            # 검증 이후에 두는 이유: reload 실패로 정상 배포를 되돌릴 수는 없고,
+            # 컨테이너 재생성 직후에는 admin API 바인딩 전이라 레이스가 날 수 있다.
+            for i in 1 2 3; do
+              if sudo docker exec ddd-be-caddy caddy reload \
+                   --config /etc/caddy/Caddyfile --adapter caddyfile; then
+                echo "caddy reload 완료"
+                break
+              fi
+              if [ "$i" -eq 3 ]; then
+                echo "ERROR: caddy reload 3회 실패. 라우팅이 옛 설정으로 남아 있습니다."
+                sudo docker logs --tail 50 ddd-be-caddy || true
+                exit 1
+              fi
+              sleep 5
+            done
+
+            # 정리 대상을 우리 앱 이미지로만 한정한다.
+            # label 필터가 없으면 postgres:16-alpine / caddy:2-alpine 도 until 조건에 걸린다
+            # (until 은 pull 시각이 아니라 이미지 빌드 시각 기준이고, 업스트림 이미지는 수개월 전 빌드다).
+            # 이 호스트는 containerd 스냅샷터라 실행 중 컨테이너의 이미지가 prune 된 전례가 있으므로
+            # -a 가 그 둘을 후보로 보게 두어서는 안 된다.
+            echo "오래된 앱 이미지 정리 (최근 168h 는 롤백용으로 보존)"
+            sudo docker image prune -af \
+              --filter "until=168h" \
+              --filter "label=org.opencontainers.image.revision" 2>&1 | tail -2 || true
             df -h /
+            echo "배포 완료: $GIT_SHA"
         env:
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
           APP_IMAGE: ${{ steps.image.outputs.name }}
+          IMAGE_REPO: ${{ steps.image.outputs.repo }}
           GIT_SHA: ${{ steps.target.outputs.sha }}
+          SKIP_VERSION_CHECK: ${{ inputs.skip_version_check }}
           APP_PORT: ${{ secrets.APP_PORT }}
           DB_PORT: ${{ secrets.DB_PORT }}
           DB_USERNAME: ${{ secrets.DB_USERNAME }}
@@ -290,8 +429,6 @@ jobs:
           GOOGLE_CALLBACK_URL: ${{ secrets.GOOGLE_CALLBACK_URL }}
           CLIENT_REDIRECT_URL: ${{ secrets.CLIENT_REDIRECT_URL }}
           ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
-          EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
-          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
           GOOGLE_CALENDAR_ID: ${{ secrets.GOOGLE_CALENDAR_ID }}
           GCS_BUCKET_NAME: ${{ secrets.GCS_BUCKET_NAME }}
           GCP_SERVICE_ACCOUNT_JSON: ${{ secrets.GCP_SERVICE_ACCOUNT_JSON }}
@@ -311,6 +448,10 @@ jobs:
   export-openapi:
     runs-on: ubuntu-latest
     needs: deploy
+    # 롤백(workflow_dispatch)에서는 건너뛴다.
+    # 이 잡은 ref 없이 기본 브랜치를 체크아웃해 push 하므로,
+    # 과거 커밋을 배포하면 구버전 스펙이 main 의 openapi.json 을 덮어쓴다.
+    if: ${{ github.event_name != 'workflow_dispatch' }}
     permissions:
       contents: write
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,9 +2,17 @@ name: Deploy to GCP VM
 
 on:
   workflow_run:
-    workflows: ["CD"]
+    workflows: ['CD']
     branches: [main]
     types: [completed]
+  # 재실행이 실패했을 때 쓸 수동 배포 레버.
+  # 이게 없으면 main 에 커밋을 밀어 CI -> CD -> Deploy 전체를 다시 태우는 방법밖에 없다.
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: '배포할 커밋 SHA (비우면 main HEAD)'
+        required: false
+        type: string
 
 concurrency:
   group: deploy-${{ github.ref }}
@@ -13,17 +21,32 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 
     steps:
+      # 배포 대상 커밋을 한 곳에서 확정한다.
+      # workflow_run 재실행은 원래 이벤트의 head_sha 에 묶이므로, 무엇이 배포되는지 로그에 남겨야 한다.
+      - name: Resolve target commit
+        id: target
+        run: |
+          SHA="${{ github.event.inputs.sha }}"
+          [ -n "$SHA" ] || SHA="${{ github.event.workflow_run.head_sha }}"
+          [ -n "$SHA" ] || SHA="${{ github.sha }}"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "배포 대상 커밋: $SHA"
+
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.target.outputs.sha }}
 
+      # :latest 가 아니라 커밋 SHA 태그로 배포한다.
+      # 불변 태그라야 "지금 무엇이 돌고 있는가" 에 답할 수 있고, 롤백 대상도 특정된다.
       - name: Set image name
         id: image
         run: |
           OWNER="${{ github.repository_owner }}"
-          echo "name=ghcr.io/${OWNER,,}/ddd-be:latest" >> "$GITHUB_OUTPUT"
+          echo "name=ghcr.io/${OWNER,,}/ddd-be:${{ steps.target.outputs.sha }}" >> "$GITHUB_OUTPUT"
 
       - name: Upload docker-compose
         uses: appleboy/scp-action@v0.1.7
@@ -31,8 +54,8 @@ jobs:
           host: ${{ secrets.GCP_VM_HOST }}
           username: ${{ secrets.GCP_VM_USER }}
           key: ${{ secrets.GCP_VM_SSH_KEY }}
-          source: "docker-compose.yml,Caddyfile"
-          target: "/opt/ddd-be/"
+          source: 'docker-compose.yml,Caddyfile'
+          target: '/opt/ddd-be/'
           overwrite: true
 
       - name: Deploy
@@ -42,7 +65,7 @@ jobs:
           username: ${{ secrets.GCP_VM_USER }}
           key: ${{ secrets.GCP_VM_SSH_KEY }}
           envs: >
-            GHCR_TOKEN,GITHUB_ACTOR,APP_IMAGE,APP_PORT,DB_PORT,DB_USERNAME,DB_PASSWORD,DB_NAME,
+            GHCR_TOKEN,GITHUB_ACTOR,APP_IMAGE,GIT_SHA,APP_PORT,DB_PORT,DB_USERNAME,DB_PASSWORD,DB_NAME,
             JWT_SECRET,JWT_EXPIRES_IN,ADMIN_BOOTSTRAP_TOKEN,ADMIN_BOOTSTRAP_TOKEN_EXPIRES_AT,
             GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_CALLBACK_URL,
             CLIENT_REDIRECT_URL,ENCRYPTION_KEY,EMAIL_FROM,RESEND_API_KEY,GOOGLE_CALENDAR_ID,
@@ -51,22 +74,49 @@ jobs:
             DISCORD_ROLE_ID_PM,DISCORD_ROLE_ID_PD,DISCORD_ROLE_ID_BE,DISCORD_ROLE_ID_FE,
             DISCORD_ROLE_ID_IOS,DISCORD_ROLE_ID_AOS
           script: |
-            echo "$GHCR_TOKEN" | sudo docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
-            sudo docker pull "$APP_IMAGE"
-            cd /opt/ddd-be
-            umask 077
+            # 어떤 명령이 실패해도 즉시 중단한다.
+            # 이 한 줄이 없어서 2026-08-09 배포가 실패하고도 초록불로 보고됐고, 3개월간 아무도 몰랐다.
+            set -euo pipefail
 
-            # Frontend bootstrap precondition (FE 팀 release 패턴: /opt/admin/frontend/current 가 symlink 여야 함)
-            # 최초 1회 VM 부트스트랩이 누락되면 여기서 실패 — docs/admin-deploy.md §A 참고
-            if [ ! -e /opt/admin/frontend/current ]; then
-              echo "ERROR: /opt/admin/frontend/current 가 없습니다. VM 1회 부트스트랩이 필요합니다."
-              echo "  ssh dddstudy1@<VM> 후 docs/admin-deploy.md §A 의 5줄 실행"
+            APP_PORT="${APP_PORT:-3000}"
+            BASE="http://localhost:${APP_PORT}"
+            echo "==> 배포 대상: $APP_IMAGE"
+
+            echo "==> [1/7] 디스크 정리 및 가드"
+            # 이미지는 여기서 건드리지 않는다. 배포가 실패했을 때 되돌아갈 대상이기 때문이다.
+            # 상한 없이 자라기만 하는 것들만 먼저 정리한다.
+            sudo sh -c 'truncate -s 0 /var/lib/docker/containers/*/*-json.log' || true
+            sudo journalctl --vacuum-size=200M >/dev/null 2>&1 || true
+
+            AVAIL_MB=$(df -BM --output=avail / | tail -1 | tr -dc '0-9')
+            echo "여유 공간: ${AVAIL_MB}MB"
+            if [ "$AVAIL_MB" -lt 2048 ]; then
+              echo "ERROR: 여유 공간이 ${AVAIL_MB}MB 로 2048MB 미만입니다. 배포를 중단합니다."
+              echo "       이미지 pull 이 남은 공간을 소진하면 DB 까지 함께 죽습니다."
+              df -h /
+              sudo docker system df
               exit 1
             fi
 
-            # Create GCP Service Account Key file
+            echo "==> [2/7] 이미지 받기"
+            echo "$GHCR_TOKEN" | sudo docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+            sudo docker pull "$APP_IMAGE"
+
+            cd /opt/ddd-be
+            umask 077
+
+            echo "==> [3/7] 프론트엔드 부트스트랩 확인"
+            if [ ! -e /opt/admin/frontend/current ]; then
+              echo "ERROR: /opt/admin/frontend/current 가 없습니다. VM 1회 부트스트랩이 필요합니다."
+              echo "  sudo mkdir -p /opt/admin/frontend/releases"
+              echo "  sudo chown -R \$USER:\$USER /opt/admin/frontend"
+              echo "  cd /opt/admin/frontend && mkdir -p releases/initial && ln -sfn releases/initial current"
+              exit 1
+            fi
+
+            echo "==> [4/7] 설정 파일 생성"
             echo "$GCP_SERVICE_ACCOUNT_JSON" > gcp-key.json
-            
+
             printf 'PORT=%s\n'        "$APP_PORT"    > .env.production
             printf 'NODE_ENV=%s\n'    "production"   >> .env.production
             printf 'DB_HOST=%s\n'     "postgres"     >> .env.production
@@ -75,6 +125,7 @@ jobs:
             printf 'DB_PASSWORD=%s\n' "$DB_PASSWORD" >> .env.production
             printf 'DB_NAME=%s\n'     "$DB_NAME"     >> .env.production
             printf 'APP_IMAGE=%s\n'   "$APP_IMAGE"   >> .env.production
+            printf 'APP_VERSION=%s\n' "$GIT_SHA"     >> .env.production
             printf 'JWT_SECRET=%s\n'         "$JWT_SECRET"           >> .env.production
             printf 'JWT_EXPIRES_IN=%s\n'     "$JWT_EXPIRES_IN"       >> .env.production
             printf 'ADMIN_BOOTSTRAP_TOKEN=%s\n'           "$ADMIN_BOOTSTRAP_TOKEN"           >> .env.production
@@ -84,22 +135,22 @@ jobs:
             printf 'GOOGLE_CALLBACK_URL=%s\n' "$GOOGLE_CALLBACK_URL" >> .env.production
             printf 'CLIENT_REDIRECT_URL=%s\n' "$CLIENT_REDIRECT_URL" >> .env.production
             printf 'ENCRYPTION_KEY=%s\n'     "$ENCRYPTION_KEY"       >> .env.production
-            
+
             # Email (console 모드 - Resend 미사용)
             printf 'EMAIL_PROVIDER=%s\n'     "console"               >> .env.production
-            
+
             # Interview & Calendar
             printf 'INTERVIEW_BOOKING_URL=%s\n' "https://admin.dddstudy.kr/interview" >> .env.production
             printf 'CALENDAR_PROVIDER=%s\n'  "google"                >> .env.production
             printf 'GOOGLE_CALENDAR_ID=%s\n' "$GOOGLE_CALENDAR_ID"   >> .env.production
             printf 'GOOGLE_CALENDAR_KEY_FILE_PATH=%s\n' "/app/gcp-key.json" >> .env.production
-            
+
             # Storage
             printf 'STORAGE_PROVIDER=%s\n'   "gcs"                   >> .env.production
             printf 'GCS_PROJECT_ID=%s\n'     "ddd-project-450002"    >> .env.production
             printf 'GCS_BUCKET_NAME=%s\n'    "$GCS_BUCKET_NAME"      >> .env.production
             printf 'GCS_KEY_FILE_PATH=%s\n'  "/app/gcp-key.json"     >> .env.production
-            
+
             # Discord
             printf 'DISCORD_PROVIDER=%s\n'   "discord"               >> .env.production
             printf 'DISCORD_CLIENT_ID=%s\n'  "$DISCORD_CLIENT_ID"    >> .env.production
@@ -108,7 +159,7 @@ jobs:
             printf 'DISCORD_BOT_TOKEN=%s\n'  "$DISCORD_BOT_TOKEN"    >> .env.production
             printf 'DISCORD_GUILD_ID=%s\n'   "$DISCORD_GUILD_ID"     >> .env.production
             printf 'DISCORD_INVITE_URL=%s\n' "$DISCORD_INVITE_URL"   >> .env.production
-            
+
             # Discord Role IDs
             printf 'DISCORD_ROLE_ID_PM=%s\n'  "$DISCORD_ROLE_ID_PM"  >> .env.production
             printf 'DISCORD_ROLE_ID_PD=%s\n'  "$DISCORD_ROLE_ID_PD"  >> .env.production
@@ -116,28 +167,74 @@ jobs:
             printf 'DISCORD_ROLE_ID_FE=%s\n'  "$DISCORD_ROLE_ID_FE"  >> .env.production
             printf 'DISCORD_ROLE_ID_IOS=%s\n' "$DISCORD_ROLE_ID_IOS" >> .env.production
             printf 'DISCORD_ROLE_ID_AOS=%s\n' "$DISCORD_ROLE_ID_AOS" >> .env.production
-            
+
+            echo "==> [5/7] 설정 파일 검증"
+            # 디스크가 가득 차면 printf 가 0바이트 파일을 남긴다. 2026-08-09 에 실제로 그렇게 됐다.
+            # 빈 env 로 컨테이너를 띄우면 getOrThrow 가 던져서 앱이 무한 크래시 루프에 빠진다.
+            if [ ! -s .env.production ]; then
+              echo "ERROR: .env.production 이 비어 있습니다. 디스크 여유를 확인하세요."
+              df -h /
+              exit 1
+            fi
+            ENV_LINES=$(wc -l < .env.production)
+            if [ "$ENV_LINES" -lt 30 ]; then
+              echo "ERROR: .env.production 이 ${ENV_LINES}줄뿐입니다. 생성이 중단된 것으로 보입니다."
+              exit 1
+            fi
+            if [ ! -s gcp-key.json ]; then
+              echo "ERROR: gcp-key.json 이 비어 있습니다. GCS/캘린더 연동이 조용히 깨집니다."
+              exit 1
+            fi
+            grep -q '^APP_IMAGE=..*' .env.production
+            echo "설정 파일 정상 (.env.production ${ENV_LINES}줄)"
+
+            echo "==> [6/7] 컨테이너 기동"
             sudo APP_ENV_FILE=.env.production docker compose --env-file .env.production up -d
 
-            # Caddyfile 변경분 즉시 반영 (zero-downtime reload)
-            # docker compose up -d 는 이미지/마운트가 동일하면 caddy 컨테이너를 재생성하지 않으므로
-            # Caddyfile 만 바뀐 배포에서는 컨테이너 안 메모리 설정이 옛 상태로 남는다.
+            # Caddyfile 만 바뀐 배포에서는 compose 가 caddy 를 재생성하지 않으므로 명시적으로 reload 한다.
             sudo docker exec ddd-be-caddy caddy reload \
               --config /etc/caddy/Caddyfile --adapter caddyfile
 
-            for i in $(seq 1 12); do
-              curl -sf "http://localhost:${APP_PORT:-3000}/api/v1/health" && break
-              if [ "$i" -eq 12 ]; then
-                echo "Health check failed. Showing app logs:"
-                sudo docker logs ddd-be-app
+            echo "==> [7/7] 헬스체크 + 버전 검증"
+            for i in $(seq 1 24); do
+              if curl -sf "${BASE}/api/v1/health" > /dev/null 2>&1; then
+                echo "헬스체크 통과 (${i}회차)"
+                break
+              fi
+              if [ "$i" -eq 24 ]; then
+                echo "ERROR: 헬스체크 실패. 앱 로그:"
+                sudo docker logs --tail 100 ddd-be-app
                 exit 1
               fi
               sleep 5
             done
+
+            # 헬스체크 200 만으로는 배포 성공을 판정할 수 없다.
+            # 갱신되지 않은 옛 컨테이너도 200 을 돌려주기 때문이다 (2026-08-09 가짜 성공의 원인).
+            # 실행 중인 컨테이너가 실제로 이번 커밋인지 직접 확인한다.
+            DEPLOYED=$(curl -sf "${BASE}/api/v1/health/version" 2>/dev/null \
+              | sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p') || DEPLOYED=""
+            echo "배포 요청 커밋: $GIT_SHA"
+            echo "실행 중인 커밋: ${DEPLOYED:-(응답 없음)}"
+            if [ "$DEPLOYED" != "$GIT_SHA" ]; then
+              echo "ERROR: 버전 불일치 - 컨테이너가 갱신되지 않았습니다."
+              echo "       배포는 실패로 처리합니다. 컨테이너 상태:"
+              sudo docker ps -a
+              exit 1
+            fi
+            echo "배포 검증 완료: $GIT_SHA"
+
+            # 검증이 끝난 뒤에만 오래된 이미지를 정리한다.
+            # 실패 시 되돌아갈 이미지를 미리 지우지 않기 위해 순서가 중요하다.
+            # 이미지마다 커밋 SHA 태그가 붙으므로 최근 7일치는 롤백용으로 남는다.
+            echo "==> 오래된 이미지 정리"
+            sudo docker image prune -af --filter "until=168h" 2>&1 | tail -2 || true
+            df -h /
         env:
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
           APP_IMAGE: ${{ steps.image.outputs.name }}
+          GIT_SHA: ${{ steps.target.outputs.sha }}
           APP_PORT: ${{ secrets.APP_PORT }}
           DB_PORT: ${{ secrets.DB_PORT }}
           DB_USERNAME: ${{ secrets.DB_USERNAME }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,7 +76,46 @@ jobs:
           script: |
             # 어떤 명령이 실패해도 즉시 중단한다.
             # 이 한 줄이 없어서 2026-08-09 배포가 실패하고도 초록불로 보고됐고, 3개월간 아무도 몰랐다.
+            # 원격 셸은 bash 5.2 이므로 pipefail 과 간접 참조를 모두 쓸 수 있다.
             set -euo pipefail
+
+            # drone-ssh(appleboy/ssh-action) 는 envs 에 나열된 변수라도 값이 비어 있으면
+            # 원격에 export 하지 않는다. set -u 하에서는 참조하는 순간 배포가 죽으므로,
+            # 앱이 선택적으로 취급하는 값은 여기서 기본값을 채워 둔다.
+            : "${JWT_EXPIRES_IN:=1d}"
+            : "${ADMIN_BOOTSTRAP_TOKEN:=}"
+            : "${ADMIN_BOOTSTRAP_TOKEN_EXPIRES_AT:=}"
+            : "${GOOGLE_CALENDAR_ID:=}"
+            : "${DISCORD_CLIENT_ID:=}"
+            : "${DISCORD_CLIENT_SECRET:=}"
+            : "${DISCORD_CALLBACK_URL:=}"
+            : "${DISCORD_BOT_TOKEN:=}"
+            : "${DISCORD_GUILD_ID:=}"
+            : "${DISCORD_INVITE_URL:=}"
+            : "${DISCORD_ROLE_ID_PM:=}"
+            : "${DISCORD_ROLE_ID_PD:=}"
+            : "${DISCORD_ROLE_ID_BE:=}"
+            : "${DISCORD_ROLE_ID_FE:=}"
+            : "${DISCORD_ROLE_ID_IOS:=}"
+            : "${DISCORD_ROLE_ID_AOS:=}"
+
+            # 반대로 이게 비면 앱이 부팅조차 못 한다(env.validation 의 필수 항목 + 배포 필수값).
+            # 2분 뒤 헬스체크 실패로 알게 되는 대신, 여기서 이름을 찍고 즉시 멈춘다.
+            MISSING=""
+            for required in GHCR_TOKEN APP_IMAGE GIT_SHA \
+                            DB_PORT DB_USERNAME DB_PASSWORD DB_NAME \
+                            JWT_SECRET ENCRYPTION_KEY \
+                            GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET GOOGLE_CALLBACK_URL \
+                            CLIENT_REDIRECT_URL GCP_SERVICE_ACCOUNT_JSON GCS_BUCKET_NAME; do
+              if [ -z "${!required:-}" ]; then
+                MISSING="$MISSING $required"
+              fi
+            done
+            if [ -n "$MISSING" ]; then
+              echo "ERROR: 필수 시크릿이 비어 있습니다:$MISSING"
+              echo "       GitHub 저장소 Settings > Secrets 를 확인하세요."
+              exit 1
+            fi
 
             APP_PORT="${APP_PORT:-3000}"
             BASE="http://localhost:${APP_PORT}"
@@ -125,7 +164,9 @@ jobs:
             printf 'DB_PASSWORD=%s\n' "$DB_PASSWORD" >> .env.production
             printf 'DB_NAME=%s\n'     "$DB_NAME"     >> .env.production
             printf 'APP_IMAGE=%s\n'   "$APP_IMAGE"   >> .env.production
-            printf 'APP_VERSION=%s\n' "$GIT_SHA"     >> .env.production
+            # APP_VERSION 은 여기에 쓰지 않는다.
+            # 이미지에 각인된 값(Dockerfile 의 ENV)만 읽어야 "이미지가 실제로 갱신됐는가" 를
+            # 검증할 수 있다. env 파일에 써넣으면 우리가 쓴 값을 우리가 되읽어 항상 통과한다.
             printf 'JWT_SECRET=%s\n'         "$JWT_SECRET"           >> .env.production
             printf 'JWT_EXPIRES_IN=%s\n'     "$JWT_EXPIRES_IN"       >> .env.production
             printf 'ADMIN_BOOTSTRAP_TOKEN=%s\n'           "$ADMIN_BOOTSTRAP_TOKEN"           >> .env.production

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,13 @@ RUN yarn install --frozen-lockfile --production=true && yarn cache clean
 
 COPY --from=builder /app/dist ./dist
 
+# 이미지에 빌드 커밋을 각인한다.
+# 배포 후 "실제로 어떤 커밋이 돌고 있는가" 를 이미지/런타임 양쪽에서 확인할 수 있어야
+# 컨테이너가 갱신되지 않은 채 헬스체크만 통과하는 가짜 성공을 잡아낼 수 있다.
+ARG GIT_SHA=unknown
+ENV APP_VERSION=$GIT_SHA
+LABEL org.opencontainers.image.revision=$GIT_SHA
+
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 USER appuser
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,16 @@
+# 컨테이너 stdout 로그는 기본값이 무제한이라 디스크를 조용히 채운다.
+# 2026-08 장애에서 postgres 크래시 루프 로그만 312MB 까지 자랐다.
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: '10m'
+    max-file: '3'
+
 services:
   app:
     image: ${APP_IMAGE:-ddd-be:local}
     container_name: ddd-be-app
+    logging: *default-logging
     env_file:
       - ${APP_ENV_FILE:-.env.development}
     environment:
@@ -18,6 +27,7 @@ services:
   postgres:
     image: postgres:16-alpine
     container_name: ddd-be-postgres
+    logging: *default-logging
     environment:
       POSTGRES_DB: ${DB_NAME}
       POSTGRES_USER: ${DB_USERNAME}
@@ -37,6 +47,7 @@ services:
   caddy:
     image: caddy:2-alpine
     container_name: ddd-be-caddy
+    logging: *default-logging
     restart: unless-stopped
     ports:
       - '80:80'

--- a/src/config/env.validation.spec.ts
+++ b/src/config/env.validation.spec.ts
@@ -38,6 +38,47 @@ describe('env validation', () => {
     }).toThrow('ENCRYPTION_KEY must be a 64-character hex string.');
   });
 
+  describe('DB_SYNCHRONIZE 스위치', () => {
+    // 이 값은 프로덕션 DB 에 자동 DDL 을 돌릴지를 결정한다.
+    // 기본값이 바뀌면 기존 배포의 스키마 반영 방식이 조용히 달라지므로 회귀 테스트로 고정한다.
+    it('미설정이면 기존 동작인 true 가 유지된다', () => {
+      const result = validate(createValidConfig());
+
+      expect(result.DB_SYNCHRONIZE).toBe('true');
+    });
+
+    it('false 를 명시하면 그대로 유지된다', () => {
+      const result = validate({ ...createValidConfig(), DB_SYNCHRONIZE: 'false' });
+
+      expect(result.DB_SYNCHRONIZE).toBe('false');
+    });
+
+    it('빈 문자열이어도 앱 부팅을 막지 않는다', () => {
+      expect(() => validate({ ...createValidConfig(), DB_SYNCHRONIZE: '' })).not.toThrow();
+    });
+
+    it('true/false 가 아닌 값이면 앱 시작 전에 실패한다', () => {
+      expect(() => validate({ ...createValidConfig(), DB_SYNCHRONIZE: 'yes' })).toThrow();
+    });
+  });
+
+  describe('APP_VERSION', () => {
+    // 배포 워크플로가 "요청한 커밋 == 실행 중인 커밋" 을 이 값으로 판정한다.
+    it('미설정이면 unknown 이 되어 배포 검증이 불일치로 떨어진다', () => {
+      const result = validate(createValidConfig());
+
+      expect(result.APP_VERSION).toBe('unknown');
+    });
+
+    it('이미지가 각인한 커밋 SHA 를 그대로 통과시킨다', () => {
+      const sha = 'ab0974367cfcc5295df479bf59336a14a497a4b0';
+
+      const result = validate({ ...createValidConfig(), APP_VERSION: sha });
+
+      expect(result.APP_VERSION).toBe(sha);
+    });
+  });
+
   describe('CALENDAR_PROVIDER 조건부 검증', () => {
     it('CALENDAR_PROVIDER 미설정(기본 console)이면 GOOGLE_CALENDAR_ID/KEY 없이 통과한다', () => {
       expect(() => validate(createValidConfig())).not.toThrow();

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -43,6 +43,18 @@ class EnvironmentVariables {
   @IsOptional()
   NODE_ENV: string = 'development';
 
+  // 이미지 빌드 시 Dockerfile 이 주입하는 커밋 SHA. 배포 검증에 사용한다.
+  @IsString()
+  @IsOptional()
+  APP_VERSION: string = 'unknown';
+
+  // 운영에서 자동 DDL(synchronize) 을 끄기 위한 스위치.
+  // 마이그레이션 체계가 갖춰지기 전까지 기본값은 기존 동작(true) 을 유지한다.
+  // 환경변수는 항상 문자열로 들어오므로 boolean 대신 명시적 문자열로 검증한다.
+  @IsIn(['true', 'false'])
+  @IsOptional()
+  DB_SYNCHRONIZE: string = 'true';
+
   @IsString()
   JWT_SECRET: string;
 

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -51,6 +51,9 @@ class EnvironmentVariables {
   // 운영에서 자동 DDL(synchronize) 을 끄기 위한 스위치.
   // 마이그레이션 체계가 갖춰지기 전까지 기본값은 기존 동작(true) 을 유지한다.
   // 환경변수는 항상 문자열로 들어오므로 boolean 대신 명시적 문자열로 검증한다.
+  // (boolean 으로 선언하면 enableImplicitConversion 이 'false' 를 true 로 뒤집는다)
+  // 빈 문자열이 들어오면 @IsIn 이 실패해 앱이 부팅조차 못 하므로 미설정과 동일하게 취급한다.
+  @ValidateIf((env: EnvironmentVariables) => env.DB_SYNCHRONIZE !== '')
   @IsIn(['true', 'false'])
   @IsOptional()
   DB_SYNCHRONIZE: string = 'true';

--- a/src/config/typeorm.config.ts
+++ b/src/config/typeorm.config.ts
@@ -2,17 +2,24 @@ import { ConfigService } from '@nestjs/config';
 import { TypeOrmModuleOptions } from '@nestjs/typeorm';
 import { DataSourceOptions } from 'typeorm';
 
-export const createTypeOrmModuleOptions = (config: ConfigService): TypeOrmModuleOptions => ({
-  type: 'postgres',
-  host: config.getOrThrow<string>('DB_HOST'),
-  port: config.getOrThrow<number>('DB_PORT'),
-  username: config.getOrThrow<string>('DB_USERNAME'),
-  password: config.getOrThrow<string>('DB_PASSWORD'),
-  database: config.getOrThrow<string>('DB_NAME'),
-  autoLoadEntities: true,
-  synchronize: true,
-  migrationsRun: false,
-});
+export const createTypeOrmModuleOptions = (config: ConfigService): TypeOrmModuleOptions => {
+  // synchronize 는 부팅할 때마다 엔티티 정의에 맞춰 DDL 을 자동 실행한다.
+  // 운영에서는 DB_SYNCHRONIZE=false 로 꺼야 하지만, 마이그레이션이 아직 없으므로
+  // 기본값은 기존 동작(true) 을 유지한다. 마이그레이션 도입 후 운영 환경변수만 바꾸면 된다.
+  const synchronize = config.get<string>('DB_SYNCHRONIZE') !== 'false';
+
+  return {
+    type: 'postgres',
+    host: config.getOrThrow<string>('DB_HOST'),
+    port: config.getOrThrow<number>('DB_PORT'),
+    username: config.getOrThrow<string>('DB_USERNAME'),
+    password: config.getOrThrow<string>('DB_PASSWORD'),
+    database: config.getOrThrow<string>('DB_NAME'),
+    autoLoadEntities: true,
+    synchronize,
+    migrationsRun: false,
+  };
+};
 
 // NOTE :: CLI/마이그레이션 컨텍스트는 NestJS DI 밖에서 실행되므로 process.env 직접 접근을 허용한다.
 export const createTypeOrmDataSourceOptions = (): DataSourceOptions => ({

--- a/src/health/dto/version.response.dto.ts
+++ b/src/health/dto/version.response.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class VersionResponseDto {
+  @ApiProperty({
+    description: '실행 중인 빌드의 커밋 SHA. 이미지에 각인된 값을 그대로 반환한다.',
+    example: 'ab0974367cfcc5295df479bf59336a14a497a4b0',
+  })
+  version: string;
+}

--- a/src/health/health.controller.spec.ts
+++ b/src/health/health.controller.spec.ts
@@ -1,0 +1,41 @@
+import { ConfigService } from '@nestjs/config';
+import { HealthCheckService, TypeOrmHealthIndicator } from '@nestjs/terminus';
+
+import { HealthController } from './health.controller';
+
+describe('HealthController', () => {
+  const createController = (configValue: string | undefined) => {
+    const health = {} as HealthCheckService;
+    const database = {} as TypeOrmHealthIndicator;
+    const config = { get: jest.fn().mockReturnValue(configValue) } as unknown as ConfigService;
+
+    return new HealthController(health, database, config);
+  };
+
+  describe('getVersion', () => {
+    // 배포 워크플로가 "요청한 커밋 == 실행 중인 커밋" 을 이 값으로 판정한다.
+    // 값이 비거나 형식이 달라지면 배포 검증이 통째로 무력화되므로 회귀 테스트로 고정한다.
+    it('이미지에 각인된 커밋 SHA 를 그대로 반환한다', () => {
+      // given
+      const sha = 'ab0974367cfcc5295df479bf59336a14a497a4b0';
+      const controller = createController(sha);
+
+      // when
+      const result = controller.getVersion();
+
+      // then
+      expect(result).toEqual({ version: sha });
+    });
+
+    it('APP_VERSION 이 없으면 unknown 을 반환한다', () => {
+      // given
+      const controller = createController(undefined);
+
+      // when
+      const result = controller.getVersion();
+
+      // then
+      expect(result).toEqual({ version: 'unknown' });
+    });
+  });
+});

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -30,6 +30,8 @@ export class HealthController {
   @ApiOkResponse({ type: VersionResponseDto })
   @Get('version')
   getVersion(): VersionResponseDto {
-    return { version: this.config.get<string>('APP_VERSION') ?? 'unknown' };
+    const version = this.config.get<string>('APP_VERSION') ?? 'unknown';
+
+    return { version };
   }
 }

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -1,12 +1,16 @@
 import { Controller, Get } from '@nestjs/common';
-import { ApiOperation } from '@nestjs/swagger';
+import { ConfigService } from '@nestjs/config';
+import { ApiOkResponse, ApiOperation } from '@nestjs/swagger';
 import { HealthCheck, HealthCheckService, TypeOrmHealthIndicator } from '@nestjs/terminus';
+
+import { VersionResponseDto } from './dto/version.response.dto';
 
 @Controller({ path: 'health', version: '1' })
 export class HealthController {
   constructor(
     private readonly health: HealthCheckService,
     private readonly database: TypeOrmHealthIndicator,
+    private readonly config: ConfigService,
   ) {}
 
   @ApiOperation({ summary: 'Health check', operationId: 'health_getHealth' })
@@ -15,5 +19,17 @@ export class HealthController {
   async check() {
     const checks = [() => this.database.pingCheck('database')];
     return this.health.check(checks);
+  }
+
+  /**
+   * 실행 중인 컨테이너의 빌드 커밋을 그대로 노출한다.
+   * 배포 워크플로가 "요청한 커밋 == 실제 실행 중인 커밋" 을 검증하는 데 사용하며,
+   * DB 에 의존하지 않으므로 DB 장애 중에도 응답한다.
+   */
+  @ApiOperation({ summary: '실행 중인 빌드 버전', operationId: 'health_getVersion' })
+  @ApiOkResponse({ type: VersionResponseDto })
+  @Get('version')
+  getVersion(): VersionResponseDto {
+    return { version: this.config.get<string>('APP_VERSION') ?? 'unknown' };
   }
 }


### PR DESCRIPTION
## 개요

배포가 실패해도 GitHub Actions 가 성공으로 보고하던 문제를 고칩니다. 그 결과 **2026-05-19 이후 3개월간 어떤 배포도 프로덕션에 반영되지 않았고 아무도 몰랐습니다.**

프로덕션 VM 에서 직접 확인한 증거입니다.

```
ddd-be-app  Created=2026-05-19T02:51:25Z  RestartCount=0
```

컨테이너가 5월 19일 이후 한 번도 재생성되지 않았습니다. 그동안 CI/CD/Deploy 는 계속 초록불이었습니다.

## 변경 이유

2026-08-16 프로덕션 장애(디스크 100% → postgres 크래시 루프 → 모든 DB API 500)를 조사하다 발견했습니다. 디스크는 방아쇠였을 뿐이고, 근본 원인은 파이프라인이 거짓말을 한다는 것이었습니다.

인과 사슬입니다.

1. `deploy.yml` 의 ssh script 에 `set -e` 가 없었습니다.
2. 디스크가 가득 차 `printf ... > .env.production` 이 ENOSPC 로 실패했는데도 다음 줄로 진행했습니다.
3. `.env.production` 이 0바이트가 되어 `${APP_IMAGE}` 가 비었고, `docker-compose.yml` 의 `${APP_IMAGE:-ddd-be:local}` 폴백이 존재하지 않는 이미지를 가리켜 `docker compose up -d` 가 조용히 실패했습니다.
4. 마지막 검증이 `curl /api/v1/health` 200 뿐이었는데, **갱신되지 않은 옛 컨테이너가 대신 200 을 돌려주어** 배포가 성공으로 처리됐습니다.

`/opt/ddd-be/.env.production` 과 `gcp-key.json` 이 0바이트에 mtime 이 `Aug 9 12:52` 로 남아 있는 것이 그 흔적입니다.

## 주요 변경 사항

### 1. 배포 성공 판정을 코드 동일성으로 바꿉니다 (이 PR 의 핵심)

- `Dockerfile` 이 빌드 커밋을 `ENV APP_VERSION` 과 `LABEL org.opencontainers.image.revision` 으로 이미지에 각인합니다.
- `GET /api/v1/health/version` 을 추가했습니다. DB 에 의존하지 않아 DB 장애 중에도 응답합니다.
- `deploy.yml` 이 헬스체크 뒤에 **"요청한 커밋 == 실행 중인 커밋"** 을 검증하고, 불일치면 실패 처리합니다.
- `APP_VERSION` 은 `.env.production` 에 쓰지 않습니다. `env_file` 이 이미지 `ENV` 를 덮어쓰므로, 거기에 쓰면 우리가 써넣은 값을 우리가 되읽어 검증이 항상 통과합니다. 미래에 누가 다시 넣으면 배포가 실패하도록 가드도 넣었습니다.

이 검증이 있었다면 8월 9일에 빨간불이 떴고, 3개월이 아니라 그날 끝났습니다.

### 2. 조용한 실패를 없앱니다

- `set -euo pipefail` 추가. 원격 셸이 bash 인지도 확인합니다. dash 면 `set -o pipefail` 이 실패해 `-e`/`-u` 까지 통째로 적용되지 않은 채 사고 이전 상태로 회귀합니다.
- 선택 시크릿 16개에 기본값을 주고, 필수 15개는 반대로 조기 검증합니다. `set -e` 는 "명령 실패" 만 잡고 "값의 부재" 는 잡지 못합니다.
- `.env.production` 완결성을 **센티널 라인**으로 판정합니다. 줄 수 임계값 같은 매직 넘버는 항목이 늘면 곧바로 거짓말을 합니다(실제 39줄인데 임계값 30 이면 뒤 9줄이 잘려도 통과합니다).
- `gcp-key.json` 을 임시 파일 검증 후 **inode 를 보존한 채** 치환합니다. 이 파일은 실행 중 컨테이너에 단일 파일로 바인드 마운트되어 있어, `>` 로 직접 쓰면 쓰기 실패 시 아직 교체되지도 않은 구 컨테이너가 0바이트 키를 보게 됩니다.
- 빈 파일 판정을 `echo` 에서 `printf` 로 바꿨습니다. `echo ""` 는 개행 1바이트를 써서 `[ -s ]` 가 통과합니다.

### 3. 배포 대상을 불변 태그로 특정합니다

- `:latest` 대신 커밋 SHA 태그로 배포합니다. `:latest` 는 "지금 무엇이 돌고 있는가" 에 답할 수 없게 만드는 태그입니다.
- `cd.yml` 의 이미지 태그를 `github.sha` 에서 `github.event.workflow_run.head_sha` 로 고쳤습니다. 체크아웃 ref 와 달라서 **커밋 X 의 코드를 빌드해 커밋 Y 의 태그를 붙일 수 있었습니다.**
- VM 을 건드리기 전에 GHCR 에 태그가 있는지 `docker manifest inspect` 로 확인합니다. `workflow_run` 이 CI → CD → Deploy 로 두 번 연쇄되어 SHA 가 미끄러질 수 있는데, scp 로 VM 파일을 덮어쓴 뒤 pull 에서 죽으면 상태만 어중간해집니다.
- pull 직후 이미지 라벨과 배포 대상 SHA 를 대조합니다. 컨테이너를 띄우기 전에 잡습니다.

### 4. 디스크 축적을 차단합니다

- `docker-compose.yml` 에 로그 로테이션(`10m × 3`)을 넣었습니다. 이번 장애에서 postgres 로그만 312MB 였습니다.
- 배포 전 디스크 가드(2GB). 부족하면 롤백 창 밖의 앱 이미지만 비파괴 회수한 뒤 재측정합니다. 곧바로 포기하면 정리 단계에 영원히 도달하지 못해 디스크가 한 번 차는 순간 Actions 만으로 빠져나올 수 없게 됩니다.
- 이미지 정리를 **배포 검증 이후로** 옮겼습니다. 실패 시 되돌아갈 대상을 먼저 지우지 않습니다.
- 정리 대상을 `label` 필터로 우리 앱 이미지에만 한정했습니다. `until` 은 pull 시각이 아니라 **이미지 빌드 시각** 기준이라, 필터가 없으면 수개월 전 빌드된 `postgres:16-alpine` 과 `caddy:2-alpine` 도 매 배포마다 후보가 됩니다. 이 호스트는 containerd 스냅샷터라 실행 중 컨테이너의 이미지가 prune 된 전례가 있습니다.

### 5. 운영 레버

- `workflow_dispatch` 추가. 지금까지 **수동 배포 레버가 아예 없어서** 재실행이 실패하면 main 에 커밋을 밀어 전체 파이프라인을 다시 태우는 수밖에 없었습니다.
- 구버전 롤백용 `skip_version_check` 입력. 이 PR 이전 이미지에는 version 엔드포인트가 없어 롤백이 성공해도 검증이 실패로 떨어집니다.
- `export-openapi` 를 `workflow_dispatch` 에서 제외했습니다. `ref` 없이 기본 브랜치를 체크아웃해 push 하므로 과거 커밋 배포 시 구버전 스펙이 main 을 덮어씁니다.
- `caddy reload` 를 검증 이후로 옮기고 3회 재시도를 붙였습니다. `set -e` 도입으로 이 줄이 배포 중단 사유로 승격됐는데, 이번 배포는 `logging` 추가로 caddy 가 재생성되어 admin API 바인딩 전에 `exec` 가 걸릴 수 있습니다.
- 헬스체크 예산 24회 → 36회, 실패 시 postgres 로그도 함께 덤프합니다.

### 6. `synchronize` 스위치

`typeorm.config.ts` 의 `synchronize` 를 `DB_SYNCHRONIZE` 로 제어할 수 있게 했습니다. **기본값은 기존 동작(`true`) 그대로**라 이 PR 로는 아무것도 바뀌지 않습니다. `src/config/migrations` 가 아직 없어서 지금 끄면 스키마 변경이 영영 반영되지 않기 때문입니다.

## 아키텍처 영향

- **도메인 분리**: 변경 없음
- **레이어 변경**: health 모듈에 version 응답 DTO 추가 (Interface 계층). Domain 오염 없음
- **의존 방향 영향**: 없음
- **트랜잭션 경계 영향**: 없음

## 테스트

- [x] 단위 테스트 — `yarn test` **34 suites / 289 tests 통과** (`env.validation` 6건, `health.controller` 2건 신규)
- [ ] 통합 테스트
- [x] 수동 테스트

확인 내용입니다.

- `yarn lint:check` **0 errors** (경고 19건은 미변경 파일의 기존 CRLF prettier 경고)
- `yarn build` 통과
- 워크플로에서 배포 스크립트(294줄)를 추출해 `bash -n` 문법 검사 통과, 스크립트 내 GitHub 템플릿 표현식 0개 확인
- `envs` 목록과 `env` 키가 완전히 일치함을 파싱으로 확인 (desync 시 `set -u` 로 배포가 즉사)
- 원격 셸이 bash 5.2 이며 `pipefail`·간접참조를 지원함을 실제 VM 에서 확인
- 가드 15종 격리 실행: SHA 형식 4종, 센티널 2종, `APP_VERSION` 유입 2종, 버전 비교 4종(양쪽 빈 문자열 포함), gcp-key 3종 전부 의도대로 동작
- `DB_SYNCHRONIZE` 미설정 시 `synchronize=true` 로 기존 동작이 유지됨을 `dist` 직접 호출로 확인

적대적 코드 리뷰 2건(OMC / superpowers)을 받아 지적을 전부 반영했습니다. 두 리뷰 모두 최초 판정이 "수정 후 머지 가능" 이었고, Blocker 1건(prune 범위)과 High 다수를 이 PR 에 반영했습니다.

## 리뷰 포인트

1. **`deploy.yml` 의 버전 검증 로직.** 이 PR 의 존재 이유입니다. 헬스체크 200 은 옛 컨테이너도 돌려줄 수 있으므로 성공 판정 근거가 될 수 없습니다.
2. **prune 의 `label` 필터.** 이게 없으면 `postgres`/`caddy` 이미지를 매 배포마다 도박에 겁니다.
3. **센티널 방식.** 매직 넘버 임계값은 항목이 늘어나는 순간 거짓말을 시작합니다.
4. **`APP_VERSION` 을 env 파일에 쓰지 않는 것.** 여기 다시 들어가면 검증 전체가 무의미해집니다.

## 리스크 / 후속 작업

- 배포 간격이 168h 를 넘으면 **로컬 롤백 이미지가 남지 않습니다.** GHCR 의 SHA 태그가 실질적 롤백 저장소이며 `workflow_dispatch` 로 재배포할 수 있습니다.
- **검증 실패 시 자동 롤백은 없습니다.** 프로덕션이 교체된 뒤 빨간불로 끝나므로 복구는 사람이 해야 합니다.
- `synchronize` 는 여전히 `true` 입니다. **마이그레이션 베이스라인 생성이 선행되어야** 운영에서 끌 수 있습니다.
- **배포 실패 알림이 없습니다.** 3개월간 아무도 몰랐던 이유는 실패가 보고되지 않아서이기도 하지만 아무도 워크플로를 보지 않아서이기도 합니다. 저장소에 이미 `DISCORD_BOT_TOKEN` 이 있으니 알림을 붙일 수 있습니다.
- **디스크 증설(9.7GB → 50GB)과 GCP Monitoring 디스크 알람**은 인프라 콘솔 작업이라 이 PR 밖입니다. 이 둘이 사실 가장 싸고 확실한 재발 방지책입니다. VM 에 `google-cloud-ops-agent` 가 이미 설치되어 있어 알람은 설정만 하면 됩니다.
- **DB 자동 백업이 없습니다.** 데이터가 78KB 규모라 비용은 사실상 0 입니다.

### 머지 시 주의

머지하면 곧바로 배포가 돌아갑니다. 현재 프로덕션은 3개월 묵은 `70f118c` 를 돌리고 있으므로, 이 머지가 **3개월치 변경을 한 번에 올리는 배포**가 됩니다.

- `70f118c..HEAD` 사이 **엔티티 변경은 0건**이라 `synchronize` 자동 DDL 이 건드릴 것은 없습니다.
- DB 백업은 확보해 두었습니다 (`/var/tmp/pgdump_2026-08-16_0751.sql`, 78,890 bytes).
- `logging` 추가로 3개 컨테이너가 모두 재생성되므로 수십 초 다운타임이 있습니다. 저트래픽 시간대를 권합니다.
