### PR TITLE
fix(infra): 컨테이너가 GCP 키를 읽지 못해 GCS 업로드가 실패하던 문제 교정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -246,6 +246,43 @@ jobs:
             fi
             cat gcp-key.json.tmp > gcp-key.json
             rm -f gcp-key.json.tmp
+            # umask 077 때문에 0600 으로 생성되는데, 컨테이너는 non-root(uid/gid 10001, Dockerfile)
+            # 로 돌기 때문에 그대로 두면 앱이 키 파일 자체를 열지 못한다(EACCES).
+            # 자격증명은 지연 로딩이라 앱은 정상 기동하고 헬스체크도 통과하며, 첫 GCS 호출에서야
+            # 터진다. 그 첫 호출이 배포 몇 주 뒤의 사용자 업로드였던 것이 이번 PDF 업로드 장애다.
+            # 소유자를 바꾸면 위 cat 이 다음 배포에서 같은 inode 에 쓰지 못하므로,
+            # 그룹만 컨테이너 gid 로 맞추고 그룹 읽기만 연다.
+            # 노출 범위: others 는 계속 차단되지만 호스트 gid 10001 의 구성원은 읽을 수 있게 된다.
+            # VM 에 그 gid 를 쓰는 기존 그룹이 없어야 한다(getent group 10001 이 비어 있을 것).
+            if ! sudo chgrp 10001 gcp-key.json; then
+              echo "ERROR: gcp-key.json 의 그룹을 변경하지 못했습니다."
+              echo "       배포 유저의 sudo 권한이 docker 로만 제한돼 있는지 확인하세요."
+              exit 1
+            fi
+            sudo chmod 640 gcp-key.json
+
+            # 컨테이너를 교체하기 전에, 배포할 이미지가 이 키를 실제로 쓸 수 있는지 확인한다.
+            # 교체 후에 검사하면 이미 트래픽을 받는 컨테이너를 되돌릴 수 없어 게이트 구실을 못 한다.
+            # 검사 범위는 파일 가독성 + JSON 형태 + PEM 파싱까지다. 자격증명 유효성, IAM 권한,
+            # 버킷 존재, 네트워크 도달성은 커버하지 않는다 — 배포와 무관하게 바뀌는 값들이라
+            # 배포 게이트에 묶으면 관계없는 외부 사정으로 배포가 막힌다.
+            # 컨테이너 내부 경로는 아래 GOOGLE_CALENDAR_KEY_FILE_PATH / GCS_KEY_FILE_PATH 와 같아야 한다.
+            IMAGE_UID="$(sudo docker run --rm "$APP_IMAGE" id -u 2>/dev/null)" || IMAGE_UID=""
+            if [ "$IMAGE_UID" != "10001" ]; then
+              # uid 고정 이전 이미지(uid 100)로 롤백하는 중이다. 그 이미지는 gid 10001 로 열어둔
+              # 키를 읽지 못하는 것이 정상이므로 여기서 막지 않는다. 롤백은 장애 대응 경로이고,
+              # 되돌릴 수단을 없애는 쪽이 더 위험하다. skip_version_check 와는 무관하게 판정한다.
+              echo "::warning::배포 이미지의 실행 uid=${IMAGE_UID:-확인불가} 로 10001 이 아닙니다. 이 배포에서 GCS 업로드와 캘린더 연동은 동작하지 않습니다."
+            elif sudo docker run --rm -v /opt/ddd-be/gcp-key.json:/app/gcp-key.json:ro "$APP_IMAGE" \
+              node -e 'const k=require("/app/gcp-key.json"); if(!k.private_key||!k.client_email) process.exit(1); require("crypto").createPrivateKey(k.private_key)'; then
+              echo "GCP 키 사용 가능 확인 (배포할 이미지에서 파싱 성공)"
+            else
+              echo "ERROR: 배포할 이미지가 gcp-key.json 을 사용하지 못합니다(읽기 실패 또는 내용 손상)."
+              echo "       컨테이너는 교체하지 않았습니다. 현재 운영 중인 컨테이너는 그대로입니다."
+              echo "--- 호스트 파일 권한 (그룹이 10001 이어야 함) ---"
+              ls -ln gcp-key.json || true
+              exit 1
+            fi
 
             ENV_TMP=.env.production.tmp
             printf 'PORT=%s\n'        "$APP_PORT"    > "$ENV_TMP"

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,10 @@ ARG GIT_SHA=unknown
 ENV APP_VERSION=$GIT_SHA
 LABEL org.opencontainers.image.revision=$GIT_SHA
 
-RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+# uid/gid 를 고정한다. gcp-key.json 은 호스트에서 바인드 마운트되고 배포 스크립트가
+# 그 파일의 그룹을 컨테이너 gid 에 맞춰야 하는데, adduser -S 의 자동 배정 uid 는
+# base image 가 바뀌면 함께 바뀌므로 스크립트가 기댈 수 없다.
+RUN addgroup -S -g 10001 appgroup && adduser -S -u 10001 -G appgroup appuser
 USER appuser
 
 EXPOSE 3000


### PR DESCRIPTION
## 개요

어드민 PDF 업로드가 `FILE_UPLOAD_FAILED`(500)로 실패하는 제보를 추적해, 컨테이너가 마운트된 `gcp-key.json`을 열지 못하는 상태를 교정합니다.

**파일 크기 문제가 아닙니다.** 제보에는 "5.3MB PDF"라고 적혀 있지만 PDF 한도는 20MB이고, 크기 검증을 통과한 뒤 GCS 호출에서 터진 에러입니다. 작은 PDF로도 동일하게 실패합니다.

## 변경 이유

```
deploy.yml   umask 077 → gcp-key.json 이 0600 / 배포 유저 소유
Dockerfile   USER appuser, adduser -S 가 배정하는 uid = 100
결과         uid 100 이 배포 유저 소유 0600 파일을 열 수 없음 → EACCES
```

`google-auth-library`는 키를 지연 로딩합니다. 그래서 키를 못 읽어도 **앱은 정상 기동하고 헬스체크도 통과**하며, 첫 GCS 호출에서만 실패합니다. 그 첫 호출이 배포 몇 주 뒤의 사용자 업로드였습니다.

관측된 사실:
- GCS 버킷 `projects/pdfs/` 객체 **0개**
- `projects/thumbnails/` 객체 5개는 전부 2026-05-13 `scripts/seed-figma.ts` 실행 산물 (그중 하나는 18MB PNG로, 썸네일 한도 5MB를 넘습니다 — 서비스 검증을 거치지 않았다는 뜻)
- 서비스 계정의 `storage.objects.create` 권한은 **정상 부여됨** (`testPermissions`로 확인) — 권한 문제가 아닙니다

## 주요 변경 사항

| 파일 | 변경 |
|---|---|
| `Dockerfile` | `appuser` uid/gid를 **10001로 고정**. 자동 배정 uid는 base image 갱신 시 함께 바뀌어 배포 스크립트가 기댈 수 없음 |
| `deploy.yml` | 키 파일에 `sudo chgrp 10001` + `sudo chmod 640`. `chown`이 아니라 `chgrp`인 이유는 소유자를 바꾸면 다음 배포의 `cat tmp > gcp-key.json`이 같은 inode에 쓰지 못하기 때문 |
| `deploy.yml` | **컨테이너 교체 이전에** 배포할 이미지가 키를 읽고 파싱할 수 있는지 일회용 컨테이너로 확인, 실패 시 배포 중단 |

### 검증을 컨테이너 교체 이전에 둔 이유

초안은 헬스체크 이후에 검사했는데, 그 위치에서는 `exit 1`이 컨테이너를 되돌리지 못합니다. 깨진 컨테이너가 이미 트래픽을 받는 상태라 **탐지만 되고 예방은 안 됩니다.** 게다가 `[8/8] caddy reload`를 건너뛰어 라우팅 불일치까지 만듭니다. 이미지는 `[2/8]`에서 이미 pull돼 있으므로 키 생성 직후에 검사하면 프로덕션을 건드리기 전에 멈춥니다.

검사 범위는 **파일 가독성 + JSON 형태 + PEM 파싱**까지입니다. 자격증명 유효성·IAM·버킷 존재·네트워크 도달성은 배포와 무관하게 바뀌는 값이라 배포 게이트에 묶지 않았습니다(관계없는 외부 사정으로 배포가 막히는 것을 피하기 위함).

### 롤백 경로

uid 고정 이전 이미지로 롤백하면 그 이미지(uid 100)는 gid 10001로 열어둔 키를 읽지 못하는 것이 **정상**입니다. 배포할 이미지의 실행 uid를 먼저 확인해 10001이 아니면 `::warning::`만 남기고 진행합니다. 롤백은 장애 대응 경로라 여기서 막으면 되돌릴 수단이 사라집니다. `skip_version_check`와는 결합하지 않습니다 — 그 플래그는 "버전 엔드포인트가 없는 구버전"용이고, 실제 롤백 대상 대부분은 버전 엔드포인트가 있어 플래그를 켤 이유가 없기 때문입니다.

