### PR TITLE
feat(application): 지원서 PDF 첨부 업로드 지원 + 개인정보 파기 동작 복구

### DIFF
--- a/src/application/application.module.ts
+++ b/src/application/application.module.ts
@@ -5,6 +5,7 @@ import { CohortModule } from '../cohort/cohort.module';
 import { RolesGuard } from '../common/guard/roles.guard';
 import { InterviewModule } from '../interview/interview.module';
 import { NotificationModule } from '../notification/notification.module';
+import { StorageModule } from '../storage/storage.module';
 import { ApplicationRepository } from './domain/application.repository';
 import { ApplicationDraft } from './domain/application-draft.entity';
 import { ApplicationForm } from './domain/application-form.entity';
@@ -16,24 +17,29 @@ import { AdminApplicationController } from './interface/admin.application.contro
 import { PublicApplicationController } from './interface/public.application.controller';
 import { ApplicationService } from './usecase/application.service';
 import { ApplicationAnswerValidator } from './usecase/application-answer.validator';
+import { ApplicationAttachmentService } from './usecase/application-attachment.service';
 import { ApplicationQueryService } from './usecase/application-query.service';
+import { PiiPurgeService } from './usecase/pii-purge.service';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([ApplicationForm, ApplicationDraft]),
     CohortModule,
     NotificationModule,
+    StorageModule,
     forwardRef(() => InterviewModule),
   ],
   controllers: [AdminApplicationController, PublicApplicationController],
   providers: [
     ApplicationAnswerValidator,
+    ApplicationAttachmentService,
     ApplicationQueryService,
     ApplicationService,
     ApplicationRepository,
     FormWriteRepository,
     DraftWriteRepository,
     EmailEventHandler,
+    PiiPurgeService,
     PiiPurgeScheduler,
     RolesGuard,
   ],

--- a/src/application/domain/application-attachment.spec.ts
+++ b/src/application/domain/application-attachment.spec.ts
@@ -1,0 +1,144 @@
+import {
+  buildAttachmentSubPath,
+  collectAttachmentPaths,
+  findForeignAttachmentPaths,
+  isOwnedAttachmentPath,
+  MAX_ANSWER_DEPTH,
+  TooDeepAnswersError,
+} from './application-attachment';
+
+const DEEP_PATH = 'applications/attachments/12/deep.pdf';
+
+describe('application-attachment', () => {
+  describe('buildAttachmentSubPath', () => {
+    it('사용자 ID를 하위 경로로 사용한다', () => {
+      expect(buildAttachmentSubPath({ userId: 12 })).toBe('12');
+    });
+  });
+
+  describe('isOwnedAttachmentPath', () => {
+    it('본인 경로면 true 를 반환한다', () => {
+      const path = 'applications/attachments/12/abc.pdf';
+
+      expect(isOwnedAttachmentPath({ path, userId: 12 })).toBe(true);
+    });
+
+    it('타인 경로면 false 를 반환한다', () => {
+      const path = 'applications/attachments/99/abc.pdf';
+
+      expect(isOwnedAttachmentPath({ path, userId: 12 })).toBe(false);
+    });
+
+    it('userId 가 접두어로 겹치는 경로를 소유로 오인하지 않는다', () => {
+      const path = 'applications/attachments/121/abc.pdf';
+
+      expect(isOwnedAttachmentPath({ path, userId: 12 })).toBe(false);
+    });
+
+    it('첨부 prefix 밖의 경로는 소유로 보지 않는다', () => {
+      const path = 'projects/pdfs/12/abc.pdf';
+
+      expect(isOwnedAttachmentPath({ path, userId: 12 })).toBe(false);
+    });
+
+    it('상위 경로 탈출이 섞인 경로는 접두어가 맞아도 거부한다', () => {
+      const path = 'applications/attachments/12/../99/victim.pdf';
+
+      expect(isOwnedAttachmentPath({ path, userId: 12 })).toBe(false);
+    });
+
+    it('허용되지 않는 문자가 섞인 경로는 거부한다', () => {
+      const path = 'applications/attachments/12/a b.pdf';
+
+      expect(isOwnedAttachmentPath({ path, userId: 12 })).toBe(false);
+    });
+  });
+
+  describe('collectAttachmentPaths', () => {
+    it('answers 안의 첨부 경로를 모은다', () => {
+      const answers = {
+        q1: '텍스트 답변',
+        q2: { path: 'applications/attachments/12/a.pdf', originalName: 'a.pdf', size: 100 },
+      };
+
+      expect(collectAttachmentPaths({ answers })).toEqual(['applications/attachments/12/a.pdf']);
+    });
+
+    it('배열과 중첩 객체 안의 첨부도 찾는다', () => {
+      const answers = {
+        q1: [{ path: 'applications/attachments/12/a.pdf' }],
+        q2: { nested: { path: 'applications/attachments/12/b.pdf' } },
+      };
+
+      expect(collectAttachmentPaths({ answers }).sort()).toEqual([
+        'applications/attachments/12/a.pdf',
+        'applications/attachments/12/b.pdf',
+      ]);
+    });
+
+    it('중복 경로는 한 번만 반환한다', () => {
+      const answers = {
+        q1: { path: 'applications/attachments/12/a.pdf' },
+        q2: { path: 'applications/attachments/12/a.pdf' },
+      };
+
+      expect(collectAttachmentPaths({ answers })).toEqual(['applications/attachments/12/a.pdf']);
+    });
+
+    it('첨부 prefix 가 아닌 path 값은 무시한다', () => {
+      const answers = { q1: { path: 'projects/pdfs/a.pdf' } };
+
+      expect(collectAttachmentPaths({ answers })).toEqual([]);
+    });
+
+    it('첨부가 없으면 빈 배열을 반환한다', () => {
+      expect(collectAttachmentPaths({ answers: { q1: '텍스트' } })).toEqual([]);
+    });
+
+    it('문자열로 들어온 첨부 경로도 찾는다', () => {
+      const answers = { q1: 'applications/attachments/12/a.pdf' };
+
+      expect(collectAttachmentPaths({ answers })).toEqual(['applications/attachments/12/a.pdf']);
+    });
+
+    it('배열 안의 문자열 첨부 경로도 찾는다', () => {
+      const answers = { q1: ['applications/attachments/12/a.pdf'] };
+
+      expect(collectAttachmentPaths({ answers })).toEqual(['applications/attachments/12/a.pdf']);
+    });
+
+    it('깊게 중첩된 첨부도 놓치지 않는다', () => {
+      const answers = { a: { b: { c: { d: { e: { f: { path: DEEP_PATH } } } } } } };
+
+      expect(collectAttachmentPaths({ answers })).toEqual([DEEP_PATH]);
+    });
+
+    it('탐색 한계를 넘는 answers 는 조용히 통과시키지 않고 예외를 던진다', () => {
+      let nested: Record<string, unknown> = { path: DEEP_PATH };
+      for (let depth = 0; depth <= MAX_ANSWER_DEPTH; depth += 1) {
+        nested = { nested };
+      }
+
+      expect(() => collectAttachmentPaths({ answers: nested })).toThrow(TooDeepAnswersError);
+    });
+  });
+
+  describe('findForeignAttachmentPaths', () => {
+    it('타인 소유 첨부 경로만 골라낸다', () => {
+      const answers = {
+        q1: { path: 'applications/attachments/12/mine.pdf' },
+        q2: { path: 'applications/attachments/99/stolen.pdf' },
+      };
+
+      expect(findForeignAttachmentPaths({ answers, userId: 12 })).toEqual([
+        'applications/attachments/99/stolen.pdf',
+      ]);
+    });
+
+    it('모두 본인 소유면 빈 배열을 반환한다', () => {
+      const answers = { q1: { path: 'applications/attachments/12/mine.pdf' } };
+
+      expect(findForeignAttachmentPaths({ answers, userId: 12 })).toEqual([]);
+    });
+  });
+});

