### PR TITLE
fix(cohort): 모집 기간 밖 지원 접수 차단 (status 단독 판정 제거)

### DIFF
--- a/src/application/usecase/application.service.spec.ts
+++ b/src/application/usecase/application.service.spec.ts
@@ -3,6 +3,7 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Test } from '@nestjs/testing';
 
 import { CohortRepository } from '../../cohort/domain/cohort.repository';
+import { CohortStatus } from '../../cohort/domain/cohort.status';
 import { AppException } from '../../common/exception/app.exception';
 import { InterviewService } from '../../interview/application/interview.service';
 import type { User } from '../../user/domain/user.entity';
@@ -40,6 +41,18 @@ const mockEventEmitter = {
 const mockInterviewService = {
   hasSlotsForCohortPart: jest.fn(),
 };
+
+const daysFromNow = (days: number) => new Date(Date.now() + days * 24 * 60 * 60 * 1000);
+
+const createCohortWindow = ({
+  status = CohortStatus.RECRUITING,
+  startDayOffset = -1,
+  endDayOffset = 1,
+}: { status?: CohortStatus; startDayOffset?: number; endDayOffset?: number } = {}) => ({
+  status,
+  recruitStartAt: daysFromNow(startDayOffset),
+  recruitEndAt: daysFromNow(endDayOffset),
+});
 
 describe('ApplicationService', () => {
   let applicationService: ApplicationService;
@@ -92,6 +105,7 @@ describe('ApplicationService', () => {
       mockCohortRepository.findPartById.mockResolvedValue({
         id: 1,
         isOpen: true,
+        cohort: createCohortWindow(),
         applicationSchema: { required: ['motivation', 'portfolioUrl'] },
       });
 
@@ -107,6 +121,7 @@ describe('ApplicationService', () => {
       mockCohortRepository.findPartById.mockResolvedValue({
         id: 1,
         isOpen: true,
+        cohort: createCohortWindow(),
         applicationSchema: { required: ['motivation'] },
       });
       mockApplicationRepository.findFormByUserAndPart.mockResolvedValue({ id: 10 });
@@ -120,6 +135,7 @@ describe('ApplicationService', () => {
       mockCohortRepository.findPartById.mockResolvedValue({
         id: 1,
         isOpen: true,
+        cohort: createCohortWindow(),
         applicationSchema: {
           questions: [{ key: 'motivation', required: true }],
         },
@@ -139,6 +155,94 @@ describe('ApplicationService', () => {
         email: 'user@example.com',
         name: '홍길동',
       });
+    });
+
+    it('모집 시작 전이면 파트가 열려 있어도 제출을 거부한다', async () => {
+      mockCohortRepository.findPartById.mockResolvedValue({
+        id: 1,
+        isOpen: true,
+        cohort: createCohortWindow({ startDayOffset: 13, endDayOffset: 20 }),
+        applicationSchema: { questions: [] },
+      });
+
+      await expect(
+        applicationService.submitForm({ userId: 1, email: 'user@example.com' }, baseCommand),
+      ).rejects.toThrow(new AppException('COHORT_PART_CLOSED', HttpStatus.BAD_REQUEST));
+      expect(mockApplicationRepository.saveForm).not.toHaveBeenCalled();
+    });
+
+    it('모집 종료 후면 파트가 열려 있어도 제출을 거부한다', async () => {
+      mockCohortRepository.findPartById.mockResolvedValue({
+        id: 1,
+        isOpen: true,
+        cohort: createCohortWindow({ startDayOffset: -20, endDayOffset: -1 }),
+        applicationSchema: { questions: [] },
+      });
+
+      await expect(
+        applicationService.submitForm({ userId: 1, email: 'user@example.com' }, baseCommand),
+      ).rejects.toThrow(new AppException('COHORT_PART_CLOSED', HttpStatus.BAD_REQUEST));
+      expect(mockApplicationRepository.saveForm).not.toHaveBeenCalled();
+    });
+
+    it('파트에 기수 정보가 없으면 제출을 거부한다', async () => {
+      mockCohortRepository.findPartById.mockResolvedValue({
+        id: 1,
+        isOpen: true,
+        cohort: undefined,
+        applicationSchema: { questions: [] },
+      });
+
+      await expect(
+        applicationService.submitForm({ userId: 1, email: 'user@example.com' }, baseCommand),
+      ).rejects.toThrow(new AppException('COHORT_PART_CLOSED', HttpStatus.BAD_REQUEST));
+      expect(mockApplicationRepository.saveForm).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('saveDraft', () => {
+    const draftCommand = { cohortPartId: 1, answers: { motivation: '작성 중' } };
+
+    it('모집 기간 안이면 임시저장한다', async () => {
+      mockCohortRepository.findPartById.mockResolvedValue({
+        id: 1,
+        isOpen: true,
+        cohort: createCohortWindow(),
+        applicationSchema: { questions: [] },
+      });
+      mockApplicationRepository.findDraftByUserAndPart.mockResolvedValue(null);
+
+      await applicationService.saveDraft({ userId: 1 }, draftCommand);
+
+      expect(mockApplicationRepository.saveDraft).toHaveBeenCalledTimes(1);
+    });
+
+    it('모집 시작 전이면 임시저장을 거부한다', async () => {
+      mockCohortRepository.findPartById.mockResolvedValue({
+        id: 1,
+        isOpen: true,
+        cohort: createCohortWindow({ startDayOffset: 13, endDayOffset: 20 }),
+        applicationSchema: { questions: [] },
+      });
+
+      await expect(applicationService.saveDraft({ userId: 1 }, draftCommand)).rejects.toThrow(
+        new AppException('COHORT_PART_CLOSED', HttpStatus.BAD_REQUEST),
+      );
+      expect(mockApplicationRepository.saveDraft).not.toHaveBeenCalled();
+    });
+
+    it('모집 종료 후면 임시저장을 거부한다', async () => {
+      mockCohortRepository.findPartById.mockResolvedValue({
+        id: 1,
+        isOpen: true,
+        cohort: createCohortWindow({ startDayOffset: -20, endDayOffset: -2 }),
+        applicationSchema: { questions: [] },
+      });
+
+      await expect(applicationService.saveDraft({ userId: 1 }, draftCommand)).rejects.toThrow(
+        new AppException('COHORT_PART_CLOSED', HttpStatus.BAD_REQUEST),
+      );
+      expect(mockApplicationRepository.saveDraft).not.toHaveBeenCalled();
     });
   });
 

--- a/src/application/usecase/application.service.ts
+++ b/src/application/usecase/application.service.ts
@@ -3,6 +3,8 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { runOnTransactionCommit, Transactional } from 'typeorm-transactional';
 
 import { CohortRepository } from '../../cohort/domain/cohort.repository';
+import type { CohortPart } from '../../cohort/domain/cohort-part.entity';
+import { isRecruitmentOpenAt } from '../../cohort/domain/cohort-recruitment';
 import { AppException } from '../../common/exception/app.exception';
 import { InterviewService } from '../../interview/application/interview.service';
 import { InvalidApplicationStatusTransitionError } from '../domain/application.domain-error';
@@ -30,10 +32,22 @@ export class ApplicationService {
     private readonly interviewService: InterviewService,
   ) {}
 
+  /**
+   * 파트가 열려 있고 소속 기수의 모집 기간 안일 때만 접수를 허용한다.
+   * isOpen 만 보면 모집 시작 전·종료 후에도 지원서가 저장되므로 기수 일정까지 확인한다.
+   */
+  private isApplicationOpen(cohortPart: CohortPart | null): cohortPart is CohortPart {
+    if (!cohortPart?.isOpen || !cohortPart.cohort) {
+      return false;
+    }
+
+    return isRecruitmentOpenAt({ cohort: cohortPart.cohort, now: new Date() });
+  }
+
   @Transactional()
   async saveDraft({ userId }: { userId: number }, command: SaveDraftCommand): Promise<void> {
     const cohortPart = await this.cohortRepository.findPartById({ id: command.cohortPartId });
-    if (!cohortPart || !cohortPart.isOpen) {
+    if (!this.isApplicationOpen(cohortPart)) {
       throw new AppException('COHORT_PART_CLOSED', HttpStatus.BAD_REQUEST);
     }
 
@@ -66,7 +80,7 @@ export class ApplicationService {
     }
 
     const cohortPart = await this.cohortRepository.findPartById({ id: command.cohortPartId });
-    if (!cohortPart || !cohortPart.isOpen) {
+    if (!this.isApplicationOpen(cohortPart)) {
       throw new AppException('COHORT_PART_CLOSED', HttpStatus.BAD_REQUEST);
     }
     this.applicationAnswerValidator.validate({

--- a/src/cohort/application/cohort.service.spec.ts
+++ b/src/cohort/application/cohort.service.spec.ts
@@ -37,6 +37,17 @@ const mockNotificationCampaignService = {
   registerDefaultForCohort: jest.fn(),
 };
 
+const daysFromNow = (days: number) => new Date(Date.now() + days * 24 * 60 * 60 * 1000);
+
+const createRecruitingWindow = ({
+  startDayOffset = -1,
+  endDayOffset = 1,
+}: { startDayOffset?: number; endDayOffset?: number } = {}) => ({
+  status: CohortStatus.RECRUITING,
+  recruitStartAt: daysFromNow(startDayOffset),
+  recruitEndAt: daysFromNow(endDayOffset),
+});
+
 describe('CohortService', () => {
   let cohortService: CohortService;
 
@@ -151,7 +162,12 @@ describe('CohortService', () => {
 
   describe('updateCohort', () => {
     it('상태를 UPCOMING/RECRUITING으로 변경할 때 다른 활성 기수가 있으면 예외를 던진다', async () => {
-      mockCohortRepository.findById.mockResolvedValue({ id: 1, status: CohortStatus.ACTIVE });
+      mockCohortRepository.findById.mockResolvedValue({
+        id: 1,
+        status: CohortStatus.ACTIVE,
+        recruitStartAt: new Date('2026-08-29T00:00:00.000Z'),
+        recruitEndAt: new Date('2026-09-05T00:00:00.000Z'),
+      });
       mockCohortRepository.checkActiveCohortExistsExcept.mockResolvedValue(true);
 
       await expect(
@@ -160,6 +176,58 @@ describe('CohortService', () => {
           data: { status: CohortStatus.RECRUITING },
         }),
       ).rejects.toThrow(new AppException('COHORT_ALREADY_EXISTS', HttpStatus.CONFLICT));
+    });
+  });
+
+  describe('모집 기간 정합성 검증', () => {
+    const invalidPeriod = new AppException('INVALID_RECRUIT_PERIOD', HttpStatus.BAD_REQUEST);
+
+    it('생성 시 모집 시작일이 종료일보다 늦으면 예외를 던진다', async () => {
+      mockCohortRepository.checkActiveCohortExists.mockResolvedValue(false);
+
+      await expect(
+        cohortService.createCohort({
+          cohort: {
+            name: '15기',
+            recruitStartAt: new Date('2026-09-10T00:00:00.000Z'),
+            recruitEndAt: new Date('2026-09-01T00:00:00.000Z'),
+          },
+        }),
+      ).rejects.toThrow(invalidPeriod);
+      expect(mockCohortRepository.register).not.toHaveBeenCalled();
+    });
+
+    it('수정 시 기존 값과 병합한 결과가 역전되면 예외를 던진다', async () => {
+      mockCohortRepository.findById.mockResolvedValue({
+        id: 1,
+        status: CohortStatus.RECRUITING,
+        recruitStartAt: new Date('2026-08-29T00:00:00.000Z'),
+        recruitEndAt: new Date('2026-09-05T00:00:00.000Z'),
+      });
+
+      await expect(
+        cohortService.updateCohort({
+          id: 1,
+          data: { recruitEndAt: new Date('2026-08-01T00:00:00.000Z') },
+        }),
+      ).rejects.toThrow(invalidPeriod);
+      expect(mockCohortRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('수정 결과가 정상 구간이면 저장한다', async () => {
+      mockCohortRepository.findById.mockResolvedValue({
+        id: 1,
+        status: CohortStatus.RECRUITING,
+        recruitStartAt: new Date('2026-08-29T00:00:00.000Z'),
+        recruitEndAt: new Date('2026-09-05T00:00:00.000Z'),
+      });
+
+      await cohortService.updateCohort({
+        id: 1,
+        data: { recruitEndAt: new Date('2026-09-12T00:00:00.000Z') },
+      });
+
+      expect(mockCohortRepository.update).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -202,17 +270,37 @@ describe('CohortService', () => {
       await expect(cohortService.findPartByIdOrThrow({ id: 1 })).rejects.toThrow(expectedException);
     });
 
-    it('오픈된 파트이고 RECRUITING 기수에 속하면 파트를 반환한다', async () => {
+    it('오픈된 파트이고 모집 기간 안이면 파트를 반환한다', async () => {
       const part = {
         id: 1,
         isOpen: true,
-        cohort: { status: CohortStatus.RECRUITING },
+        cohort: createRecruitingWindow(),
       };
       mockCohortRepository.findPartById.mockResolvedValue(part);
 
       const result = await cohortService.findPartByIdOrThrow({ id: 1 });
 
       expect(result).toBe(part);
+    });
+
+    it('RECRUITING 이어도 모집 시작 전이면 404를 던진다', async () => {
+      mockCohortRepository.findPartById.mockResolvedValue({
+        id: 1,
+        isOpen: true,
+        cohort: createRecruitingWindow({ startDayOffset: 13, endDayOffset: 20 }),
+      });
+
+      await expect(cohortService.findPartByIdOrThrow({ id: 1 })).rejects.toThrow(expectedException);
+    });
+
+    it('RECRUITING 이어도 모집 종료 후면 404를 던진다', async () => {
+      mockCohortRepository.findPartById.mockResolvedValue({
+        id: 1,
+        isOpen: true,
+        cohort: createRecruitingWindow({ startDayOffset: -20, endDayOffset: -1 }),
+      });
+
+      await expect(cohortService.findPartByIdOrThrow({ id: 1 })).rejects.toThrow(expectedException);
     });
   });
 });

--- a/src/cohort/application/cohort.service.ts
+++ b/src/cohort/application/cohort.service.ts
@@ -13,6 +13,7 @@ import type {
   CohortPartCreateType,
   CohortUpdateType,
 } from '../domain/cohort.type';
+import { isRecruitmentOpenAt } from '../domain/cohort-recruitment';
 
 const AUDIT_ENTITY_TYPE = 'cohort';
 const SYSTEM_ADMIN_ID = 0;
@@ -28,8 +29,26 @@ export class CohortService {
     private readonly notificationCampaignService: NotificationCampaignService,
   ) {}
 
+  /**
+   * 모집 개폐가 일정에 좌우되므로 시작일이 종료일보다 늦으면 기수가 영구히 닫힌다.
+   * 어드민에는 RECRUITING 으로 보이면서 실제로는 아무도 지원하지 못하는 상태가 되므로 입력 시점에 막는다.
+   */
+  private assertRecruitPeriod({
+    recruitStartAt,
+    recruitEndAt,
+  }: {
+    recruitStartAt: Date;
+    recruitEndAt: Date;
+  }) {
+    if (recruitStartAt.getTime() > recruitEndAt.getTime()) {
+      throw new AppException('INVALID_RECRUIT_PERIOD', HttpStatus.BAD_REQUEST);
+    }
+  }
+
   @Transactional()
   async createCohort({ cohort }: { cohort: CohortCreateType }) {
+    this.assertRecruitPeriod(cohort);
+
     const isExists = await this.cohortRepository.checkActiveCohortExists();
     if (isExists) {
       throw new AppException('COHORT_ALREADY_EXISTS', HttpStatus.CONFLICT);
@@ -93,6 +112,11 @@ export class CohortService {
       throw new AppException('COHORT_NOT_FOUND', HttpStatus.NOT_FOUND);
     }
 
+    this.assertRecruitPeriod({
+      recruitStartAt: data.recruitStartAt ?? found.recruitStartAt,
+      recruitEndAt: data.recruitEndAt ?? found.recruitEndAt,
+    });
+
     const isTargetStatus =
       data.status !== undefined &&
       [CohortStatus.UPCOMING, CohortStatus.RECRUITING].includes(data.status);
@@ -146,13 +170,13 @@ export class CohortService {
     await this.cohortRepository.deleteById({ id });
   }
 
-  async findPartById({ id }: { id: number }) {
-    return this.cohortRepository.findPartById({ id });
-  }
-
   async findPartByIdOrThrow({ id }: { id: number }) {
     const part = await this.cohortRepository.findPartById({ id });
-    if (!part || !part.isOpen || part.cohort?.status !== CohortStatus.RECRUITING) {
+    if (!part?.isOpen || !part.cohort) {
+      throw new AppException('COHORT_PART_NOT_FOUND', HttpStatus.NOT_FOUND);
+    }
+
+    if (!isRecruitmentOpenAt({ cohort: part.cohort, now: new Date() })) {
       throw new AppException('COHORT_PART_NOT_FOUND', HttpStatus.NOT_FOUND);
     }
     return part;

--- a/src/cohort/domain/cohort-recruitment.spec.ts
+++ b/src/cohort/domain/cohort-recruitment.spec.ts
@@ -1,0 +1,101 @@
+import { CohortStatus } from './cohort.status';
+import type { CohortRecruitmentWindow } from './cohort-recruitment';
+import { isBeforeRecruitStart, isRecruitmentOpenAt } from './cohort-recruitment';
+
+const RECRUIT_START_AT = new Date('2026-08-29T00:00:00.000Z');
+const RECRUIT_END_AT = new Date('2026-09-05T00:00:00.000Z');
+
+const createWindow = (
+  override: Partial<CohortRecruitmentWindow> = {},
+): CohortRecruitmentWindow => ({
+  status: CohortStatus.RECRUITING,
+  recruitStartAt: RECRUIT_START_AT,
+  recruitEndAt: RECRUIT_END_AT,
+  ...override,
+});
+
+describe('isRecruitmentOpenAt', () => {
+  it('RECRUITING 이고 모집 기간 안이면 열려 있다', () => {
+    const now = new Date('2026-09-01T00:00:00.000Z');
+
+    expect(isRecruitmentOpenAt({ cohort: createWindow(), now })).toBe(true);
+  });
+
+  it('RECRUITING 이어도 모집 시작 전이면 닫혀 있다', () => {
+    const now = new Date('2026-08-16T00:00:00.000Z');
+
+    expect(isRecruitmentOpenAt({ cohort: createWindow(), now })).toBe(false);
+  });
+
+  it('RECRUITING 이어도 모집 종료 후면 닫혀 있다', () => {
+    const now = new Date('2026-09-06T00:00:00.000Z');
+
+    expect(isRecruitmentOpenAt({ cohort: createWindow(), now })).toBe(false);
+  });
+
+  it('모집 시작 시각 정각은 열려 있다', () => {
+    expect(isRecruitmentOpenAt({ cohort: createWindow(), now: RECRUIT_START_AT })).toBe(true);
+  });
+
+  it('모집 종료 시각 정각은 열려 있다', () => {
+    expect(isRecruitmentOpenAt({ cohort: createWindow(), now: RECRUIT_END_AT })).toBe(true);
+  });
+
+  it('모집 종료일이 00:00 으로 저장돼 있어도 그날 하루는 열려 있다', () => {
+    const now = new Date('2026-09-05T12:00:00.000Z');
+
+    expect(isRecruitmentOpenAt({ cohort: createWindow(), now })).toBe(true);
+  });
+
+  it('모집 종료일의 마지막 순간까지 열려 있다', () => {
+    const now = new Date('2026-09-05T23:59:59.999Z');
+
+    expect(isRecruitmentOpenAt({ cohort: createWindow(), now })).toBe(true);
+  });
+
+  it('모집 종료일 다음 날 0시에는 닫혀 있다', () => {
+    const now = new Date('2026-09-06T00:00:00.000Z');
+
+    expect(isRecruitmentOpenAt({ cohort: createWindow(), now })).toBe(false);
+  });
+
+  it('종료 시각이 23:59:59 로 저장돼 있어도 그날까지만 열려 있다', () => {
+    const cohort = createWindow({ recruitEndAt: new Date('2026-09-05T23:59:59.000Z') });
+
+    expect(isRecruitmentOpenAt({ cohort, now: new Date('2026-09-05T23:59:59.500Z') })).toBe(true);
+    expect(isRecruitmentOpenAt({ cohort, now: new Date('2026-09-06T00:00:00.000Z') })).toBe(false);
+  });
+
+  it('RECRUITING 이 아니면 모집 기간 안이어도 닫혀 있다', () => {
+    const now = new Date('2026-09-01T00:00:00.000Z');
+    const cohort = createWindow({ status: CohortStatus.UPCOMING });
+
+    expect(isRecruitmentOpenAt({ cohort, now })).toBe(false);
+  });
+
+  it('모집 일정이 비어 있으면 닫혀 있다', () => {
+    const now = new Date('2026-09-01T00:00:00.000Z');
+    const cohort = createWindow({ recruitStartAt: undefined, recruitEndAt: undefined });
+
+    expect(isRecruitmentOpenAt({ cohort, now })).toBe(false);
+  });
+});
+
+describe('isBeforeRecruitStart', () => {
+  it('모집 시작 전이면 true 를 반환한다', () => {
+    const now = new Date('2026-08-16T00:00:00.000Z');
+
+    expect(isBeforeRecruitStart({ cohort: createWindow(), now })).toBe(true);
+  });
+
+  it('모집 시작 시각 정각이면 false 를 반환한다', () => {
+    expect(isBeforeRecruitStart({ cohort: createWindow(), now: RECRUIT_START_AT })).toBe(false);
+  });
+
+  it('모집 시작일이 비어 있으면 false 를 반환한다', () => {
+    const now = new Date('2026-08-16T00:00:00.000Z');
+    const cohort = createWindow({ recruitStartAt: undefined });
+
+    expect(isBeforeRecruitStart({ cohort, now })).toBe(false);
+  });
+});

--- a/src/cohort/domain/cohort-recruitment.ts
+++ b/src/cohort/domain/cohort-recruitment.ts
@@ -1,0 +1,65 @@
+import { CohortStatus } from './cohort.status';
+
+/**
+ * 모집 개폐 판정에 필요한 최소 정보.
+ * 엔티티 전체가 아니라 이 형태만 요구해 파트 relation 등 부분 로드된 객체도 그대로 넘길 수 있다.
+ */
+export type CohortRecruitmentWindow = {
+  status: CohortStatus;
+  recruitStartAt?: Date | null;
+  recruitEndAt?: Date | null;
+};
+
+/**
+ * 모집 종료일은 "그날까지 모집"을 뜻하므로 저장된 시각이 아니라 그날의 끝을 마감으로 본다.
+ * 어드민이 날짜만 고르면 00:00:00 으로 저장되는데(예: 2026-09-05T00:00:00Z),
+ * 그 시각을 그대로 마감으로 쓰면 마지막 하루가 통째로 사라진다.
+ */
+const endOfUtcDay = (date: Date): Date => {
+  const end = new Date(date);
+  end.setUTCHours(23, 59, 59, 999);
+  return end;
+};
+
+/**
+ * 지원 접수가 열려 있는지 판정한다.
+ * status 만으로 판단하면 모집 시작 전·종료 후에도 접수가 열리므로 모집 일정까지 함께 본다.
+ * 일정이 비어 있으면 닫힌 것으로 본다(fail-closed).
+ */
+export const isRecruitmentOpenAt = ({
+  cohort,
+  now,
+}: {
+  cohort: CohortRecruitmentWindow;
+  now: Date;
+}): boolean => {
+  if (cohort.status !== CohortStatus.RECRUITING) {
+    return false;
+  }
+
+  const { recruitStartAt, recruitEndAt } = cohort;
+  if (!recruitStartAt || !recruitEndAt) {
+    return false;
+  }
+
+  const current = now.getTime();
+  const started = recruitStartAt.getTime() <= current;
+  const notEnded = current <= endOfUtcDay(recruitEndAt).getTime();
+  return started && notEnded;
+};
+
+/** 모집 시작 전 구간인지 판정한다. 사전 알림 CTA 노출 여부에 쓴다. */
+export const isBeforeRecruitStart = ({
+  cohort,
+  now,
+}: {
+  cohort: CohortRecruitmentWindow;
+  now: Date;
+}): boolean => {
+  const { recruitStartAt } = cohort;
+  if (!recruitStartAt) {
+    return false;
+  }
+
+  return now.getTime() < recruitStartAt.getTime();
+};

--- a/src/cohort/interface/dto/public-cohort.response.dto.spec.ts
+++ b/src/cohort/interface/dto/public-cohort.response.dto.spec.ts
@@ -4,6 +4,13 @@ import { CohortPart } from '../../domain/cohort-part.entity';
 import { CohortPartName } from '../../domain/cohort-part-name';
 import { CohortCtaStatus, PublicCohortResponseDto } from './public-cohort.response.dto';
 
+const RECRUIT_START_AT = new Date('2026-03-01T00:00:00.000Z');
+const RECRUIT_END_AT = new Date('2026-03-15T23:59:59.000Z');
+
+const BEFORE_START = new Date('2026-02-20T00:00:00.000Z');
+const DURING = new Date('2026-03-10T00:00:00.000Z');
+const AFTER_END = new Date('2026-03-16T00:00:00.000Z');
+
 const makeCohort = ({
   status,
   parts = [],
@@ -14,8 +21,8 @@ const makeCohort = ({
   const cohort = new Cohort();
   cohort.id = 1;
   cohort.name = '16기';
-  cohort.recruitStartAt = new Date('2026-03-01T00:00:00.000Z');
-  cohort.recruitEndAt = new Date('2026-03-15T23:59:59.000Z');
+  cohort.recruitStartAt = RECRUIT_START_AT;
+  cohort.recruitEndAt = RECRUIT_END_AT;
   cohort.status = status;
   cohort.process = { documentResultAt: '2026-03-20' };
   cohort.curriculum = [{ week: 1 }];
@@ -31,6 +38,8 @@ const makeCohort = ({
   return cohort;
 };
 
+const openFePart = { id: 10, partName: CohortPartName.FE, isOpen: true };
+
 describe('PublicCohortResponseDto', () => {
   describe('from', () => {
     it('활성 기수가 없으면 사전 알림 CTA와 null 기수 필드를 반환한다', () => {
@@ -38,7 +47,7 @@ describe('PublicCohortResponseDto', () => {
       const cohort = null;
 
       // When
-      const result = PublicCohortResponseDto.from(cohort);
+      const result = PublicCohortResponseDto.from(cohort, DURING);
 
       // Then
       expect(result).toEqual({
@@ -61,7 +70,7 @@ describe('PublicCohortResponseDto', () => {
       const cohort = makeCohort({ status: CohortStatus.UPCOMING });
 
       // When
-      const result = PublicCohortResponseDto.from(cohort);
+      const result = PublicCohortResponseDto.from(cohort, DURING);
 
       // Then
       expect(result.hasActiveCohort).toBe(true);
@@ -71,18 +80,15 @@ describe('PublicCohortResponseDto', () => {
 
     it('RECRUITING 기수에 열린 파트가 있으면 지원 CTA와 열린 파트 정보를 반환한다', () => {
       // Given
-      const cohort = makeCohort({
-        status: CohortStatus.RECRUITING,
-        parts: [{ id: 10, partName: CohortPartName.FE, isOpen: true }],
-      });
+      const cohort = makeCohort({ status: CohortStatus.RECRUITING, parts: [openFePart] });
 
       // When
-      const result = PublicCohortResponseDto.from(cohort);
+      const result = PublicCohortResponseDto.from(cohort, DURING);
 
       // Then
       expect(result.ctaStatus).toBe(CohortCtaStatus.APPLY);
       expect(result.isRecruitmentOpen).toBe(true);
-      expect(result.parts).toEqual([{ id: 10, partName: CohortPartName.FE, isOpen: true }]);
+      expect(result.parts).toEqual([openFePart]);
     });
 
     it('RECRUITING 기수에 열린 파트가 없으면 마감 CTA를 반환한다', () => {
@@ -90,7 +96,7 @@ describe('PublicCohortResponseDto', () => {
       const cohort = makeCohort({ status: CohortStatus.RECRUITING });
 
       // When
-      const result = PublicCohortResponseDto.from(cohort);
+      const result = PublicCohortResponseDto.from(cohort, DURING);
 
       // Then
       expect(result.ctaStatus).toBe(CohortCtaStatus.CLOSED);
@@ -105,7 +111,7 @@ describe('PublicCohortResponseDto', () => {
         const cohort = makeCohort({ status });
 
         // When
-        const result = PublicCohortResponseDto.from(cohort);
+        const result = PublicCohortResponseDto.from(cohort, DURING);
 
         // Then
         expect(result.ctaStatus).toBe(CohortCtaStatus.CLOSED);
@@ -117,17 +123,62 @@ describe('PublicCohortResponseDto', () => {
       // Given
       const cohort = makeCohort({
         status: CohortStatus.RECRUITING,
-        parts: [
-          { id: 10, partName: CohortPartName.FE, isOpen: true },
-          { id: 11, partName: CohortPartName.BE, isOpen: false },
-        ],
+        parts: [openFePart, { id: 11, partName: CohortPartName.BE, isOpen: false }],
       });
 
       // When
-      const result = PublicCohortResponseDto.from(cohort);
+      const result = PublicCohortResponseDto.from(cohort, DURING);
 
       // Then
-      expect(result.parts).toEqual([{ id: 10, partName: CohortPartName.FE, isOpen: true }]);
+      expect(result.parts).toEqual([openFePart]);
+    });
+
+    it('RECRUITING 이어도 모집 시작 전이면 사전 알림 CTA를 반환한다', () => {
+      // Given
+      const cohort = makeCohort({ status: CohortStatus.RECRUITING, parts: [openFePart] });
+
+      // When
+      const result = PublicCohortResponseDto.from(cohort, BEFORE_START);
+
+      // Then
+      expect(result.ctaStatus).toBe(CohortCtaStatus.PRE_NOTIFICATION);
+      expect(result.isRecruitmentOpen).toBe(false);
+    });
+
+    it('RECRUITING 이어도 모집 종료 후면 마감 CTA를 반환한다', () => {
+      // Given
+      const cohort = makeCohort({ status: CohortStatus.RECRUITING, parts: [openFePart] });
+
+      // When
+      const result = PublicCohortResponseDto.from(cohort, AFTER_END);
+
+      // Then
+      expect(result.ctaStatus).toBe(CohortCtaStatus.CLOSED);
+      expect(result.isRecruitmentOpen).toBe(false);
+    });
+
+    it('모집 시작 전에도 parts 는 열린 파트를 그대로 노출한다', () => {
+      // Given
+      const cohort = makeCohort({ status: CohortStatus.RECRUITING, parts: [openFePart] });
+
+      // When
+      const result = PublicCohortResponseDto.from(cohort, BEFORE_START);
+
+      // Then — 진입 가능 여부의 기준은 parts 가 아니라 isRecruitmentOpen 이다
+      expect(result.parts).toEqual([openFePart]);
+      expect(result.isRecruitmentOpen).toBe(false);
+    });
+
+    it('모집 종료일이 지정 시각을 넘겨도 그날 하루는 지원 CTA 를 유지한다', () => {
+      // Given — recruitEndAt 은 03-15T23:59:59Z
+      const cohort = makeCohort({ status: CohortStatus.RECRUITING, parts: [openFePart] });
+
+      // When
+      const result = PublicCohortResponseDto.from(cohort, new Date('2026-03-15T23:59:59.500Z'));
+
+      // Then
+      expect(result.ctaStatus).toBe(CohortCtaStatus.APPLY);
+      expect(result.isRecruitmentOpen).toBe(true);
     });
   });
 });

--- a/src/cohort/interface/dto/public-cohort.response.dto.ts
+++ b/src/cohort/interface/dto/public-cohort.response.dto.ts
@@ -4,6 +4,7 @@ import type { Cohort } from '../../domain/cohort.entity';
 import { CohortStatus } from '../../domain/cohort.status';
 import type { CohortPart } from '../../domain/cohort-part.entity';
 import { CohortPartName } from '../../domain/cohort-part-name';
+import { isBeforeRecruitStart, isRecruitmentOpenAt } from '../../domain/cohort-recruitment';
 
 export enum CohortCtaStatus {
   PRE_NOTIFICATION = 'PRE_NOTIFICATION',
@@ -78,7 +79,7 @@ export class PublicCohortResponseDto {
   })
   parts: PublicCohortPartSummaryDto[];
 
-  static from(cohort: Cohort | null): PublicCohortResponseDto {
+  static from(cohort: Cohort | null, now: Date = new Date()): PublicCohortResponseDto {
     const dto = new PublicCohortResponseDto();
     if (!cohort) {
       dto.hasActiveCohort = false;
@@ -106,10 +107,15 @@ export class PublicCohortResponseDto {
     dto.parts = (cohort.parts ?? [])
       .filter((part) => part.isOpen)
       .map((part) => ({ id: part.id, partName: part.partName, isOpen: true }));
-    dto.isRecruitmentOpen = cohort.status === CohortStatus.RECRUITING && dto.parts.length > 0;
-    if (cohort.status === CohortStatus.UPCOMING) {
+
+    const recruitmentOpen = isRecruitmentOpenAt({ cohort, now });
+    const beforeStart =
+      cohort.status === CohortStatus.RECRUITING && isBeforeRecruitStart({ cohort, now });
+
+    dto.isRecruitmentOpen = recruitmentOpen && dto.parts.length > 0;
+    if (cohort.status === CohortStatus.UPCOMING || beforeStart) {
       dto.ctaStatus = CohortCtaStatus.PRE_NOTIFICATION;
-    } else if (cohort.status === CohortStatus.RECRUITING && dto.parts.length > 0) {
+    } else if (dto.isRecruitmentOpen) {
       dto.ctaStatus = CohortCtaStatus.APPLY;
     } else {
       dto.ctaStatus = CohortCtaStatus.CLOSED;

--- a/src/common/error/error-message.ts
+++ b/src/common/error/error-message.ts
@@ -15,6 +15,7 @@ export const ErrorMessage = {
 
   COHORT_NOT_FOUND: '기수를 찾을 수 없습니다.',
   COHORT_ALREADY_EXISTS: '이미 진행 중인 기수가 존재합니다.',
+  INVALID_RECRUIT_PERIOD: '모집 시작일은 종료일보다 늦을 수 없습니다.',
   COHORT_PART_NOT_FOUND: '모집 중인 파트를 찾을 수 없습니다.',
 
   APPLICATION_FORM_NOT_FOUND: '지원서를 찾을 수 없습니다.',


### PR DESCRIPTION
## 개요

모집 개폐를 `status` 만으로 판정하던 것을 **모집 일정까지 함께 보도록** 바꿉니다. 공개 응답의 CTA 계산, 공개 파트 조회, 지원서 임시저장·최종제출 네 경로에 동일한 게이트를 적용했습니다.

## 변경 이유

14기는 모집기간이 **2026-08-29 ~ 09-05** 인데 어드민에서 상태가 이미 `RECRUITING` 입니다(시작일이 미래라 스케줄러가 바꾼 것이 아니라 수동 조작). 기존 코드는 날짜를 전혀 보지 않으므로, 프론트가 정상화되는 순간 **모집 시작 13일 전에 실제 지원서 접수가 열립니다.**

쓰기 경로가 특히 약했습니다. `submitForm`/`saveDraft` 는 `cohortPart.isOpen` 만 확인하고 기수 상태도 날짜도 보지 않아, 공개 조회 경로가 `RECRUITING` 을 확인하는 것과 비대칭이었습니다. 이 경로로 저장되는 값에는 암호화된 실명·전화번호·생년월일이 포함됩니다.

## 주요 변경 사항

- **`src/cohort/domain/cohort-recruitment.ts` (신규)** — `isRecruitmentOpenAt` / `isBeforeRecruitStart` 순수 함수. 프레임워크·ORM 의존 없음. 일정이 비면 닫힘(fail-closed)
- **종료 경계를 "그날의 끝"으로 정규화** — 어드민이 날짜만 고르면 `2026-09-05T00:00:00Z` 로 저장됩니다. 이를 그대로 마감으로 쓰면 마지막 하루가 통째로 사라지므로, 기존 만료 크론(`recruitEndAt < now` 판정 + 다음 자정 실행)의 실질 마감 시각과 일치시켰습니다
- **`PublicCohortResponseDto.from(cohort, now)`** — `RECRUITING` 이어도 시작 전이면 `PRE_NOTIFICATION`, 종료 후면 `CLOSED`. **필드 구조는 변경 없음**, 값이 나오는 조건만 변경
- **`ApplicationService.isApplicationOpen()`** — `saveDraft`/`submitForm` 양쪽에 적용
- **`CohortService.findPartByIdOrThrow`** — status 검사를 날짜 게이트로 교체
- **`INVALID_RECRUIT_PERIOD`(400) 추가** — 날짜 게이트 도입으로 `recruitStartAt > recruitEndAt` 오입력이 "어드민에는 RECRUITING, 실제로는 영구 마감"이라는 무음 실패가 됩니다. 입력 시점에 차단하며, 수정은 부분 패치이므로 **기존 값과 병합한 뒤** 검증합니다
- **`CohortService.findPartById` 삭제** — 호출자 0, 게이트 없는 우회 통로가 될 수 있던 dead code

## 아키텍처 영향

- **도메인 분리**: 모집 개폐 판정 규칙을 `cohort/domain` 순수 함수로 추출. 기존에는 DTO·서비스 세 곳에 흩어져 있었습니다
- **레이어 변경**: 없음. Domain은 framework-free 유지(`cohort.status` enum 외 import 없음)
- **의존 방향 영향**: `application` → `cohort/domain` 은 기존 `CohortRepository` 의존과 동일 패턴
- **트랜잭션 경계 영향**: 없음

## 테스트

- [x] 단위 테스트
- [ ] 통합 테스트
- [x] 수동 테스트 (프로덕션 응답값으로 시나리오 재현)

**321개 통과 / 0 실패** (기존 289 → +32). `yarn lint` exit 0, `yarn build` exit 0.

TDD로 작성했고 각 게이트를 되돌리면 해당 테스트만 실패하는 것을 확인했습니다(red-green 역검증).

14기 실제 값(`2026-08-29T00:00:00Z` ~ `2026-09-05T00:00:00Z`, RECRUITING, 오픈 파트 6개) 기준 시점별 응답:

| 시점 | ctaStatus | isRecruitmentOpen |
|---|---|---|
| 2026-08-16 (현재) | `PRE_NOTIFICATION` | `false` |
| 2026-08-29 (시작) | `APPLY` | `true` |
| 2026-09-05 (종료일 당일) | `APPLY` | `true` |
| 2026-09-06 | `CLOSED` | `false` |

## 리뷰 포인트

1. **종료 경계 정규화가 핵심입니다.** `endOfUtcDay` 없이 저장값을 그대로 마감으로 쓰면 마감이 24시간 앞당겨집니다. 어드민이 `recruitEndAt` 을 어떤 형식으로 전송하는지 확인해 주세요 — 날짜만 고르는 UI라면 현재 구현이 맞고, `23:59:59` 를 보낸다면 그때도 동작은 동일합니다
2. `openParts` 는 여전히 `isOpen` 만으로 채워집니다. 즉 **모집 시작 전에도 파트 목록은 비어 있지 않은데 해당 파트를 조회하면 404** 입니다. 프론트가 `openParts` 로 카드를 렌더링하고 클릭 진입을 허용한다면 조정이 필요합니다. 진입 가능 여부의 단일 기준은 `isRecruitmentOpen` 입니다
3. `COHORT_PART_CLOSED`(400, 쓰기 경로)와 `COHORT_PART_NOT_FOUND`(404, 조회 경로)가 같은 원인에 다른 코드를 반환합니다. 기존 동작을 유지했습니다

## 리스크 / 후속 작업

- **머지만으로는 홈페이지가 고쳐지지 않습니다.** 별도 원인(`openParts` vs 프론트가 읽는 `parts` 계약 불일치)은 `fix/home-cta-api-contract` 브랜치에 이미 수정되어 있으나 미머지 상태입니다
- **타임존 미고정** — `Dockerfile`·`docker-compose.yml` 에 `TZ` 가 없어 컨테이너는 UTC 이고, `cohorts.recruit_*` 는 `timestamp without time zone` 입니다. 이번 변경으로 이 컬럼이 **모든 지원 요청의 개폐 판정 근거**가 되어 영향 반경이 커졌습니다. `ENV TZ=UTC` 고정 또는 `timestamptz` 마이그레이션을 별도 PR로 권합니다(현재 다른 브랜치가 인프라 파일을 수정 중이라 이번 PR에서는 제외)
- **운영 런북**: 잘못 닫힌 것이 발견되면 이제 `status` 조작만으로는 열리지 않습니다. `recruitStartAt`/`recruitEndAt` 을 수정해야 합니다
- 게이트가 닫아서 400/404 를 반환할 때 로그가 없습니다. 필요하면 `logger.warn` 추가를 검토해 주세요