## 아키텍처 영향

- 도메인 분리: 영향 없음
- 레이어 변경: 없음 (인프라 전용)
- 의존 방향 영향: 없음
- 트랜잭션 경계 영향: 없음
- **API 계약 변경 없음.** 요청·응답 스키마와 에러 코드 모두 그대로이고, 동작만 복구됩니다

## 테스트

- [x] 단위 테스트 — 35 suites / 296 tests 통과
- [x] 수동 테스트 (컨테이너 재현)

`node:22-alpine`에서 실제로 재현·검증했습니다.

```
uid 고정          addgroup -S -g 10001 / adduser -S -u 10001 → uid=10001 gid=10001
case 1  0600, 타 유저 소유  → 차단 (EACCES, 수정 전 상태 재현)
case 2  0640, gid 10001     → 통과
case 3  PEM 손상            → 차단 (JSON 검사만으로는 못 잡던 케이스)
case 4  0바이트             → 차단
회귀    배포 유저의 후속 배포 쓰기 → 가능
순서    키 검사가 docker compose up -d 보다 앞에 위치 확인
```

## 리뷰 포인트

- `chgrp`/`chmod`가 요구사항 세 가지(컨테이너 읽기 가능 / 다음 배포 쓰기 가능 / world-readable 아님)를 동시에 만족하는지
- 검사 위치가 컨테이너 교체 이전인지
- 롤백 분기가 uid 기준으로 판정하는지

## 머지 전 VM에서 확인 필요 (30초)

프로덕션 SSH 접근 없이 코드·base image·git 히스토리에서 연역한 진단이라, 아래 확인으로 확정됩니다.

```bash
ls -ln /opt/ddd-be/gcp-key.json     # 0600 + 배포 유저 소유여야 진단 확정
ls -la /opt/ddd-be/                  # docker-compose.override.yml 잔존 시 build 시도 위험
getent group 10001                   # 비어 있어야 함 (키를 읽게 될 기존 그룹 없음)
docker info | grep -i userns         # userns-remap 이 켜져 있으면 이 교정이 작동하지 않음
sudo -n chgrp 10001 /opt/ddd-be/gcp-key.json; echo $?   # sudoers 가 docker 로만 제한되면 실패
```

### 반증 테스트 (1분)

같은 키가 목록 조회도 구동하므로, 아래가 **200이면 이 PR의 진단이 틀린 것**입니다.

```
GET /api/v1/admin/files?category=project-pdf   → EACCES 가설이 맞다면 FILE_LIST_FAILED(500)
```

어드민 파일 목록 화면이 한 번이라도 정상 동작한 적 있다면 그 자체가 반증입니다.

## 리스크 / 후속 작업

**리스크**
- 캘린더 연동은 같은 키를 쓰므로 키 접근 문제는 함께 해소되지만, scope와 캘린더 공유 설정이 별개라 동작 여부는 별도 확인이 필요합니다
- `chmod 640`으로 노출 범위가 "소유자 전용"에서 "소유자 + 호스트 gid 10001 구성원"으로 넓어집니다 (위 `getent` 확인 항목)

**후속 이슈 (이 PR 범위 밖)**
1. **키 파일을 없애는 방향** — `umask`·bind mount·`chgrp`·uid 고정·배포 게이트가 전부 "자격증명을 디스크에 둔다"는 선택 하나를 떠받치고 있습니다. `GCP_SERVICE_ACCOUNT_JSON`이 이미 시크릿 env로 들어오므로 `new Storage({ credentials: JSON.parse(...) })`로 바꾸면 이 계열 버그가 통째로 사라집니다
2. **`openapi.json`의 `storage_uploadFile`에 `requestBody` 누락** — `@ApiConsumes`만 있고 `@ApiBody`가 없어, 스펙 기반 생성 클라이언트를 그대로 쓰면 파일이 실리지 않습니다
3. **어드민 업로드에 multer `limits` 없음** — 파일 전체를 메모리에 받은 뒤에야 크기 검증이 돕니다. 추가하려면 `MulterError` → 400 매핑도 함께 필요 (지원서 첨부 브랜치에도 같은 구멍)
4. **`gcs.client.ts`의 `resumable:false` + 재시도 부재** — 일시적 네트워크 오류 한 번이 그대로 `FILE_UPLOAD_FAILED`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
