### PR TITLE
chore(cohort): 파트명 enum 을 공용 스키마로 노출

### DIFF
--- a/src/cohort/interface/dto/admin-cohort.request.dto.ts
+++ b/src/cohort/interface/dto/admin-cohort.request.dto.ts
@@ -17,7 +17,12 @@ import { CohortStatus } from '../../domain/cohort.status';
 import { CohortPartName } from '../../domain/cohort-part-name';
 
 export class CohortPartConfigDto {
-  @ApiProperty({ description: '파트명', enum: CohortPartName, example: CohortPartName.IOS })
+  @ApiProperty({
+    description: '파트명',
+    enum: CohortPartName,
+    enumName: 'CohortPartName',
+    example: CohortPartName.IOS,
+  })
   @IsEnum(CohortPartName)
   name: CohortPartName;
 

--- a/src/cohort/interface/dto/admin-cohort.response.dto.ts
+++ b/src/cohort/interface/dto/admin-cohort.response.dto.ts
@@ -3,13 +3,18 @@ import { ApiProperty } from '@nestjs/swagger';
 import type { Cohort } from '../../domain/cohort.entity';
 import { CohortStatus } from '../../domain/cohort.status';
 import type { CohortPart } from '../../domain/cohort-part.entity';
-import type { CohortPartName } from '../../domain/cohort-part-name';
+import { CohortPartName } from '../../domain/cohort-part-name';
 
 export class CohortPartAdminResponseDto {
   @ApiProperty({ description: 'ID', example: 1 })
   id: number;
 
-  @ApiProperty({ description: '파트명', example: 'FE' })
+  @ApiProperty({
+    description: '파트명',
+    enum: CohortPartName,
+    enumName: 'CohortPartName',
+    example: CohortPartName.FE,
+  })
   partName: CohortPartName;
 
   @ApiProperty({ description: '모집 오픈 여부', example: false })

--- a/src/cohort/interface/dto/public-cohort.response.dto.ts
+++ b/src/cohort/interface/dto/public-cohort.response.dto.ts
@@ -19,6 +19,7 @@ export class PublicCohortPartSummaryDto {
   @ApiProperty({
     description: '파트명',
     enum: CohortPartName,
+    enumName: 'CohortPartName',
     example: CohortPartName.FE,
   })
   partName: CohortPartName;
@@ -128,7 +129,12 @@ export class PublicCohortPartResponseDto {
   @ApiProperty({ description: '파트 ID', example: 1 })
   id: number;
 
-  @ApiProperty({ description: '파트명', example: 'FE' })
+  @ApiProperty({
+    description: '파트명',
+    enum: CohortPartName,
+    enumName: 'CohortPartName',
+    example: CohortPartName.FE,
+  })
   partName: CohortPartName;
 
   @ApiProperty({

--- a/src/cohort/interface/public.cohort.swagger.spec.ts
+++ b/src/cohort/interface/public.cohort.swagger.spec.ts
@@ -1,0 +1,71 @@
+import type { INestApplication } from '@nestjs/common';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { Test } from '@nestjs/testing';
+
+import { CohortService } from '../application/cohort.service';
+import { PublicCohortController } from './public.cohort.controller';
+
+// 이 엔드포인트의 200 응답 스키마가 OpenAPI 에 비어 있던 탓에 프론트가 타입을 수동
+// 추측 정의했고, 필드명이 어긋난 채 런타임에서만 깨진 사고가 있었다(#62). e2e 는
+// 응답 값을 고정하지만 문서에 스키마가 실리는지는 검증하지 않아 여기서 고정한다.
+describe('PublicCohortController Swagger 계약', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [PublicCohortController],
+      providers: [{ provide: CohortService, useValue: {} }],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  const createSchemas = () =>
+    SwaggerModule.createDocument(app, new DocumentBuilder().build()).components?.schemas ?? {};
+
+  it('공개 기수 응답 DTO 를 스키마로 노출한다', () => {
+    // Given & When
+    const schemas = createSchemas();
+
+    // Then
+    expect(schemas.PublicCohortResponseDto).toBeDefined();
+    expect(schemas.PublicCohortPartSummaryDto).toBeDefined();
+    expect(schemas.PublicCohortPartResponseDto).toBeDefined();
+  });
+
+  it('파트 목록이 파트 스키마를 참조한다', () => {
+    // Given & When
+    const cohortSchema = createSchemas().PublicCohortResponseDto;
+    const parts = 'properties' in cohortSchema ? cohortSchema.properties?.parts : undefined;
+
+    // Then
+    expect(parts).toEqual(
+      expect.objectContaining({
+        type: 'array',
+        items: { $ref: '#/components/schemas/PublicCohortPartSummaryDto' },
+      }),
+    );
+  });
+
+  // partName 이 string 으로 새면 프론트 생성 타입도 string 이 되어 오타를 잡지 못한다.
+  it('파트명을 공용 enum 스키마로 노출한다', () => {
+    // Given & When
+    const schemas = createSchemas();
+    const summary = schemas.PublicCohortPartSummaryDto;
+    const detail = schemas.PublicCohortPartResponseDto;
+
+    // Then
+    expect(schemas.CohortPartName).toEqual(
+      expect.objectContaining({ enum: ['PM', 'PD', 'BE', 'FE', 'IOS', 'AND'] }),
+    );
+    for (const schema of [summary, detail]) {
+      const partName = 'properties' in schema ? schema.properties?.partName : undefined;
+      expect(JSON.stringify(partName)).toContain('#/components/schemas/CohortPartName');
+    }
+  });
+});


### PR DESCRIPTION
## 개요

`partName` 이 OpenAPI 에 `string` 으로 나가던 2곳을 교정하고, 파트명 enum 을 공용 스키마로 분리합니다. #62 후속입니다.

## 변경 이유

`PublicCohortPartResponseDto`(파트 상세 `GET /cohorts/parts/{id}`)와 `CohortPartAdminResponseDto`(어드민 응답)의 `partName` 에 `enum` 지정이 없어 스펙에 `{"type": "string"}` 으로 나갑니다. 프론트 생성 타입도 `string` 이 되어, 파트명 오타나 enum 값 변경을 컴파일 단계에서 잡지 못합니다.

`#62` 가 활성 기수 응답의 `partName` 에는 enum 을 지정했지만 각 DTO 안에 인라인으로 펼쳐집니다. 같은 enum 이 스펙 4곳에 중복되고, 프론트가 파트명 타입을 하나로 참조할 수 없습니다.

## 주요 변경 사항

- `PublicCohortPartResponseDto.partName`, `CohortPartAdminResponseDto.partName` 에 `enum` 지정 (누락 교정)
- 4곳 모두에 `enumName: 'CohortPartName'` 을 붙여 공용 스키마로 분리
  - `PublicCohortPartSummaryDto`, `PublicCohortPartResponseDto`, `CohortPartAdminResponseDto`, `CohortPartConfigDto`(요청)
- `public.cohort.swagger.spec.ts` 신규 — 스키마가 문서에 실제로 실리는지 검증

변경 후 스펙에 `components.schemas.CohortPartName` 이 생기고, 네 곳이 `$ref` 로 참조합니다.

## 아키텍처 영향

- 도메인 분리: cohort 도메인 내부
- 레이어 변경: Interface Layer(DTO) 만. 응답 **값**은 바뀌지 않습니다 — 스펙 표현만 달라집니다
- 의존 방향 영향: `CohortPartName` 을 `import type` → 값 import 로 변경 (데코레이터에서 런타임 값 필요). Interface → Domain 방향 유지
- 트랜잭션 경계 영향: 없음

## 테스트

- [x] 단위 테스트 — cohort 45개, 전체 328개 통과
- [ ] 통합 테스트 — 해당 없음
- [x] 수동 테스트 — 스펙 생성 결과 확인

확인 내용
- `public.cohort.swagger.spec.ts` — 공개 기수 DTO 3종이 스키마로 노출되는지, `parts` 가 파트 스키마를 `$ref` 하는지, `partName` 이 `CohortPartName` 을 참조하는지
- `yarn build`, `yarn lint` 통과

## 리뷰 포인트

- 응답 페이로드는 그대로입니다. 프론트 재생성 시 `partName` 타입이 `string` → `CohortPartName` 유니온으로 좁혀지는 것이 유일한 변화입니다
- 요청 DTO(`CohortPartConfigDto.name`)도 같은 `enumName` 을 공유합니다. 요청·응답이 한 정의를 참조하는 것이 의도입니다

## 리스크 / 후속 작업

- 리스크 낮음. 런타임 동작 무변경
- `openapi.json` 은 배포 후 갱신되는 구조라 이 PR 로는 파일이 바뀌지 않습니다

**별도 처리 중인 사항** — 이대리 자동 리뷰와 적대적 검토에서 공통으로 지적된 2건이 남아 있습니다.

1. 지원서 제출 시 `400 INVALID_APPLICATION_ANSWERS` — 프론트가 고정 키 11개만 보내는데 `ApplicationAnswerValidator` 는 `applicationSchema.questions[].required` 인 key 를 요구합니다. 14기 PM 파트 기준 겹치는 키가 0개입니다. 프론트 동적 폼 작업이 필요합니다
2. `submitForm`/`saveDraft` 가 `cohortPart.isOpen` 만 검사하고 기수 status 를 보지 않아, 모집 마감(ACTIVE 전환) 후에도 제출이 가능합니다. 별도 PR 로 올립니다

## 관련 이슈

- #62 후속

🤖 Generated with [Claude Code](https://claude.com/claude-code)
