### PR TITLE
fix(cohort): 공개 기수 응답의 모집 파트 필드를 프론트 계약에 맞춤

### DIFF
--- a/src/cohort/interface/dto/public-cohort.response.dto.spec.ts
+++ b/src/cohort/interface/dto/public-cohort.response.dto.spec.ts
@@ -1,0 +1,137 @@
+import type { Cohort } from '../../domain/cohort.entity';
+import { CohortStatus } from '../../domain/cohort.status';
+import type { CohortPart } from '../../domain/cohort-part.entity';
+import { CohortPartName } from '../../domain/cohort-part-name';
+import { CohortCtaStatus, PublicCohortResponseDto } from './public-cohort.response.dto';
+
+const createPart = ({
+  id,
+  partName,
+  isOpen,
+}: {
+  id: number;
+  partName: CohortPartName;
+  isOpen: boolean;
+}) =>
+  ({
+    id,
+    partName,
+    isOpen,
+    applicationSchema: { questions: [] },
+  }) as unknown as CohortPart;
+
+const createCohort = ({
+  status = CohortStatus.RECRUITING,
+  parts = [],
+}: {
+  status?: CohortStatus;
+  parts?: CohortPart[];
+} = {}) =>
+  ({
+    id: 5,
+    name: '14기',
+    recruitStartAt: new Date('2026-08-29'),
+    recruitEndAt: new Date('2026-09-05'),
+    status,
+    parts,
+  }) as unknown as Cohort;
+
+describe('PublicCohortResponseDto', () => {
+  // 지원서 페이지(fetchApplyPartIdMap)가 응답의 parts[].isOpen 으로 파트 ID 맵을 만든다.
+  // 필드명이 openParts 였을 때 맵이 항상 비어 "지원 파트 정보를 불러오지 못했어요" 가 떴다.
+  it('모집 중인 파트를 parts 필드에 isOpen 과 함께 담는다', () => {
+    // Given
+    const cohort = createCohort({
+      parts: [createPart({ id: 8, partName: CohortPartName.PM, isOpen: true })],
+    });
+
+    // When
+    const dto = PublicCohortResponseDto.from(cohort);
+
+    // Then
+    expect(dto.parts).toEqual([{ id: 8, partName: CohortPartName.PM, isOpen: true }]);
+  });
+
+  // 공개 API 이므로 소비자를 전수 확인할 수 없다. 한 릴리스 동안 구 필드를 함께 내린다.
+  it('구 필드 openParts 를 parts 와 동일하게 유지한다', () => {
+    // Given
+    const cohort = createCohort({
+      parts: [createPart({ id: 8, partName: CohortPartName.PM, isOpen: true })],
+    });
+
+    // When
+    const dto = PublicCohortResponseDto.from(cohort);
+
+    // Then
+    expect(dto.openParts).toEqual(dto.parts);
+  });
+
+  it('모집하지 않는 파트는 제외한다', () => {
+    // Given
+    const cohort = createCohort({
+      parts: [
+        createPart({ id: 8, partName: CohortPartName.PM, isOpen: true }),
+        createPart({ id: 9, partName: CohortPartName.PD, isOpen: false }),
+      ],
+    });
+
+    // When
+    const dto = PublicCohortResponseDto.from(cohort);
+
+    // Then
+    expect(dto.parts.map((p) => p.id)).toEqual([8]);
+  });
+
+  it('모집 중이고 열린 파트가 있으면 지원 CTA 를 노출한다', () => {
+    // Given
+    const cohort = createCohort({
+      parts: [createPart({ id: 8, partName: CohortPartName.PM, isOpen: true })],
+    });
+
+    // When
+    const dto = PublicCohortResponseDto.from(cohort);
+
+    // Then
+    expect(dto.isRecruitmentOpen).toBe(true);
+    expect(dto.ctaStatus).toBe(CohortCtaStatus.APPLY);
+  });
+
+  it('모집 중이어도 열린 파트가 없으면 CTA 를 닫는다', () => {
+    // Given
+    const cohort = createCohort({
+      parts: [createPart({ id: 9, partName: CohortPartName.PD, isOpen: false })],
+    });
+
+    // When
+    const dto = PublicCohortResponseDto.from(cohort);
+
+    // Then
+    expect(dto.isRecruitmentOpen).toBe(false);
+    expect(dto.ctaStatus).toBe(CohortCtaStatus.CLOSED);
+  });
+
+  it('모집 예정 기수는 사전 알림 CTA 를 노출한다', () => {
+    // Given
+    const cohort = createCohort({ status: CohortStatus.UPCOMING, parts: [] });
+
+    // When
+    const dto = PublicCohortResponseDto.from(cohort);
+
+    // Then
+    expect(dto.ctaStatus).toBe(CohortCtaStatus.PRE_NOTIFICATION);
+    expect(dto.isRecruitmentOpen).toBe(false);
+  });
+
+  // parts 는 옵셔널 관계(Cohort.parts?)라 relation 을 로드하지 않은 기수가 들어올 수 있다.
+  it('파트 관계가 로드되지 않아도 빈 배열로 응답한다', () => {
+    // Given
+    const cohort = { ...createCohort(), parts: undefined } as unknown as Cohort;
+
+    // When
+    const dto = PublicCohortResponseDto.from(cohort);
+
+    // Then
+    expect(dto.parts).toEqual([]);
+    expect(dto.ctaStatus).toBe(CohortCtaStatus.CLOSED);
+  });
+});