--- a/src/application/domain/application-attachment.ts
+++ b/src/application/domain/application-attachment.ts
@@ -1,0 +1,113 @@
+/**
+ * 지원서 첨부파일(포트폴리오 PDF) 경로 규칙.
+ *
+ * 첨부는 `applications/attachments/{userId}/{uuid}.pdf` 로 저장한다.
+ * 경로에 소유자를 박아두면 열람 권한 검증이 문자열 비교로 끝나고,
+ * answers 안에 남의 첨부 경로를 섞어 넣는 것도 같은 규칙으로 막을 수 있다.
+ */
+export const ATTACHMENT_PATH_PREFIX = 'applications/attachments';
+
+/**
+ * answers 탐색 깊이 상한.
+ *
+ * 순환 참조는 answers 가 JSON 파싱 결과라 발생할 수 없으므로, 이 상한의 목적은
+ * 스택 오버플로를 노린 과도한 중첩을 막는 것뿐이다. 프런트가 쓸 법한 중첩
+ * (섹션 > 질문 배열 > 답변 > 파일 배열)을 여유 있게 담도록 넉넉히 잡는다.
+ */
+export const MAX_ANSWER_DEPTH = 12;
+
+/** 탐색 상한을 넘은 answers. 저장 시점에 거부해야 파기 시 미탐이 생기지 않는다. */
+export class TooDeepAnswersError extends Error {
+  constructor() {
+    super(`answers 중첩이 허용 깊이(${MAX_ANSWER_DEPTH})를 초과했습니다.`);
+    this.name = 'TooDeepAnswersError';
+  }
+}
+
+export type ApplicationAttachment = {
+  path: string;
+  originalName: string;
+  size: number;
+};
+
+export const buildAttachmentSubPath = ({ userId }: { userId: number }): string => String(userId);
+
+/** 스토리지 경로에 허용하는 문자. traversal·인코딩 우회를 여기서 끊는다. */
+const SAFE_ATTACHMENT_PATH_PATTERN = /^[a-zA-Z0-9._\-/]+$/;
+
+const hasSafePathShape = ({ path }: { path: string }): boolean => {
+  if (!path || path.length > 1024 || !SAFE_ATTACHMENT_PATH_PATTERN.test(path)) {
+    return false;
+  }
+  return !path.split('/').some((segment) => segment === '' || segment === '.' || segment === '..');
+};
+
+export const isAttachmentPath = ({ path }: { path: string }): boolean =>
+  hasSafePathShape({ path }) && path.startsWith(`${ATTACHMENT_PATH_PREFIX}/`);
+
+/**
+ * 경로 형식까지 여기서 함께 검증한다.
+ * `applications/attachments/12/../99/x.pdf` 는 접두어만 보면 통과하므로,
+ * 형식 검사를 storage 쪽 하류 가드에 미루면 이 게이트를 쓰는 새 호출자가
+ * 생기는 순간 그대로 취약점이 된다.
+ */
+export const isOwnedAttachmentPath = ({
+  path,
+  userId,
+}: {
+  path: string;
+  userId: number;
+}): boolean =>
+  hasSafePathShape({ path }) && path.startsWith(`${ATTACHMENT_PATH_PREFIX}/${userId}/`);
+
+/**
+ * answers JSON 안에 들어있는 첨부 경로를 모두 모은다.
+ *
+ * 질문 스키마가 자유 형식(jsonb)이라 첨부가 어느 위치·어느 키·어느 모양으로
+ * 오는지 고정할 수 없다. 그래서 특정 키(`path`)나 특정 깊이를 가정하지 않고
+ * **모든 문자열 값**을 검사한다. 여기서 놓친 경로는 소유권 검증도 통과하고
+ * 180일 파기에서도 누락되므로, 미탐은 곧 개인정보 잔존이다.
+ *
+ * 깊이 상한을 넘으면 조용히 무시하지 않고 던진다(fail-closed). 저장 시점에
+ * 거부되므로 DB에 들어간 answers 는 항상 이 함수로 완전히 훑을 수 있다.
+ *
+ * @throws {TooDeepAnswersError} 중첩이 MAX_ANSWER_DEPTH 를 초과한 경우
+ */
+export const collectAttachmentPaths = ({ answers }: { answers: unknown }): string[] => {
+  const paths = new Set<string>();
+
+  const visit = (value: unknown, depth: number): void => {
+    if (typeof value === 'string') {
+      if (isAttachmentPath({ path: value })) {
+        paths.add(value);
+      }
+      return;
+    }
+
+    if (value === null || typeof value !== 'object') {
+      return;
+    }
+
+    if (depth >= MAX_ANSWER_DEPTH) {
+      throw new TooDeepAnswersError();
+    }
+
+    // 배열도 Object.values 로 함께 순회된다.
+    for (const child of Object.values(value as Record<string, unknown>)) {
+      visit(child, depth + 1);
+    }
+  };
+
+  visit(answers, 0);
+  return [...paths];
+};
+
+/** answers 안의 첨부 중 해당 사용자 소유가 아닌 경로를 돌려준다. */
+export const findForeignAttachmentPaths = ({
+  answers,
+  userId,
+}: {
+  answers: unknown;
+  userId: number;
+}): string[] =>
+  collectAttachmentPaths({ answers }).filter((path) => !isOwnedAttachmentPath({ path, userId }));

--- a/src/application/domain/application.repository.ts
+++ b/src/application/domain/application.repository.ts
@@ -73,6 +73,6 @@ export class ApplicationRepository {
       ApplicationStatus.활동중단,
     ];
 
-    return this.formWriteRepository.nullifyPii({ terminalStatuses, cutoffDate });
+    return await this.formWriteRepository.nullifyPii({ terminalStatuses, cutoffDate });
   }
 }

--- a/src/application/infrastructure/form.write.repository.ts
+++ b/src/application/infrastructure/form.write.repository.ts
@@ -5,6 +5,44 @@ import type { ApplicationStatus } from '../domain/application.status';
 import { ApplicationForm } from '../domain/application-form.entity';
 import type { ApplicationFormFilter, ApplicationFormQuery } from './write.repository.type';
 
+// 기산점 우선순위:
+//   1) activityEndedAt (활동완료/활동중단 확정일)
+//   2) announcedAt (서류/최종 합격 발표일)
+//   3) updatedAt (터미널 상태 진입 시점 fallback)
+//   4) createdAt (비터미널 상태 기본 fallback)
+// 활동 종료 시점이 존재하면 수료생에 대해 가장 늦은 기산점으로 동작하며,
+// 그 외에는 기존 announcedAt -> updatedAt -> createdAt 순으로 판단한다.
+//
+// 컬럼에 `form.` alias 를 붙이면 안 된다.
+// TypeORM 의 UpdateQueryBuilder 는 UPDATE 대상 테이블에 alias 를 붙이지 않으면서
+// WHERE 절의 alias 한정자는 그대로 남긴다(UpdateQueryBuilder.createUpdateExpression).
+// 그 결과 PostgreSQL 이 `missing FROM-clause entry for table "form"` 으로 거부해
+// 파기가 매번 실패한다. 단일 테이블이라 alias 없이도 모호하지 않다.
+//
+// deletedAt 조건도 명시한다. SELECT 는 TypeORM 이 soft-delete 필터를 자동으로 붙이지만
+// UPDATE 에는 붙이지 않아, 조건을 공유해도 실제 대상 집합이 갈라진다.
+const PII_PURGE_TARGET_CONDITION = `
+  "deletedAt" IS NULL
+  AND "applicantName" IS NOT NULL
+  AND (
+    ("activityEndedAt" IS NOT NULL AND "activityEndedAt" <= :cutoffDate)
+    OR
+    ("activityEndedAt" IS NULL
+      AND "announcedAt" IS NOT NULL
+      AND "announcedAt" <= :cutoffDate)
+    OR
+    ("activityEndedAt" IS NULL
+      AND "announcedAt" IS NULL
+      AND status IN (:...terminalStatuses)
+      AND "updatedAt" <= :cutoffDate)
+    OR
+    ("activityEndedAt" IS NULL
+      AND "announcedAt" IS NULL
+      AND status NOT IN (:...terminalStatuses)
+      AND "createdAt" <= :cutoffDate)
+  )
+`;
+
 @Injectable()
 export class FormWriteRepository {
   private readonly repository: Repository<ApplicationForm>;
@@ -55,13 +93,6 @@ export class FormWriteRepository {
     terminalStatuses: ApplicationStatus[];
     cutoffDate: Date;
   }): Promise<number> {
-    // 기산점 우선순위:
-    //   1) activityEndedAt (활동완료/활동중단 확정일)
-    //   2) announcedAt (서류/최종 합격 발표일)
-    //   3) updatedAt (터미널 상태 진입 시점 fallback)
-    //   4) createdAt (비터미널 상태 기본 fallback)
-    // 활동 종료 시점이 존재하면 수료생에 대해 가장 늦은 기산점으로 동작하며,
-    // 그 외에는 기존 announcedAt -> updatedAt -> createdAt 순으로 판단한다.
     const result = await this.repository
       .createQueryBuilder('form')
       .update(ApplicationForm)
@@ -72,27 +103,7 @@ export class FormWriteRepository {
         applicantRegion: () => 'NULL',
         answers: () => "'{}'::jsonb",
       })
-      .where('form."applicantName" IS NOT NULL')
-      .andWhere(
-        `(
-          (form."activityEndedAt" IS NOT NULL AND form."activityEndedAt" <= :cutoffDate)
-          OR
-          (form."activityEndedAt" IS NULL
-            AND form."announcedAt" IS NOT NULL
-            AND form."announcedAt" <= :cutoffDate)
-          OR
-          (form."activityEndedAt" IS NULL
-            AND form."announcedAt" IS NULL
-            AND form.status IN (:...terminalStatuses)
-            AND form."updatedAt" <= :cutoffDate)
-          OR
-          (form."activityEndedAt" IS NULL
-            AND form."announcedAt" IS NULL
-            AND form.status NOT IN (:...terminalStatuses)
-            AND form."createdAt" <= :cutoffDate)
-        )`,
-        { terminalStatuses, cutoffDate },
-      )
+      .where(PII_PURGE_TARGET_CONDITION, { terminalStatuses, cutoffDate })
       .execute();
 
     return result.affected ?? 0;

--- a/src/application/infrastructure/pii-purge.scheduler.spec.ts
+++ b/src/application/infrastructure/pii-purge.scheduler.spec.ts
@@ -1,50 +1,209 @@
 import { Test } from '@nestjs/testing';
 
+import { StorageService } from '../../storage/application/storage.service';
+import { UploadCategory } from '../../storage/domain/storage.type';
 import { ApplicationRepository } from '../domain/application.repository';
 import { ApplicationStatus } from '../domain/application.status';
+import { PiiPurgeService } from '../usecase/pii-purge.service';
 import type { DraftWriteRepository } from './draft.write.repository';
 import type { FormWriteRepository } from './form.write.repository';
 import { PiiPurgeScheduler } from './pii-purge.scheduler';
 
-const mockApplicationRepository = {
+const mockPiiPurgeService = {
   purgeExpiredPii: jest.fn(),
 };
+
+const buildAttachmentResult = (overrides = {}) => ({
+  scanned: 0,
+  deleted: 0,
+  failed: 0,
+  truncated: false,
+  ...overrides,
+});
 
 describe('PiiPurgeScheduler', () => {
   let scheduler: PiiPurgeScheduler;
 
   beforeEach(async () => {
     const module = await Test.createTestingModule({
-      providers: [
-        PiiPurgeScheduler,
-        { provide: ApplicationRepository, useValue: mockApplicationRepository },
-      ],
+      providers: [PiiPurgeScheduler, { provide: PiiPurgeService, useValue: mockPiiPurgeService }],
     }).compile();
 
     scheduler = module.get(PiiPurgeScheduler);
     jest.clearAllMocks();
+    mockPiiPurgeService.purgeExpiredPii.mockResolvedValue({
+      purgedCount: 0,
+      attachment: buildAttachmentResult(),
+    });
   });
 
-  describe('purgeExpiredPii', () => {
-    it('180일 이전 기준일로 파기를 요청한다', async () => {
-      // Given
-      mockApplicationRepository.purgeExpiredPii.mockResolvedValue(3);
-
-      // When
-      await scheduler.purgeExpiredPii();
-
-      // Then
-      expect(mockApplicationRepository.purgeExpiredPii).toHaveBeenCalledTimes(1);
-
-      const calledCutoff = (
-        mockApplicationRepository.purgeExpiredPii.mock.calls[0] as [{ cutoffDate: Date }]
-      )[0].cutoffDate;
-      const expectedCutoff = new Date();
-      expectedCutoff.setDate(expectedCutoff.getDate() - 180);
-
-      const diffMs = Math.abs(calledCutoff.getTime() - expectedCutoff.getTime());
-      expect(diffMs).toBeLessThan(1000);
+  it('180일 이전 기준일로 파기를 요청한다', async () => {
+    // Given
+    mockPiiPurgeService.purgeExpiredPii.mockResolvedValue({
+      purgedCount: 3,
+      attachment: buildAttachmentResult(),
     });
+
+    // When
+    await scheduler.purgeExpiredPii();
+
+    // Then
+    expect(mockPiiPurgeService.purgeExpiredPii).toHaveBeenCalledTimes(1);
+
+    const calledCutoff = (
+      mockPiiPurgeService.purgeExpiredPii.mock.calls[0] as [{ cutoffDate: Date }]
+    )[0].cutoffDate;
+    const expectedCutoff = new Date();
+    expectedCutoff.setDate(expectedCutoff.getDate() - 180);
+
+    expect(Math.abs(calledCutoff.getTime() - expectedCutoff.getTime())).toBeLessThan(1000);
+  });
+
+  it('파기가 실패해도 cron 이 죽지 않도록 예외를 흡수한다', async () => {
+    // Given
+    mockPiiPurgeService.purgeExpiredPii.mockRejectedValue(new Error('db down'));
+
+    // When & Then
+    await expect(scheduler.purgeExpiredPii()).resolves.toBeUndefined();
+  });
+});
+
+describe('PiiPurgeService', () => {
+  const mockApplicationRepository = { purgeExpiredPii: jest.fn() };
+  const mockStorageService = { listFiles: jest.fn(), deleteFile: jest.fn() };
+  let service: PiiPurgeService;
+
+  const buildObject = (path: string, updatedAt: string | null) => ({
+    path,
+    size: 100,
+    contentType: 'application/pdf',
+    updatedAt,
+    url: `https://storage.googleapis.com/bucket/${path}`,
+  });
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        PiiPurgeService,
+        { provide: ApplicationRepository, useValue: mockApplicationRepository },
+        { provide: StorageService, useValue: mockStorageService },
+      ],
+    }).compile();
+
+    service = module.get(PiiPurgeService);
+    jest.clearAllMocks();
+    mockApplicationRepository.purgeExpiredPii.mockResolvedValue(0);
+    mockStorageService.listFiles.mockResolvedValue({
+      items: [],
+      nextCursor: null,
+      hasNext: false,
+    });
+  });
+
+  it('첨부 카테고리를 스캔해 보관기간이 지난 파일만 삭제한다', async () => {
+    // Given
+    const cutoffDate = new Date('2026-01-01T00:00:00.000Z');
+    mockStorageService.listFiles.mockResolvedValue({
+      items: [
+        buildObject('applications/attachments/12/old.pdf', '2025-06-01T00:00:00.000Z'),
+        buildObject('applications/attachments/13/fresh.pdf', '2026-08-01T00:00:00.000Z'),
+      ],
+      nextCursor: null,
+      hasNext: false,
+    });
+
+    // When
+    const result = await service.purgeExpiredPii({ cutoffDate });
+
+    // Then
+    expect(mockStorageService.listFiles).toHaveBeenCalledWith(
+      expect.objectContaining({ category: UploadCategory.APPLICATION_ATTACHMENT }),
+    );
+    expect(mockStorageService.deleteFile).toHaveBeenCalledTimes(1);
+    expect(mockStorageService.deleteFile).toHaveBeenCalledWith({
+      path: 'applications/attachments/12/old.pdf',
+    });
+    expect(result.attachment).toMatchObject({ scanned: 2, deleted: 1, failed: 0 });
+  });
+
+  it('answers 에 참조가 없는 고아 첨부도 삭제한다', async () => {
+    // Given: 어떤 지원서에서도 참조하지 않는 파일. 스토리지를 진실의 원천으로 삼으므로 삭제된다.
+    mockStorageService.listFiles.mockResolvedValue({
+      items: [buildObject('applications/attachments/77/orphan.pdf', '2020-01-01T00:00:00.000Z')],
+      nextCursor: null,
+      hasNext: false,
+    });
+
+    // When
+    const result = await service.purgeExpiredPii({ cutoffDate: new Date() });
+
+    // Then
+    expect(mockStorageService.deleteFile).toHaveBeenCalledWith({
+      path: 'applications/attachments/77/orphan.pdf',
+    });
+    expect(result.attachment.deleted).toBe(1);
+  });
+
+  it('커서를 따라 모든 페이지를 훑는다', async () => {
+    // Given
+    mockStorageService.listFiles
+      .mockResolvedValueOnce({
+        items: [buildObject('applications/attachments/12/a.pdf', '2020-01-01T00:00:00.000Z')],
+        nextCursor: 'page-2',
+        hasNext: true,
+      })
+      .mockResolvedValueOnce({
+        items: [buildObject('applications/attachments/12/b.pdf', '2020-01-01T00:00:00.000Z')],
+        nextCursor: null,
+        hasNext: false,
+      });
+
+    // When
+    const result = await service.purgeExpiredPii({ cutoffDate: new Date() });
+
+    // Then
+    expect(mockStorageService.listFiles).toHaveBeenCalledTimes(2);
+    expect(mockStorageService.listFiles).toHaveBeenLastCalledWith(
+      expect.objectContaining({ cursor: 'page-2' }),
+    );
+    expect(result.attachment).toMatchObject({ scanned: 2, deleted: 2, truncated: false });
+  });
+
+  it('한 건이 삭제에 실패해도 나머지를 계속 처리한다', async () => {
+    // Given
+    mockStorageService.listFiles.mockResolvedValue({
+      items: [
+        buildObject('applications/attachments/12/a.pdf', '2020-01-01T00:00:00.000Z'),
+        buildObject('applications/attachments/13/b.pdf', '2020-01-01T00:00:00.000Z'),
+      ],
+      nextCursor: null,
+      hasNext: false,
+    });
+    mockStorageService.deleteFile
+      .mockRejectedValueOnce(new Error('already gone'))
+      .mockResolvedValueOnce(undefined);
+
+    // When
+    const result = await service.purgeExpiredPii({ cutoffDate: new Date() });
+
+    // Then
+    expect(mockStorageService.deleteFile).toHaveBeenCalledTimes(2);
+    expect(result.attachment).toMatchObject({ deleted: 1, failed: 1 });
+  });
+
+  it('업로드 시각을 알 수 없는 객체는 삭제하지 않는다', async () => {
+    // Given
+    mockStorageService.listFiles.mockResolvedValue({
+      items: [buildObject('applications/attachments/12/unknown.pdf', null)],
+      nextCursor: null,
+      hasNext: false,
+    });
+
+    // When
+    await service.purgeExpiredPii({ cutoffDate: new Date() });
+
+    // Then
+    expect(mockStorageService.deleteFile).not.toHaveBeenCalled();
   });
 });
 

--- a/src/application/infrastructure/pii-purge.scheduler.ts
+++ b/src/application/infrastructure/pii-purge.scheduler.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 
-import { ApplicationRepository } from '../domain/application.repository';
+import { PiiPurgeService } from '../usecase/pii-purge.service';
 
 const PII_RETENTION_DAYS = 180;
 