--- a/src/cohort/interface/dto/public-cohort.response.dto.ts
+++ b/src/cohort/interface/dto/public-cohort.response.dto.ts
@@ -3,12 +3,36 @@ import { ApiProperty } from '@nestjs/swagger';
 import type { Cohort } from '../../domain/cohort.entity';
 import { CohortStatus } from '../../domain/cohort.status';
 import type { CohortPart } from '../../domain/cohort-part.entity';
-import type { CohortPartName } from '../../domain/cohort-part-name';
+import { CohortPartName } from '../../domain/cohort-part-name';
 
 export enum CohortCtaStatus {
   PRE_NOTIFICATION = 'PRE_NOTIFICATION',
   APPLY = 'APPLY',
   CLOSED = 'CLOSED',
+}
+
+export class PublicCohortPartSummaryResponseDto {
+  @ApiProperty({ description: '파트 ID', example: 1 })
+  id: number;
+
+  @ApiProperty({
+    description: '파트명',
+    enum: CohortPartName,
+    enumName: 'CohortPartName',
+    example: CohortPartName.FE,
+  })
+  partName: CohortPartName;
+
+  @ApiProperty({ description: '모집 오픈 여부', example: true })
+  isOpen: boolean;
+
+  static from(part: CohortPart): PublicCohortPartSummaryResponseDto {
+    const dto = new PublicCohortPartSummaryResponseDto();
+    dto.id = part.id;
+    dto.partName = part.partName;
+    dto.isOpen = part.isOpen;
+    return dto;
+  }
 }
 
 export class PublicCohortResponseDto {
@@ -55,10 +79,18 @@ export class PublicCohortResponseDto {
   ctaStatus: CohortCtaStatus;
 
   @ApiProperty({
-    description: '모집 중인 파트 목록',
-    example: [{ id: 1, partName: 'FE' }],
+    description:
+      '모집 중인 파트 목록. isOpen 이 true 인 파트만 담기므로 항목의 isOpen 은 항상 true.',
+    type: [PublicCohortPartSummaryResponseDto],
   })
-  openParts: { id: number; partName: CohortPartName }[];
+  parts: PublicCohortPartSummaryResponseDto[];
+
+  @ApiProperty({
+    description: '[Deprecated] parts 와 동일합니다. 소비자 이전 후 다음 릴리스에서 제거됩니다.',
+    type: [PublicCohortPartSummaryResponseDto],
+    deprecated: true,
+  })
+  openParts: PublicCohortPartSummaryResponseDto[];
 
   static from(cohort: Cohort): PublicCohortResponseDto {
     const dto = new PublicCohortResponseDto();
@@ -69,13 +101,14 @@ export class PublicCohortResponseDto {
     dto.status = cohort.status;
     dto.process = cohort.process ?? null;
     dto.curriculum = cohort.curriculum ?? null;
-    dto.openParts = (cohort.parts ?? [])
-      .filter((p) => p.isOpen)
-      .map((p) => ({ id: p.id, partName: p.partName }));
-    dto.isRecruitmentOpen = cohort.status === CohortStatus.RECRUITING && dto.openParts.length > 0;
+    dto.parts = (cohort.parts ?? [])
+      .filter((part) => part.isOpen)
+      .map((part) => PublicCohortPartSummaryResponseDto.from(part));
+    dto.openParts = dto.parts;
+    dto.isRecruitmentOpen = cohort.status === CohortStatus.RECRUITING && dto.parts.length > 0;
     if (cohort.status === CohortStatus.UPCOMING) {
       dto.ctaStatus = CohortCtaStatus.PRE_NOTIFICATION;
-    } else if (cohort.status === CohortStatus.RECRUITING && dto.openParts.length > 0) {
+    } else if (cohort.status === CohortStatus.RECRUITING && dto.parts.length > 0) {
       dto.ctaStatus = CohortCtaStatus.APPLY;
     } else {
       dto.ctaStatus = CohortCtaStatus.CLOSED;
@@ -88,7 +121,12 @@ export class PublicCohortPartResponseDto {
   @ApiProperty({ description: '파트 ID', example: 1 })
   id: number;
 
-  @ApiProperty({ description: '파트명', example: 'FE' })
+  @ApiProperty({
+    description: '파트명',
+    enum: CohortPartName,
+    enumName: 'CohortPartName',
+    example: CohortPartName.FE,
+  })
   partName: CohortPartName;
 
   @ApiProperty({

--- a/src/cohort/interface/public.cohort.controller.ts
+++ b/src/cohort/interface/public.cohort.controller.ts
@@ -1,15 +1,22 @@
 import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiExtraModels, ApiTags } from '@nestjs/swagger';
 
 import { ApiResponse } from '../../common/response/api-response';
 import { ApiDoc } from '../../common/swagger/api-doc.decorator';
 import { CohortService } from '../application/cohort.service';
 import {
   PublicCohortPartResponseDto,
+  PublicCohortPartSummaryResponseDto,
   PublicCohortResponseDto,
 } from './dto/public-cohort.response.dto';
+import { PublicCohortSwagger } from './public.cohort.swagger';
 
 @ApiTags('Cohort')
+@ApiExtraModels(
+  PublicCohortResponseDto,
+  PublicCohortPartSummaryResponseDto,
+  PublicCohortPartResponseDto,
+)
 @Controller({ path: 'cohorts', version: '1' })
 export class PublicCohortController {
   constructor(private readonly cohortService: CohortService) {}
@@ -18,6 +25,7 @@ export class PublicCohortController {
     summary: '현재 활성 기수 조회',
     description: '현재 모집 중이거나 활동 중인 기수 정보와 홈페이지 CTA 버튼 상태를 반환합니다.',
     operationId: 'cohort_getPublicActive',
+    responses: [PublicCohortSwagger.active.success, PublicCohortSwagger.active.notFound],
   })
   @Get('active')
   async findActiveCohort() {
@@ -29,6 +37,7 @@ export class PublicCohortController {
     summary: '모집 파트 상세 조회',
     description: '특정 기수의 모집 분야(파트) 상세 정보 및 지원서 문항(Schema)을 조회합니다.',
     operationId: 'cohort_getPublicPartById',
+    responses: [PublicCohortSwagger.partById.success, PublicCohortSwagger.partById.notFound],
   })
   @Get('parts/:id')
   async findPartById(@Param('id', ParseIntPipe) id: number) {

--- a/src/cohort/interface/public.cohort.swagger.spec.ts
+++ b/src/cohort/interface/public.cohort.swagger.spec.ts
@@ -1,0 +1,87 @@
+import type { INestApplication } from '@nestjs/common';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { Test } from '@nestjs/testing';
+
+import { CohortService } from '../application/cohort.service';
+import { PublicCohortController } from './public.cohort.controller';
+
+// 이번 사고의 배경: openapi.json 의 /cohorts/active 200 응답이 비어 있어
+// 프론트가 응답 타입을 손으로 추측해 정의했고(어드민 DTO 를 재사용), 필드명이 어긋난 채
+// 런타임에서만 깨졌다. 스키마가 문서에 노출되는지를 테스트로 고정해 같은 사고를 막는다.
+describe('PublicCohortController Swagger 계약', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [PublicCohortController],
+      providers: [{ provide: CohortService, useValue: {} }],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  const createDocument = () => SwaggerModule.createDocument(app, new DocumentBuilder().build());
+
+  it('활성 기수 응답 DTO 를 스키마로 노출한다', () => {
+    // Given & When
+    const schemas = createDocument().components?.schemas ?? {};
+
+    // Then
+    expect(schemas.PublicCohortResponseDto).toBeDefined();
+    expect(schemas.PublicCohortPartSummaryResponseDto).toBeDefined();
+    expect(schemas.PublicCohortPartResponseDto).toBeDefined();
+  });
+
+  it('파트 목록이 파트 스키마를 참조한다', () => {
+    // Given & When
+    const schemas = createDocument().components?.schemas ?? {};
+    const cohortSchema = schemas.PublicCohortResponseDto;
+    const parts = 'properties' in cohortSchema ? cohortSchema.properties?.parts : undefined;
+
+    // Then
+    expect(parts).toEqual(
+      expect.objectContaining({
+        type: 'array',
+        items: { $ref: '#/components/schemas/PublicCohortPartSummaryResponseDto' },
+      }),
+    );
+  });
+
+  it('파트명을 문자열이 아닌 enum 으로 노출한다', () => {
+    // Given & When
+    const schemas = createDocument().components?.schemas ?? {};
+    const partSchema = schemas.PublicCohortPartSummaryResponseDto;
+    const partName = 'properties' in partSchema ? partSchema.properties?.partName : undefined;
+
+    // Then
+    expect(JSON.stringify(partName)).toContain('#/components/schemas/CohortPartName');
+    expect(schemas.CohortPartName).toEqual(
+      expect.objectContaining({ enum: ['PM', 'PD', 'BE', 'FE', 'IOS', 'AND'] }),
+    );
+  });
+
+  it('활성 기수 200 응답 본문이 빈 스키마가 아니다', () => {
+    // Given
+    const document = createDocument();
+    // 전역 prefix/버저닝은 main.ts 에서 붙으므로 테스트 앱 기준으로 경로를 찾는다.
+    const activePath = Object.keys(document.paths).find((path) => path.endsWith('cohorts/active'));
+
+    // When
+    const ok = activePath ? document.paths[activePath]?.get?.responses?.['200'] : undefined;
+
+    // Then
+    expect(activePath).toBeDefined();
+    expect(ok && 'content' in ok ? ok.content?.['application/json']?.schema : undefined).toEqual(
+      expect.objectContaining({
+        properties: expect.objectContaining({
+          data: { $ref: '#/components/schemas/PublicCohortResponseDto' },
+        }),
+      }),
+    );
+  });
+});

--- a/src/cohort/interface/public.cohort.swagger.ts
+++ b/src/cohort/interface/public.cohort.swagger.ts
@@ -1,0 +1,34 @@
+import {
+  CommonSwaggerResponses,
+  successResponseSchema,
+} from '../../common/swagger/response-schema';
+import {
+  PublicCohortPartResponseDto,
+  PublicCohortResponseDto,
+} from './dto/public-cohort.response.dto';
+
+/**
+ * PublicCohortController Swagger 응답 스키마 정의
+ * 컨트롤러 가독성 보호를 위해 별도 파일로 분리
+ */
+export const PublicCohortSwagger = {
+  active: {
+    success: {
+      status: 200,
+      description: '현재 모집 중이거나 활동 중인 기수 정보와 홈페이지 CTA 버튼 상태를 반환합니다.',
+      ...successResponseSchema(PublicCohortResponseDto),
+    },
+    notFound: CommonSwaggerResponses.notFound('활성 기수가 없습니다.', 'COHORT_NOT_FOUND'),
+  },
+  partById: {
+    success: {
+      status: 200,
+      description: '특정 기수의 모집 파트 상세 정보와 지원서 문항(Schema)을 반환합니다.',
+      ...successResponseSchema(PublicCohortPartResponseDto),
+    },
+    notFound: CommonSwaggerResponses.notFound(
+      '모집 중인 파트를 찾을 수 없습니다.',
+      'COHORT_PART_NOT_FOUND',
+    ),
+  },
+} as const;


### PR DESCRIPTION
## 개요

지원자용 페이지 `/recruit/apply` 에서 상시 노출되던 "현재 모집 중인 지원 파트 정보를 불러오지 못했어요" 를 해결합니다. 함께 이 사고를 만든 구조적 원인(공개 엔드포인트의 openapi 응답 스키마 공백)도 닫습니다.

## 변경 이유

프론트(`apps/web/lib/mappers/cohort.ts`)는 활성 기수 응답에서 `parts[].isOpen` 을 읽습니다.

```ts
const parts: CohortPartConfigDto[] = cohort?.parts ?? [];
for (const part of parts) { if (!part.isOpen) continue; map[key] = part.id; }
```

백엔드는 `openParts: { id, partName }[]` 를 내려주고 있었습니다. 필드명이 다르고 `isOpen` 도 없어 맵이 항상 비었고, 프론트는 그 상태를 에러 문구로 표시합니다. **API 는 200 을 반환하므로 서버 로그·모니터링에는 아무 흔적이 남지 않습니다.**

왜 컴파일에서 안 잡혔는지도 확인했습니다. `packages/api/src/cohort/types.ts` 가 `GetActiveCohortResponse = CohortDto`(어드민 기수 DTO)로 수동 정의하고, `api.ts:75` 가 `as unknown as` 로 캐스팅합니다. 프론트 주석에 이유가 적혀 있습니다.

> BE 실제 응답은 `{ id, partName, isOpen, applicationSchema }` 형태이나 OpenAPI 스키마는 `{ name, isOpen, formSchema }` 로 아직 정합되지 않았다 (**BE 측 schema 보강 대기 중**).

즉 `/api/v1/cohorts/active` 의 200 응답 스키마가 비어 있어서 프론트가 타입을 손으로 추측했고, 그 추측이 어긋난 채 런타임에서만 깨졌습니다.

## 주요 변경 사항

- `openParts` → `parts` 로 필드명을 맞추고 항목에 `isOpen` 포함
- `openParts` 를 `deprecated` 로 **한 릴리스 동안 병행 유지** (`dto.openParts = dto.parts`). 미인증 공개 API 라 조직 외부 소비자를 전수 확인할 수 없어 `CODE_RULES.md` §7 버저닝 규칙을 따릅니다
- 파트 항목을 `PublicCohortPartSummaryResponseDto` 클래스로 분리
- `partName` 에 `enum: CohortPartName, enumName` 명시 → 생성 타입이 `string` 이 아닌 유니온이 됩니다 (`import type` 을 값 import 로 변경해야 동작)
- **`public.cohort.swagger.ts` 신규 + 컨트롤러에 `@ApiExtraModels` / `responses` 연결** — 레포에 이미 있는 `user.swagger.ts` 패턴을 따랐습니다. 이것 없이는 `@ApiProperty({ type: [...] })` 만으로 스키마가 emit 되지 않습니다 (증거: `admin-cohort.response.dto.ts` 가 이미 같은 데코레이터를 쓰는데 `openapi.json` 에 해당 스키마가 없습니다)

## 아키텍처 영향

- 도메인 분리: cohort 도메인 경계 내부에서만 변경
- 레이어 변경: Interface Layer(DTO/Controller/Swagger)만 수정. domain·application·infrastructure 무변경
- 의존 방향 영향: 없음. 엔티티는 `import type` 으로만 참조
- 트랜잭션 경계 영향: 없음

## 테스트

- [x] 단위 테스트 — cohort 23개 통과, 전체 299개 통과
- [x] 수동 테스트 — 프로덕션 응답 및 프론트 소스 대조
- [ ] 통합 테스트 — 해당 없음

확인 내용
- `public-cohort.response.dto.spec.ts` 신규 — `parts` 에 `isOpen` 이 실리는지, `openParts` 병행, 파트 필터, CTA 3분기, `parts` 미로드 경로
- `public.cohort.swagger.spec.ts` 신규 — **openapi 문서에 스키마가 실제로 노출되는지 검증**. 이번 사고의 재발 방지가 목적입니다. 작성 중 이 테스트가 기대값 2건을 틀렸다고 잡아냈습니다(nest 는 `partName` 을 `allOf: [$ref]` 로 감싸고, 전역 prefix 는 테스트 앱에 안 붙음)
- `yarn build`, `yarn lint` 통과

## 리뷰 포인트

1. `openParts` 병행 유지 기간 — 프론트 배포 확인 후 다음 릴리스에서 제거할지
2. `parts` 에 열린 파트만 담는 현재 설계 (항목의 `isOpen` 은 항상 `true`). 전체 파트를 내리고 프론트가 필터하게 하면 이름과 내용이 정합해지고 "마감된 파트 비활성 표시" UI 가 가능해집니다. 다만 프론트 수정이 함께 필요해 이번 범위에서 제외했습니다

## 리스크 / 후속 작업

**이 PR 만으로는 지원서 제출이 완료되지 않습니다.** 배포 전 반드시 읽어 주세요.

프론트 지원서 폼(`RecruitApplySection.tsx`)은 `applicationSchema` 기반 동적 렌더링이 없고 고정 키 11개(`email, name, phone, birth, region, agreedToPrivacy, part, essay, portfolioLink, portfolioFileName, channels`)만 전송합니다. 반면 `ApplicationAnswerValidator` 는 `applicationSchema.questions[].required === true` 인 `key` 를 필수로 검증합니다.

프로덕션 14기 PM 파트(id=8)를 확인한 결과 `required: true` 질문이 **19개**이고 key 는 한글 라벨을 slugify 한 값입니다(`성함을_적어주세요_ex_홍길동` 등). 프론트가 보내는 키와 **하나도 겹치지 않습니다.**

따라서 이 PR 만 배포하면 배너는 사라지지만 지원자가 4단계를 다 작성한 뒤 `400 INVALID_APPLICATION_ANSWERS` 를 받고 작성 내용을 잃습니다. **현재의 사전 차단보다 나쁜 상태가 될 수 있습니다.**

- 필수 선행/동시 작업: 프론트가 `GET /api/v1/cohorts/parts/{id}` 의 `applicationSchema.questions` 로 3단계를 동적 렌더링하고 `answers[question.key]` 로 담아야 합니다. 이 PR 의 스키마 노출이 그 작업의 전제입니다
- 성공 기준은 "배너가 사라짐" 이 아니라 **"지원서 제출 성공 1건 이상"** 이어야 합니다

**별도 PR 로 분리한 사항** — `ApplicationService.submitForm`/`saveDraft` 는 `cohortPart.isOpen` 만 검사하고 기수 status 를 보지 않습니다. 반면 공개 조회 `findPartByIdOrThrow` 는 `status === RECRUITING` 까지 검사합니다. 모집이 마감돼 기수가 ACTIVE 로 전환돼도 파트가 열려 있으면 제출이 가능합니다. 선재 결함이며 도메인이 달라 이번 PR 에서 제외했습니다

**후속** — `openapi.json` 은 배포 성공 후 운영 서버에서 긁어와 커밋되는 구조라 PR 단계에서 갱신되지 않습니다. 이번 스키마가 반영되려면 배포가 선행돼야 합니다

## 관련 이슈

- 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)