@@ -9,17 +9,27 @@ const PII_RETENTION_DAYS = 180;
 export class PiiPurgeScheduler {
   private readonly logger = new Logger(PiiPurgeScheduler.name);
 
-  constructor(private readonly applicationRepository: ApplicationRepository) {}
+  constructor(private readonly piiPurgeService: PiiPurgeService) {}
 
   @Cron(CronExpression.EVERY_DAY_AT_3AM)
-  async purgeExpiredPii() {
+  async purgeExpiredPii(): Promise<void> {
     this.logger.log('개인정보 파기 스케줄러 실행');
 
     const cutoffDate = new Date();
     cutoffDate.setDate(cutoffDate.getDate() - PII_RETENTION_DAYS);
 
-    const purgedCount = await this.applicationRepository.purgeExpiredPii({ cutoffDate });
+    // 파기가 실패해도 cron 이 unhandled rejection 으로 죽지 않도록 여기서 막는다.
+    try {
+      const { purgedCount, attachment } = await this.piiPurgeService.purgeExpiredPii({
+        cutoffDate,
+      });
 
-    this.logger.log(`개인정보 파기 완료: ${purgedCount}건 처리`);
+      this.logger.log(
+        `개인정보 파기 완료: ${purgedCount}건 처리, ` +
+          `첨부 ${attachment.deleted}건 삭제 (스캔 ${attachment.scanned}건, 실패 ${attachment.failed}건)`,
+      );
+    } catch (error) {
+      this.logger.error('개인정보 파기 실패', error);
+    }
   }
 }

--- a/src/application/interface/dto/application.request.dto.ts
+++ b/src/application/interface/dto/application.request.dto.ts
@@ -10,6 +10,7 @@ import {
   IsOptional,
   IsString,
   Matches,
+  MaxLength,
 } from 'class-validator';
 
 import { ApplicationStatus } from '../../domain/application.status';
@@ -59,6 +60,17 @@ export class SubmitApplicationRequestDto {
   @ApiProperty({ description: '개인정보 수집 동의 여부', example: true })
   @IsBoolean()
   privacyAgreed: boolean;
+}
+
+export class AttachmentPathQueryDto {
+  @ApiProperty({
+    description: '첨부파일 경로 (업로드 응답의 path)',
+    example: 'applications/attachments/12/9f1c0d3e-1f2a-4b8c-9d0e-1a2b3c4d5e6f.pdf',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(1024)
+  path: string;
 }
 
 export class UpdateApplicationStatusRequestDto {

--- a/src/application/interface/dto/application.response.dto.ts
+++ b/src/application/interface/dto/application.response.dto.ts
@@ -2,10 +2,33 @@ import { ApiProperty } from '@nestjs/swagger';
 
 import { UserRole } from '../../../user/domain/user.role';
 import { ApplicationStatus } from '../../domain/application.status';
+import type { ApplicationAttachment } from '../../domain/application-attachment';
 import { ApplicationDraft } from '../../domain/application-draft.entity';
 import { ApplicationForm } from '../../domain/application-form.entity';
 
 const PII_ACCESSIBLE_ROLES: UserRole[] = [UserRole.계정관리, UserRole.운영자, UserRole.면접관];
+
+export class ApplicationAttachmentResponseDto {
+  @ApiProperty({
+    description: '첨부파일 경로. 지원서 answers 에 그대로 넣어 제출한다.',
+    example: 'applications/attachments/12/9f1c0d3e-1f2a-4b8c-9d0e-1a2b3c4d5e6f.pdf',
+  })
+  path: string;
+
+  @ApiProperty({ description: '원본 파일명', example: '홍길동_포트폴리오.pdf' })
+  originalName: string;
+
+  @ApiProperty({ description: '파일 크기(bytes)', example: 3145728 })
+  size: number;
+
+  static from(attachment: ApplicationAttachment): ApplicationAttachmentResponseDto {
+    const dto = new ApplicationAttachmentResponseDto();
+    dto.path = attachment.path;
+    dto.originalName = attachment.originalName;
+    dto.size = attachment.size;
+    return dto;
+  }
+}
 
 export class AdminApplicationFormResponseDto {
   @ApiProperty({ description: 'ID', example: 1 })

--- a/src/application/interface/public.application.controller.ts
+++ b/src/application/interface/public.application.controller.ts
@@ -7,27 +7,41 @@ import {
   Param,
   ParseIntPipe,
   Post,
+  Query,
+  UploadedFile,
   UseGuards,
+  UseInterceptors,
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
-import { ApiTags } from '@nestjs/swagger';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { ApiConsumes, ApiTags } from '@nestjs/swagger';
 
 import type { JwtUser } from '../../auth/application/auth.type';
 import { AuthUser } from '../../common/decorator/auth-user.decorator';
 import { ApiResponse } from '../../common/response/api-response';
 import { ApiDoc } from '../../common/swagger/api-doc.decorator';
+import { UPLOAD_CATEGORY_CONFIG, UploadCategory } from '../../storage/domain/storage.type';
+import { SignedUrlResponseDto } from '../../storage/interface/dto/storage.response.dto';
 import { ApplicationService } from '../usecase/application.service';
+import { ApplicationAttachmentService } from '../usecase/application-attachment.service';
 import {
+  AttachmentPathQueryDto,
   SaveApplicationDraftRequestDto,
   SubmitApplicationRequestDto,
 } from './dto/application.request.dto';
-import { PublicApplicationDraftResponseDto } from './dto/application.response.dto';
+import {
+  ApplicationAttachmentResponseDto,
+  PublicApplicationDraftResponseDto,
+} from './dto/application.response.dto';
 
 @ApiTags('Application')
 @Controller({ path: 'applications', version: '1' })
 @UseGuards(AuthGuard('jwt'))
 export class PublicApplicationController {
-  constructor(private readonly applicationService: ApplicationService) {}
+  constructor(
+    private readonly applicationService: ApplicationService,
+    private readonly applicationAttachmentService: ApplicationAttachmentService,
+  ) {}
 
   @ApiDoc({
     summary: '지원서 임시저장',
@@ -59,6 +73,58 @@ export class PublicApplicationController {
   ) {
     const draft = await this.applicationService.findDraftByPart({ userId: user.id, cohortPartId });
     return ApiResponse.ok(PublicApplicationDraftResponseDto.from(draft));
+  }
+
+  @ApiDoc({
+    summary: '지원서 첨부파일 업로드',
+    description:
+      'PDF 포트폴리오 등 지원서 첨부파일을 업로드하고 경로를 반환합니다. 반환된 path 를 answers 에 담아 제출하세요.',
+    operationId: 'application_uploadAttachment',
+    auth: true,
+  })
+  @ApiConsumes('multipart/form-data')
+  @Post('attachments')
+  @HttpCode(HttpStatus.CREATED)
+  @UseInterceptors(
+    FileInterceptor('file', {
+      limits: {
+        fileSize: UPLOAD_CATEGORY_CONFIG[UploadCategory.APPLICATION_ATTACHMENT].maxSizeBytes,
+      },
+    }),
+  )
+  async uploadAttachment(@AuthUser() user: JwtUser, @UploadedFile() file: Express.Multer.File) {
+    const filePayload = file
+      ? {
+          buffer: file.buffer,
+          originalName: file.originalname,
+          mimeType: file.mimetype,
+          size: file.size,
+        }
+      : null;
+
+    const attachment = await this.applicationAttachmentService.upload({
+      userId: user.id,
+      file: filePayload,
+    });
+
+    return ApiResponse.ok(ApplicationAttachmentResponseDto.from(attachment));
+  }
+
+  @ApiDoc({
+    summary: '지원서 첨부파일 열람 URL 발급',
+    description:
+      '본인이 업로드한 첨부파일의 만료형 서명 URL을 발급합니다. 타인의 첨부 경로는 거부됩니다.',
+    operationId: 'application_createAttachmentUrl',
+    auth: true,
+  })
+  @Get('attachments/signed-url')
+  async createAttachmentUrl(@AuthUser() user: JwtUser, @Query() query: AttachmentPathQueryDto) {
+    const result = await this.applicationAttachmentService.createReadUrl({
+      userId: user.id,
+      path: query.path,
+    });
+
+    return ApiResponse.ok(SignedUrlResponseDto.from(result));
   }
 
   @ApiDoc({

--- a/src/application/usecase/application-answer.validator.ts
+++ b/src/application/usecase/application-answer.validator.ts
@@ -78,6 +78,13 @@ export class ApplicationAnswerValidator {
       return value.length > 0;
     }
 
+    // 파일 첨부 답변은 { path, originalName, size } 형태로 들어온다.
+    // path 가 비어 있으면 첨부하지 않은 것으로 본다.
+    if (typeof value === 'object' && 'path' in value) {
+      const path = (value as { path: unknown }).path;
+      return typeof path === 'string' && path.trim().length > 0;
+    }
+
     return true;
   }
 }

--- a/src/application/usecase/application-attachment.service.spec.ts
+++ b/src/application/usecase/application-attachment.service.spec.ts
@@ -1,0 +1,145 @@
+import { Test } from '@nestjs/testing';
+
+import { AppException } from '../../common/exception/app.exception';
+import { StorageService } from '../../storage/application/storage.service';
+import { SignedUrlAction, UploadCategory } from '../../storage/domain/storage.type';
+import { ApplicationAttachmentService } from './application-attachment.service';
+
+const mockStorageService = {
+  upload: jest.fn(),
+  generateSignedUrl: jest.fn(),
+};
+
+describe('ApplicationAttachmentService', () => {
+  let service: ApplicationAttachmentService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        ApplicationAttachmentService,
+        { provide: StorageService, useValue: mockStorageService },
+      ],
+    }).compile();
+
+    service = moduleRef.get(ApplicationAttachmentService);
+  });
+
+  describe('upload', () => {
+    it('사용자 ID를 하위 경로로 넘겨 첨부 카테고리로 업로드한다', async () => {
+      const file = {
+        buffer: Buffer.from('x'),
+        originalName: '포트폴리오.pdf',
+        mimeType: 'application/pdf',
+        size: 2048,
+      };
+      mockStorageService.upload.mockResolvedValue({
+        url: 'https://storage.googleapis.com/bucket/applications/attachments/12/abc.pdf',
+        path: 'applications/attachments/12/abc.pdf',
+        originalName: '포트폴리오.pdf',
+        mimeType: 'application/pdf',
+        size: 2048,
+      });
+
+      const result = await service.upload({ userId: 12, file });
+
+      expect(mockStorageService.upload).toHaveBeenCalledWith({
+        file,
+        category: UploadCategory.APPLICATION_ATTACHMENT,
+        subPath: '12',
+      });
+      expect(result).toEqual({
+        path: 'applications/attachments/12/abc.pdf',
+        originalName: '포트폴리오.pdf',
+        size: 2048,
+      });
+    });
+
+    it('공개 URL은 응답에 담지 않는다', async () => {
+      const file = {
+        buffer: Buffer.from('x'),
+        originalName: 'a.pdf',
+        mimeType: 'application/pdf',
+        size: 1,
+      };
+      mockStorageService.upload.mockResolvedValue({
+        url: 'https://storage.googleapis.com/bucket/applications/attachments/12/abc.pdf',
+        path: 'applications/attachments/12/abc.pdf',
+        originalName: 'a.pdf',
+        mimeType: 'application/pdf',
+        size: 1,
+      });
+
+      const result = await service.upload({ userId: 12, file });
+
+      expect(result).not.toHaveProperty('url');
+      expect(Object.values(result).join(' ')).not.toContain('storage.googleapis.com');
+    });
+
+    it('파일이 없으면 StorageService 가 그대로 판단하도록 위임한다', async () => {
+      mockStorageService.upload.mockRejectedValue(new AppException('FILE_NOT_PROVIDED', 400));
+
+      await expect(service.upload({ userId: 12, file: null })).rejects.toThrow(AppException);
+      expect(mockStorageService.upload).toHaveBeenCalledWith(
+        expect.objectContaining({ file: null }),
+      );
+    });
+  });
+
+  describe('createReadUrl', () => {
+    it('본인 첨부면 read 서명 URL을 발급한다', async () => {
+      mockStorageService.generateSignedUrl.mockResolvedValue({
+        url: 'https://signed',
+        expiresAt: '2026-08-16T00:10:00.000Z',
+      });
+
+      const result = await service.createReadUrl({
+        userId: 12,
+        path: 'applications/attachments/12/abc.pdf',
+      });
+
+      expect(mockStorageService.generateSignedUrl).toHaveBeenCalledWith({
+        path: 'applications/attachments/12/abc.pdf',
+        action: SignedUrlAction.READ,
+      });
+      expect(result.url).toBe('https://signed');
+    });
+
+    it('타인 첨부면 서명 URL을 발급하지 않고 예외를 던진다', async () => {
+      await expect(
+        service.createReadUrl({ userId: 12, path: 'applications/attachments/99/abc.pdf' }),
+      ).rejects.toThrow(AppException);
+
+      expect(mockStorageService.generateSignedUrl).not.toHaveBeenCalled();
+    });
+
+    it('첨부 prefix 밖의 경로도 거부한다', async () => {
+      await expect(
+        service.createReadUrl({ userId: 12, path: 'projects/pdfs/secret.pdf' }),
+      ).rejects.toThrow(AppException);
+
+      expect(mockStorageService.generateSignedUrl).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('assertAttachmentsOwnedByUser', () => {
+    it('본인 첨부만 있으면 통과한다', () => {
+      expect(() =>
+        service.assertAttachmentsOwnedByUser({
+          userId: 12,
+          answers: { q1: { path: 'applications/attachments/12/a.pdf' } },
+        }),
+      ).not.toThrow();
+    });
+
+    it('타인 첨부가 섞이면 예외를 던진다', () => {
+      expect(() =>
+        service.assertAttachmentsOwnedByUser({
+          userId: 12,
+          answers: { q1: { path: 'applications/attachments/99/a.pdf' } },
+        }),
+      ).toThrow(AppException);
+    });
+  });
+});

--- a/src/application/usecase/application-attachment.service.ts
+++ b/src/application/usecase/application-attachment.service.ts
@@ -1,0 +1,68 @@
+import { HttpStatus, Injectable } from '@nestjs/common';
+
+import { AppException } from '../../common/exception/app.exception';
+import { StorageService } from '../../storage/application/storage.service';
+import type { FilePayload, SignedUrlResult } from '../../storage/domain/storage.type';
+import { SignedUrlAction, UploadCategory } from '../../storage/domain/storage.type';
+import type { ApplicationAttachment } from '../domain/application-attachment';
+import {
+  buildAttachmentSubPath,
+  findForeignAttachmentPaths,
+  isOwnedAttachmentPath,
+} from '../domain/application-attachment';
+
+@Injectable()
+export class ApplicationAttachmentService {
+  constructor(private readonly storageService: StorageService) {}
+
+  async upload({
+    userId,
+    file,
+  }: {
+    userId: number;
+    file: FilePayload | null;
+  }): Promise<ApplicationAttachment> {
+    const result = await this.storageService.upload({
+      file,
+      category: UploadCategory.APPLICATION_ATTACHMENT,
+      subPath: buildAttachmentSubPath({ userId }),
+    });
+
+    return {
+      path: result.path,
+      originalName: result.originalName,
+      size: result.size,
+    };
+  }
+
+  async createReadUrl({
+    userId,
+    path,
+  }: {
+    userId: number;
+    path: string;
+  }): Promise<SignedUrlResult> {
+    if (!isOwnedAttachmentPath({ path, userId })) {
+      throw new AppException('ATTACHMENT_NOT_OWNED', HttpStatus.FORBIDDEN);
+    }
+
+    return await this.storageService.generateSignedUrl({ path, action: SignedUrlAction.READ });
+  }
+
+  /**
+   * answers 에 남의 첨부 경로가 섞여 들어오는 것을 막는다.
+   * 임시저장·최종제출 양쪽에서 호출한다.
+   */
+  assertAttachmentsOwnedByUser({
+    userId,
+    answers,
+  }: {
+    userId: number;
+    answers: Record<string, unknown>;
+  }): void {
+    const foreignPaths = findForeignAttachmentPaths({ answers, userId });
+    if (foreignPaths.length > 0) {
+      throw new AppException('ATTACHMENT_NOT_OWNED', HttpStatus.FORBIDDEN);
+    }
+  }
+}

--- a/src/application/usecase/application.service.spec.ts
+++ b/src/application/usecase/application.service.spec.ts
@@ -5,12 +5,14 @@ import { Test } from '@nestjs/testing';
 import { CohortRepository } from '../../cohort/domain/cohort.repository';
 import { AppException } from '../../common/exception/app.exception';
 import { InterviewService } from '../../interview/application/interview.service';
+import { StorageService } from '../../storage/application/storage.service';
 import type { User } from '../../user/domain/user.entity';
 import { ApplicationRepository } from '../domain/application.repository';
 import { ApplicationStatus } from '../domain/application.status';
 import { ApplicationForm } from '../domain/application-form.entity';
 import { ApplicationService } from './application.service';
 import { ApplicationAnswerValidator } from './application-answer.validator';
+import { ApplicationAttachmentService } from './application-attachment.service';
 
 jest.mock('typeorm-transactional', () => ({
   Transactional: () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) =>
@@ -41,6 +43,11 @@ const mockInterviewService = {
   hasSlotsForCohortPart: jest.fn(),
 };
 
+const mockStorageService = {
+  upload: jest.fn(),
+  generateSignedUrl: jest.fn(),
+};
+
 describe('ApplicationService', () => {
   let applicationService: ApplicationService;
 
@@ -49,10 +56,12 @@ describe('ApplicationService', () => {
       providers: [
         ApplicationService,
         ApplicationAnswerValidator,
+        ApplicationAttachmentService,
         { provide: ApplicationRepository, useValue: mockApplicationRepository },
         { provide: CohortRepository, useValue: mockCohortRepository },
         { provide: EventEmitter2, useValue: mockEventEmitter },
         { provide: InterviewService, useValue: mockInterviewService },
+        { provide: StorageService, useValue: mockStorageService },
       ],
     }).compile();
 
@@ -101,6 +110,43 @@ describe('ApplicationService', () => {
           { ...baseCommand, answers: { motivation: '열심히 하겠습니다.' } },
         ),
       ).rejects.toThrow(new AppException('INVALID_APPLICATION_ANSWERS', HttpStatus.BAD_REQUEST));
+    });
+
+    it('answers 에 타인 소유 첨부가 섞이면 제출을 거부한다', async () => {
+      mockCohortRepository.findPartById.mockResolvedValue({
+        id: 1,
+        isOpen: true,
+        applicationSchema: {},
+      });
+
+      await expect(
+        applicationService.submitForm(
+          { userId: 1, email: 'user@example.com' },
+          {
+            ...baseCommand,
+            answers: { portfolio: { path: 'applications/attachments/99/victim.pdf' } },
+          },
+        ),
+      ).rejects.toThrow(new AppException('ATTACHMENT_NOT_OWNED', HttpStatus.FORBIDDEN));
+
+      expect(mockApplicationRepository.saveForm).not.toHaveBeenCalled();
+    });
+
+    it('첨부 경로가 문자열로 들어와도 타인 소유면 거부한다', async () => {
+      mockCohortRepository.findPartById.mockResolvedValue({
+        id: 1,
+        isOpen: true,
+        applicationSchema: {},
+      });
+
+      await expect(
+        applicationService.submitForm(
+          { userId: 1, email: 'user@example.com' },
+          { ...baseCommand, answers: { portfolio: 'applications/attachments/99/victim.pdf' } },
+        ),
+      ).rejects.toThrow(new AppException('ATTACHMENT_NOT_OWNED', HttpStatus.FORBIDDEN));
+
+      expect(mockApplicationRepository.saveForm).not.toHaveBeenCalled();
     });
 
     it('이미 제출된 지원서가 있으면 예외를 던진다', async () => {
@@ -212,6 +258,45 @@ describe('ApplicationService', () => {
       ).rejects.toThrow(new AppException('INTERVIEW_SLOTS_NOT_READY', HttpStatus.BAD_REQUEST));
 
       expect(mockApplicationRepository.saveForm).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('saveDraft', () => {
+    beforeEach(() => {
+      mockCohortRepository.findPartById.mockResolvedValue({
+        id: 1,
+        isOpen: true,
+        applicationSchema: {},
+      });
+    });
+
+    it('answers 에 타인 소유 첨부가 섞이면 임시저장을 거부한다', async () => {
+      await expect(
+        applicationService.saveDraft(
+          { userId: 1 },
+          {
+            cohortPartId: 1,
+            answers: { portfolio: { path: 'applications/attachments/99/victim.pdf' } },
+          },
+        ),
+      ).rejects.toThrow(new AppException('ATTACHMENT_NOT_OWNED', HttpStatus.FORBIDDEN));
+
+      expect(mockApplicationRepository.saveDraft).not.toHaveBeenCalled();
+    });
+
+    it('본인 첨부는 임시저장을 통과한다', async () => {
+      mockApplicationRepository.findDraftByUserAndPart.mockResolvedValue(null);
+      mockApplicationRepository.saveDraft.mockResolvedValue(undefined);
+
+      await applicationService.saveDraft(
+        { userId: 1 },
+        {
+          cohortPartId: 1,
+          answers: { portfolio: { path: 'applications/attachments/1/mine.pdf' } },
+        },
+      );
+
+      expect(mockApplicationRepository.saveDraft).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/application/usecase/application.service.ts
+++ b/src/application/usecase/application.service.ts
@@ -16,6 +16,7 @@ import type {
 import { ApplicationDraft } from '../domain/application-draft.entity';
 import { ApplicationForm } from '../domain/application-form.entity';
 import { ApplicationAnswerValidator } from './application-answer.validator';
+import { ApplicationAttachmentService } from './application-attachment.service';
 
 @Injectable()
 export class ApplicationService {
@@ -26,6 +27,7 @@ export class ApplicationService {
     private readonly cohortRepository: CohortRepository,
     private readonly eventEmitter: EventEmitter2,
     private readonly applicationAnswerValidator: ApplicationAnswerValidator,
+    private readonly applicationAttachmentService: ApplicationAttachmentService,
     @Inject(forwardRef(() => InterviewService))
     private readonly interviewService: InterviewService,
   ) {}
@@ -36,6 +38,11 @@ export class ApplicationService {
     if (!cohortPart || !cohortPart.isOpen) {
       throw new AppException('COHORT_PART_CLOSED', HttpStatus.BAD_REQUEST);
     }
+
+    this.applicationAttachmentService.assertAttachmentsOwnedByUser({
+      userId,
+      answers: command.answers,
+    });
 
     const found = await this.applicationRepository.findDraftByUserAndPart({
       userId,
@@ -69,6 +76,10 @@ export class ApplicationService {
     if (!cohortPart || !cohortPart.isOpen) {
       throw new AppException('COHORT_PART_CLOSED', HttpStatus.BAD_REQUEST);
     }
+    this.applicationAttachmentService.assertAttachmentsOwnedByUser({
+      userId,
+      answers: command.answers,
+    });
     this.applicationAnswerValidator.validate({
       answers: command.answers,
       schema: cohortPart.applicationSchema,

--- a/src/application/usecase/pii-purge.service.ts
+++ b/src/application/usecase/pii-purge.service.ts
@@ -1,0 +1,129 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import { StorageService } from '../../storage/application/storage.service';
+import { UploadCategory } from '../../storage/domain/storage.type';
+import { ApplicationRepository } from '../domain/application.repository';
+
+/** GCS 목록 조회 페이지 크기. */
+const ATTACHMENT_SCAN_PAGE_SIZE = 100;
+
+/** 목록이 비정상적으로 길어질 때 한 회차를 끊는 상한(페이지 수). */
+const ATTACHMENT_SCAN_MAX_PAGES = 500;
+
+export type PiiPurgeResult = {
+  purgedCount: number;
+  attachment: AttachmentPurgeResult;
+};
+
+export type AttachmentPurgeResult = {
+  scanned: number;
+  deleted: number;
+  failed: number;
+  truncated: boolean;
+};
+
+@Injectable()
+export class PiiPurgeService {
+  private readonly logger = new Logger(PiiPurgeService.name);
+
+  constructor(
+    private readonly applicationRepository: ApplicationRepository,
+    private readonly storageService: StorageService,
+  ) {}
+
+  async purgeExpiredPii({ cutoffDate }: { cutoffDate: Date }): Promise<PiiPurgeResult> {
+    const purgedCount = await this.applicationRepository.purgeExpiredPii({ cutoffDate });
+    const attachment = await this.purgeExpiredAttachments({ cutoffDate });
+
+    return { purgedCount, attachment };
+  }
+
+  /**
+   * 보관 기간이 지난 첨부파일을 스토리지에서 직접 훑어 삭제한다.
+   *
+   * answers 를 역참조해 경로를 모으는 방식은 세 가지를 놓친다.
+   *   - 업로드만 하고 제출/임시저장하지 않은 고아 파일 (참조가 아예 없음)
+   *   - 재업로드로 교체된 이전 파일
+   *   - 임시저장에만 남은 첨부 (파기는 application_forms 만 훑는다)
+   * 스토리지를 진실의 원천으로 삼으면 세 경우가 모두 덮이고, answers 의 JSON 모양에
+   * 파기 정확성이 의존하지 않게 된다.
+   *
+   * 기산점이 form 의 파기 기준(활동종료·발표일)이 아니라 업로드 시각이라는 점은
+   * 의도한 차이다. 첨부는 심사 목적이므로 더 짧게 보관하는 편이 안전하다.
+   */
+  private async purgeExpiredAttachments({
+    cutoffDate,
+  }: {
+    cutoffDate: Date;
+  }): Promise<AttachmentPurgeResult> {
+    let cursor: string | undefined;
+    let scanned = 0;
+    let deleted = 0;
+    let failed = 0;
+    let pages = 0;
+
+    do {
+      const page = await this.storageService.listFiles({
+        category: UploadCategory.APPLICATION_ATTACHMENT,
+        cursor,
+        limit: ATTACHMENT_SCAN_PAGE_SIZE,
+      });
+
+      for (const item of page.items) {
+        scanned += 1;
+        if (!this.isExpired({ updatedAt: item.updatedAt, cutoffDate })) {
+          continue;
+        }
+
+        try {
+          await this.storageService.deleteFile({ path: item.path });
+          deleted += 1;
+        } catch (error) {
+          failed += 1;
+          // 경로에 userId 가 들어 있어 그대로 남기지 않는다.
+          this.logger.error(`첨부파일 파기 실패 (${this.maskPath({ path: item.path })})`, error);
+        }
+      }
+
+      cursor = page.nextCursor ?? undefined;
+      pages += 1;
+    } while (cursor && pages < ATTACHMENT_SCAN_MAX_PAGES);
+
+    const truncated = Boolean(cursor);
+    if (truncated) {
+      this.logger.warn(
+        `첨부 파기 스캔이 ${ATTACHMENT_SCAN_MAX_PAGES}페이지 상한에 걸려 중단되었습니다. 남은 대상은 다음 회차에 처리됩니다.`,
+      );
+    }
+
+    return { scanned, deleted, failed, truncated };
+  }
+
+  private isExpired({
+    updatedAt,
+    cutoffDate,
+  }: {
+    updatedAt: string | null;
+    cutoffDate: Date;
+  }): boolean {
+    if (!updatedAt) {
+      return false;
+    }
+
+    const updatedAtMs = Date.parse(updatedAt);
+    if (Number.isNaN(updatedAtMs)) {
+      return false;
+    }
+
+    return updatedAtMs <= cutoffDate.getTime();
+  }
+
+  /** `applications/attachments/12/uuid.pdf` -> `applications/attachments/***\/uuid.pdf` */
+  private maskPath({ path }: { path: string }): string {
+    const segments = path.split('/');
+    if (segments.length < 4) {
+      return path;
+    }
+    return [...segments.slice(0, 2), '***', ...segments.slice(3)].join('/');
+  }
+}

--- a/src/common/error/error-message.ts
+++ b/src/common/error/error-message.ts
@@ -25,6 +25,7 @@ export const ErrorMessage = {
   APPLICATION_NOT_FOUND: '해당 지원서를 찾을 수 없습니다.',
   APPLICATION_DRAFT_NOT_FOUND: '해당 임시저장 지원서를 찾을 수 없습니다.',
   INVALID_STATUS_TRANSITION: '올바르지 않은 상태 변경입니다.',
+  ATTACHMENT_NOT_OWNED: '본인이 업로드한 첨부파일이 아닙니다.',
 
   EVALUATION_NOT_FOUND: '평가 정보를 찾을 수 없습니다.',
 

--- a/src/storage/application/storage.service.spec.ts
+++ b/src/storage/application/storage.service.spec.ts
@@ -102,7 +102,10 @@ describe('StorageService', () => {
 
     it('정상 업로드 시 카테고리별 GCS 경로와 함께 URL을 반환한다', async () => {
       const file = buildFile();
-      mockGcsClient.upload.mockResolvedValue('https://cdn.example.com/projects/thumbnails/abc.png');
+      mockGcsClient.upload.mockResolvedValue({
+        url: 'https://cdn.example.com/projects/thumbnails/abc.png',
+        path: 'projects/thumbnails/abc.png',
+      });
 
       const result = await service.upload({
         file,
@@ -117,10 +120,43 @@ describe('StorageService', () => {
       });
       expect(result).toEqual({
         url: 'https://cdn.example.com/projects/thumbnails/abc.png',
+        path: 'projects/thumbnails/abc.png',
         originalName: file.originalName,
         mimeType: file.mimeType,
         size: file.size,
       });
+    });
+
+    it('subPath 를 주면 카테고리 경로 아래에 덧붙인다', async () => {
+      const file = buildFile({ mimeType: 'application/pdf', originalName: 'portfolio.pdf' });
+      mockGcsClient.upload.mockResolvedValue({
+        url: 'https://cdn.example.com/applications/attachments/12/abc.pdf',
+        path: 'applications/attachments/12/abc.pdf',
+      });
+
+      await service.upload({
+        file,
+        category: UploadCategory.APPLICATION_ATTACHMENT,
+        subPath: '12',
+      });
+
+      expect(mockGcsClient.upload).toHaveBeenCalledWith(
+        expect.objectContaining({ gcsPath: 'applications/attachments/12' }),
+      );
+    });
+
+    it('subPath 에 경로 탈출 문자가 있으면 업로드하지 않는다', async () => {
+      const file = buildFile({ mimeType: 'application/pdf', originalName: 'portfolio.pdf' });
+
+      await expect(
+        service.upload({
+          file,
+          category: UploadCategory.APPLICATION_ATTACHMENT,
+          subPath: '../projects',
+        }),
+      ).rejects.toThrow(AppException);
+
+      expect(mockGcsClient.upload).not.toHaveBeenCalled();
     });
   });
 

--- a/src/storage/application/storage.service.ts
+++ b/src/storage/application/storage.service.ts
@@ -11,6 +11,7 @@ import type {
 import {
   findCategoryByPath,
   isAllowedStoragePath,
+  isSafeSubPath,
   SignedUrlAction,
   UPLOAD_CATEGORY_CONFIG,
   UploadCategory,
@@ -32,6 +33,7 @@ const ALLOWED_EXTENSIONS_BY_CATEGORY: Record<UploadCategory, string[]> = {
   [UploadCategory.PROJECT_THUMBNAIL]: ['.jpg', '.jpeg', '.png', '.webp'],
   [UploadCategory.PROJECT_PDF]: ['.pdf'],
   [UploadCategory.BLOG_THUMBNAIL]: ['.jpg', '.jpeg', '.png', '.webp'],
+  [UploadCategory.APPLICATION_ATTACHMENT]: ['.pdf'],
 };
 
 @Injectable()
@@ -40,7 +42,7 @@ export class StorageService {
 
   constructor(private readonly gcsClient: GcsClient) {}
 
-  async upload({ file, category }: UploadInput): Promise<UploadResult> {
+  async upload({ file, category, subPath }: UploadInput): Promise<UploadResult> {
     if (!file) {
       throw new AppException('FILE_NOT_PROVIDED', HttpStatus.BAD_REQUEST);
     }
@@ -51,16 +53,20 @@ export class StorageService {
     this.validateFileSize({ size: file.size, maxSize: config.maxSizeBytes });
     this.assertStorageEnabled();
 
+    const gcsPath = this.resolveGcsPath({ basePath: config.gcsPath, subPath });
+    this.validateExtension({ path: file.originalName, category });
+
     try {
-      const url = await this.gcsClient.upload({
+      const uploaded = await this.gcsClient.upload({
         buffer: file.buffer,
         originalName: file.originalName,
         mimeType: file.mimeType,
-        gcsPath: config.gcsPath,
+        gcsPath,
       });
 
       return {
-        url,
+        url: uploaded.url,
+        path: uploaded.path,
         originalName: file.originalName,
         mimeType: file.mimeType,
         size: file.size,
@@ -157,6 +163,16 @@ export class StorageService {
       this.logger.error('파일 다운로드 실패', error);
       throw new AppException('FILE_DOWNLOAD_FAILED', HttpStatus.INTERNAL_SERVER_ERROR);
     }
+  }
+
+  private resolveGcsPath({ basePath, subPath }: { basePath: string; subPath?: string }): string {
+    if (subPath === undefined) {
+      return basePath;
+    }
+    if (!isSafeSubPath({ subPath })) {
+      throw new AppException('INVALID_FILE_PATH', HttpStatus.BAD_REQUEST);
+    }
+    return `${basePath}/${subPath}`;
   }
 
   private assertAllowedPath({ path }: { path: string }): void {

--- a/src/storage/application/storage.type.ts
+++ b/src/storage/application/storage.type.ts
@@ -12,6 +12,8 @@ export type DownloadResult = {
 export type UploadInput = {
   file: FilePayload | null;
   category: UploadCategory;
+  /** 카테고리 prefix 아래에 덧붙일 하위 경로. 소유자별 분리에 사용한다. */
+  subPath?: string;
 };
 
 export type GenerateSignedUrlInput = {

--- a/src/storage/domain/storage.type.ts
+++ b/src/storage/domain/storage.type.ts
@@ -2,6 +2,7 @@ export enum UploadCategory {
   PROJECT_THUMBNAIL = 'project-thumbnail',
   PROJECT_PDF = 'project-pdf',
   BLOG_THUMBNAIL = 'blog-thumbnail',
+  APPLICATION_ATTACHMENT = 'application-attachment',
 }
 
 type CategoryConfig = {
@@ -26,6 +27,11 @@ export const UPLOAD_CATEGORY_CONFIG: Record<UploadCategory, CategoryConfig> = {
     maxSizeBytes: 5 * 1024 * 1024,
     gcsPath: 'blogs/thumbnails',
   },
+  [UploadCategory.APPLICATION_ATTACHMENT]: {
+    allowedMimeTypes: ['application/pdf'],
+    maxSizeBytes: 20 * 1024 * 1024,
+    gcsPath: 'applications/attachments',
+  },
 };
 
 export const ALLOWED_PATH_PREFIXES: readonly string[] = Object.values(UPLOAD_CATEGORY_CONFIG).map(
@@ -33,6 +39,11 @@ export const ALLOWED_PATH_PREFIXES: readonly string[] = Object.values(UPLOAD_CAT
 );
 
 const SAFE_PATH_PATTERN = /^[a-zA-Z0-9._\-/]+$/;
+
+const SAFE_SUB_PATH_PATTERN = /^[a-zA-Z0-9._-]+$/;
+
+export const isSafeSubPath = ({ subPath }: { subPath: string }): boolean =>
+  SAFE_SUB_PATH_PATTERN.test(subPath) && subPath !== '.' && subPath !== '..';
 
 export const isAllowedStoragePath = ({ path }: { path: string }): boolean => {
   if (!path || path.length > 1024 || !SAFE_PATH_PATTERN.test(path)) {
@@ -68,6 +79,7 @@ export type FilePayload = {
 
 export type UploadResult = {
   url: string;
+  path: string;
   originalName: string;
   mimeType: string;
   size: number;

--- a/src/storage/infrastructure/gcs.client.spec.ts
+++ b/src/storage/infrastructure/gcs.client.spec.ts
@@ -55,8 +55,8 @@ describe('GcsClient', () => {
       expect(client.isEnabled()).toBe(false);
     });
 
-    it('upload 는 storage.example.com 미리보기 URL을 반환하고 SDK를 호출하지 않는다', async () => {
-      const url = await client.upload({
+    it('upload 는 storage.example.com 미리보기 URL과 경로를 반환하고 SDK를 호출하지 않는다', async () => {
+      const { url, path } = await client.upload({
         buffer: Buffer.from('x'),
         originalName: 'foo.png',
         mimeType: 'image/png',
@@ -64,6 +64,7 @@ describe('GcsClient', () => {
       });
 
       expect(url).toMatch(/^https:\/\/storage\.example\.com\/projects\/thumbnails\/.+\.png$/);
+      expect(path).toMatch(/^projects\/thumbnails\/.+\.png$/);
       expect(mockSave).not.toHaveBeenCalled();
     });
 
@@ -122,10 +123,10 @@ describe('GcsClient', () => {
       expect(client.isEnabled()).toBe(true);
     });
 
-    it('upload 는 storage.googleapis.com URL을 반환하고 SDK file.save 를 호출한다', async () => {
+    it('upload 는 storage.googleapis.com URL과 경로를 반환하고 SDK file.save 를 호출한다', async () => {
       mockSave.mockResolvedValue(undefined);
 
-      const url = await client.upload({
+      const { url, path } = await client.upload({
         buffer: Buffer.from('x'),
         originalName: 'foo.png',
         mimeType: 'image/png',
@@ -140,6 +141,8 @@ describe('GcsClient', () => {
       expect(url).toMatch(
         /^https:\/\/storage\.googleapis\.com\/bucket\/projects\/thumbnails\/.+\.png$/,
       );
+      expect(path).toMatch(/^projects\/thumbnails\/.+\.png$/);
+      expect(url.endsWith(path)).toBe(true);
     });
 
     it('exists 는 GCS 응답을 그대로 반환한다', async () => {

--- a/src/storage/infrastructure/gcs.client.ts
+++ b/src/storage/infrastructure/gcs.client.ts
@@ -21,6 +21,11 @@ type UploadPayload = {
   gcsPath: string;
 };
 
+type UploadedObject = {
+  url: string;
+  path: string;
+};
+
 type ListPayload = {
   prefix: string;
   pageToken?: string;
@@ -65,7 +70,12 @@ export class GcsClient {
     return this.storage !== null && this.bucketName !== null;
   }
 
-  async upload({ buffer, originalName, mimeType, gcsPath }: UploadPayload): Promise<string> {
+  async upload({
+    buffer,
+    originalName,
+    mimeType,
+    gcsPath,
+  }: UploadPayload): Promise<UploadedObject> {
     const extension = extname(originalName);
     const destination = `${gcsPath}/${randomUUID()}${extension}`;
 
@@ -74,7 +84,7 @@ export class GcsClient {
       this.logger.log(
         `[업로드 미리보기] file=${originalName}, destination=${destination}, url=${previewUrl}`,
       );
-      return previewUrl;
+      return { url: previewUrl, path: destination };
     }
 
     const bucket = this.storage.bucket(this.bucketName);
@@ -85,7 +95,10 @@ export class GcsClient {
       resumable: false,
     });
 
-    return `https://storage.googleapis.com/${this.bucketName}/${destination}`;
+    return {
+      url: `https://storage.googleapis.com/${this.bucketName}/${destination}`,
+      path: destination,
+    };
   }
 
   async exists({ path }: { path: string }): Promise<boolean> {


### PR DESCRIPTION
## 개요

- 지원서 답변에 PDF 첨부(포트폴리오)를 추가한다. 기존 지원서 폼은 텍스트 입력만 지원했다.
- 작업 중 **180일 개인정보 파기 스케줄러가 도입 이후 한 번도 동작하지 않았다**는 사실을 발견해 함께 고쳤다. (첫 번째 커밋, 이번 기능과 독립적인 선행 버그)

## 변경 이유

기획 요청: "현재 지원서 폼에서 텍스트 입력만 지원하고 있음. 단, 디자인/PM의 경우 포트폴리오를 거의 필수로 제출 받고 있어서 pdf 업로드 기능 지원 필요."

## 주요 변경 사항

### 1. 파기 버그 수정 (`d4ae2be`, 선행 버그)

`nullifyPii` 의 WHERE 절이 `form.` alias 로 컬럼을 한정하고 있었다. TypeORM 의 `UpdateQueryBuilder` 는 UPDATE 대상 테이블에 alias 를 붙이지 않으면서 WHERE 의 alias 한정자는 그대로 남긴다. 실제 PostgreSQL 16 으로 확인한 결과:

```
alias 유지 → ERROR:  missing FROM-clause entry for table "form"
alias 제거 → UPDATE 1
```

기존 단위 테스트가 쿼리빌더를 통째로 mock 해서 이 계열 버그를 구조적으로 잡을 수 없었다. soft-delete 조건도 함께 명시했다 — TypeORM 은 SELECT 에만 `deletedAt` 필터를 자동 추가하고 UPDATE 에는 붙이지 않아, 같은 조건 문자열을 공유해도 대상 집합이 갈라진다.

### 2. 첨부 업로드 (`774a80f`)

| 엔드포인트 | 설명 |
|---|---|
| `POST /v1/applications/attachments` | multipart 업로드 (JWT). 응답은 `{ path, originalName, size }` |
| `GET /v1/applications/attachments/signed-url?path=` | 본인 첨부의 만료형 서명 URL |

- 저장 경로 `applications/attachments/{userId}/{uuid}.pdf` — 경로에 소유자를 박아 열람 권한을 접두어 비교로 판정
- **업로드 응답에 공개 URL 을 담지 않는다.** 포트폴리오는 개인정보이고 버킷 공개 여부를 앱이 보증할 수 없어, 열람은 서명 URL 로만 제공한다
- 임시저장·최종제출 시 `answers` 안 타인 소유 첨부 경로를 거부
- DB 스키마 변경 없음 (`answers` 가 이미 jsonb)

### 3. 첨부 파기 전략

첨부 삭제를 `answers` 역참조가 아니라 **스토리지 prefix 스캔**으로 수행한다. 역참조 방식은 세 가지를 놓친다.

1. 업로드만 하고 제출하지 않은 고아 파일 (참조 자체가 없음)
2. 재업로드로 교체된 이전 파일
3. 임시저장에만 남은 첨부 (파기는 `application_forms` 만 훑는다)

스토리지를 진실의 원천으로 삼아 셋을 함께 덮는다. 파기 조합은 `PiiPurgeService`(usecase)로 옮기고 스케줄러는 트리거만 담당한다.

## 아키텍처 영향

- **도메인 분리:** `application` 도메인이 `storage` 도메인의 공개 계약(도메인 타입 + Application 서비스)에 의존한다. 의존 방향은 안쪽으로만 향한다.
- **레이어 변경:** 파기 조합을 infrastructure(스케줄러) → application(`PiiPurgeService`)으로 이동. Repository 는 영속성 책임만 갖도록 되돌렸다.
- **의존 방향:** `application-attachment.ts` 는 domain layer이며 import 0개(framework-free) 유지.
- **트랜잭션 경계:** 파기에서 SELECT-then-UPDATE 조합을 제거해 두 쿼리 사이의 경합 자체가 사라졌다.

## 테스트

- [x] 단위 테스트 — 37 suites / 334 tests 통과
- [x] 수동 검증 — 실제 PostgreSQL 16 컨테이너로 파기 UPDATE SQL 실행 확인
- [ ] 통합 테스트 — 없음 (아래 리스크 참고)

추가한 회귀 케이스: 문자열 형태 첨부 경로, 깊은 중첩, 경로 탈출(`..`), 접두어 충돌(12 vs 121), 고아 첨부 파기, 임시저장·제출 소유권 게이트.

## 리뷰 포인트

1. **`PII_PURGE_TARGET_CONDITION` 의 컬럼 한정자** — alias 를 다시 붙이면 파기가 조용히 죽는다. 주석으로 이유를 남겼다.
2. **첨부 파기 기산점** — form 의 파기 기준(활동종료·발표일)이 아니라 **업로드 시각** 기준 180일이다. 심사 목적 문서라 더 짧게 보관하는 편이 안전하다고 판단했는데, 정책상 맞는지 확인 필요.
3. **업로드 확장자 검증 추가** — 이제 모든 카테고리에서 카테고리 허용 확장자를 강제한다. 확장자 없는 파일명은 거부된다(기존엔 통과). 관리자 업로드에도 적용되므로 동작 변경.

## 리스크 / 후속 작업

**머지 전 확인 필요**
- **GCS 버킷 공개 설정** — 버킷에 `allUsers: objectViewer` 가 있으면 경로만 알아도 첨부가 열려 서명 URL 통제가 무의미해진다. 코드로는 판정 불가하므로 `gsutil iam get gs://{bucket}` 확인 필요.

**후속 PR (이번 범위에서 제외)**
- **면접관 첨부 열람 경로 없음** — `면접관` 롤은 `answers` 의 경로 문자열은 보지만 PDF 를 열 수 없다. 관리자 스토리지 API 가 `계정관리`/`운영자` 전용이기 때문. 지원서 단위 열람 엔드포인트 + 감사 로그가 필요하다.
- **업로드 rate limit / 쿼터 없음** — 레포에 `Throttler` 자체가 없어 전역 도입 결정이 필요하다.
- **임시저장 answers 의 텍스트 PII** — `application_drafts` 는 파기 대상이 아니고 제출 시 soft delete 라 자유서술 답변이 남는다. 이번 기능 이전부터의 부채이며 별도 처리 필요.

## 관련 이슈

- 없음 (Notion 기획 요청 기반)
