### PR TITLE
fix(application): 첨부 존재 검증 추가 및 파기 스캔 중단 제거 (이대리 리뷰 반영)

### DIFF
--- a/src/application/infrastructure/pii-purge.scheduler.spec.ts
+++ b/src/application/infrastructure/pii-purge.scheduler.spec.ts
@@ -191,6 +191,35 @@ describe('PiiPurgeService', () => {
     expect(result.attachment).toMatchObject({ deleted: 1, failed: 1 });
   });
 
+  it('페이지가 많아도 커서가 끝날 때까지 훑는다', async () => {
+    // Given: 앞쪽 600페이지가 전부 미만료. 중간에 끊고 다음 회차에 첫 페이지부터
+    // 다시 시작하면 601페이지의 만료 첨부는 영원히 파기되지 않는다.
+    const TOTAL_PAGES = 601;
+    for (let page = 0; page < TOTAL_PAGES; page += 1) {
+      const isLast = page === TOTAL_PAGES - 1;
+      mockStorageService.listFiles.mockResolvedValueOnce({
+        items: [
+          buildObject(
+            `applications/attachments/12/p${page}.pdf`,
+            isLast ? '2020-01-01T00:00:00.000Z' : '2099-01-01T00:00:00.000Z',
+          ),
+        ],
+        nextCursor: isLast ? null : `page-${page + 1}`,
+        hasNext: !isLast,
+      });
+    }
+
+    // When
+    const result = await service.purgeExpiredPii({ cutoffDate: new Date('2026-01-01') });
+
+    // Then: 마지막 페이지까지 도달해 만료분을 지웠고, 중단되지 않았다.
+    expect(mockStorageService.listFiles).toHaveBeenCalledTimes(TOTAL_PAGES);
+    expect(mockStorageService.deleteFile).toHaveBeenCalledWith({
+      path: `applications/attachments/12/p${TOTAL_PAGES - 1}.pdf`,
+    });
+    expect(result.attachment).toMatchObject({ deleted: 1, truncated: false });
+  });
+
   it('업로드 시각을 알 수 없는 객체는 삭제하지 않는다', async () => {
     // Given
     mockStorageService.listFiles.mockResolvedValue({

--- a/src/application/infrastructure/pii-purge.scheduler.spec.ts
+++ b/src/application/infrastructure/pii-purge.scheduler.spec.ts
@@ -220,6 +220,23 @@ describe('PiiPurgeService', () => {
     expect(result.attachment).toMatchObject({ deleted: 1, truncated: false });
   });
 
+  it('끝까지 훑은 뒤에는 다음 회차가 다시 처음부터 시작한다', async () => {
+    // Given: 한 페이지로 완주하는 목록
+    mockStorageService.listFiles.mockResolvedValue({
+      items: [buildObject('applications/attachments/12/a.pdf', '2099-01-01T00:00:00.000Z')],
+      nextCursor: null,
+      hasNext: false,
+    });
+
+    // When: 두 번 연속 실행
+    await service.purgeExpiredPii({ cutoffDate: new Date('2026-01-01') });
+    await service.purgeExpiredPii({ cutoffDate: new Date('2026-01-01') });
+
+    // Then: 두 번째도 커서 없이(=첫 페이지부터) 시작한다
+    expect(mockStorageService.listFiles).toHaveBeenCalledTimes(2);
+    expect(mockStorageService.listFiles.mock.calls[1][0]).toMatchObject({ cursor: undefined });
+  });
+
   it('업로드 시각을 알 수 없는 객체는 삭제하지 않는다', async () => {
     // Given
     mockStorageService.listFiles.mockResolvedValue({

--- a/src/application/usecase/application-attachment.service.spec.ts
+++ b/src/application/usecase/application-attachment.service.spec.ts
@@ -8,6 +8,7 @@ import { ApplicationAttachmentService } from './application-attachment.service';
 const mockStorageService = {
   upload: jest.fn(),
   generateSignedUrl: jest.fn(),
+  fileExists: jest.fn(),
 };
 
 describe('ApplicationAttachmentService', () => {
@@ -140,6 +141,49 @@ describe('ApplicationAttachmentService', () => {
           answers: { q1: { path: 'applications/attachments/99/a.pdf' } },
         }),
       ).toThrow(AppException);
+    });
+  });
+
+  describe('assertAttachmentsExist', () => {
+    it('본인 경로 형태여도 실제 객체가 없으면 거부한다', async () => {
+      // Given: 업로드 없이 지어낸 경로. 소유권 검사만으로는 걸러지지 않는다.
+      mockStorageService.fileExists.mockResolvedValue(false);
+
+      // When & Then
+      await expect(
+        service.assertAttachmentsExist({
+          answers: { q1: { path: 'applications/attachments/12/never-uploaded.pdf' } },
+        }),
+      ).rejects.toThrow(AppException);
+    });
+
+    it('실제로 존재하는 첨부는 통과시킨다', async () => {
+      mockStorageService.fileExists.mockResolvedValue(true);
+
+      await expect(
+        service.assertAttachmentsExist({
+          answers: { q1: { path: 'applications/attachments/12/real.pdf' } },
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it('첨부가 하나라도 없으면 거부한다', async () => {
+      mockStorageService.fileExists.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+
+      await expect(
+        service.assertAttachmentsExist({
+          answers: {
+            q1: { path: 'applications/attachments/12/real.pdf' },
+            q2: { path: 'applications/attachments/12/fake.pdf' },
+          },
+        }),
+      ).rejects.toThrow(AppException);
+    });
+
+    it('첨부가 없으면 스토리지를 조회하지 않는다', async () => {
+      await service.assertAttachmentsExist({ answers: { q1: '텍스트 답변' } });
+
+      expect(mockStorageService.fileExists).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/application/usecase/application-attachment.service.ts
+++ b/src/application/usecase/application-attachment.service.ts
@@ -7,6 +7,7 @@ import { SignedUrlAction, UploadCategory } from '../../storage/domain/storage.ty
 import type { ApplicationAttachment } from '../domain/application-attachment';
 import {
   buildAttachmentSubPath,
+  collectAttachmentPaths,
   findForeignAttachmentPaths,
   isOwnedAttachmentPath,
 } from '../domain/application-attachment';
@@ -63,6 +64,31 @@ export class ApplicationAttachmentService {
     const foreignPaths = findForeignAttachmentPaths({ answers, userId });
     if (foreignPaths.length > 0) {
       throw new AppException('ATTACHMENT_NOT_OWNED', HttpStatus.FORBIDDEN);
+    }
+  }
+
+  /**
+   * answers 의 첨부가 실제로 업로드된 객체인지 확인한다.
+   *
+   * 소유권 검사는 경로 접두어만 보므로, 본인 prefix 아래의 존재하지 않는 경로를
+   * 지어내면 업로드 없이도 통과한다. 그 상태로 제출되면 "필수 첨부" 문항이
+   * 무력화되고 심사자는 열리지 않는 파일을 받는다.
+   *
+   * 임시저장에는 적용하지 않는다. 작성 중 첨부를 지웠다 다시 올리는 흐름을
+   * 막을 이유가 없고, 최종 제출에서 걸러지면 충분하다.
+   */
+  async assertAttachmentsExist({ answers }: { answers: Record<string, unknown> }): Promise<void> {
+    const paths = collectAttachmentPaths({ answers });
+    if (paths.length === 0) {
+      return;
+    }
+
+    const results = await Promise.all(
+      paths.map(async (path) => ({ path, exists: await this.storageService.fileExists({ path }) })),
+    );
+
+    if (results.some((result) => !result.exists)) {
+      throw new AppException('FILE_NOT_FOUND', HttpStatus.BAD_REQUEST);
     }
   }
 }

--- a/src/application/usecase/application.service.spec.ts
+++ b/src/application/usecase/application.service.spec.ts
@@ -47,6 +47,7 @@ const mockInterviewService = {
 const mockStorageService = {
   upload: jest.fn(),
   generateSignedUrl: jest.fn(),
+  fileExists: jest.fn(),
 };
 
 const daysFromNow = (days: number) => new Date(Date.now() + days * 24 * 60 * 60 * 1000);
@@ -161,6 +162,31 @@ describe('ApplicationService', () => {
           { ...baseCommand, answers: { portfolio: 'applications/attachments/99/victim.pdf' } },
         ),
       ).rejects.toThrow(new AppException('ATTACHMENT_NOT_OWNED', HttpStatus.FORBIDDEN));
+
+      expect(mockApplicationRepository.saveForm).not.toHaveBeenCalled();
+    });
+
+    it('업로드하지 않은 첨부 경로를 지어내면 필수 첨부를 우회하지 못한다', async () => {
+      // Given: 본인 prefix 형태라 소유권 검사는 통과하지만 실제 객체는 없다.
+      mockCohortRepository.findPartById.mockResolvedValue({
+        id: 1,
+        isOpen: true,
+        cohort: createCohortWindow(),
+        applicationSchema: { questions: [{ key: 'portfolio', required: true }] },
+      });
+      mockApplicationRepository.findFormByUserAndPart.mockResolvedValue(null);
+      mockStorageService.fileExists.mockResolvedValue(false);
+
+      // When & Then
+      await expect(
+        applicationService.submitForm(
+          { userId: 1, email: 'user@example.com' },
+          {
+            ...baseCommand,
+            answers: { portfolio: { path: 'applications/attachments/1/never-uploaded.pdf' } },
+          },
+        ),
+      ).rejects.toThrow(new AppException('FILE_NOT_FOUND', HttpStatus.BAD_REQUEST));
 
       expect(mockApplicationRepository.saveForm).not.toHaveBeenCalled();
     });

--- a/src/application/usecase/application.service.spec.ts
+++ b/src/application/usecase/application.service.spec.ts
@@ -191,6 +191,32 @@ describe('ApplicationService', () => {
       expect(mockApplicationRepository.saveForm).not.toHaveBeenCalled();
     });
 
+    it('첨부 존재 확인이 실패하면 제출을 중단한다', async () => {
+      // Given: 스토리지 장애 등으로 존재 확인 자체가 실패. 확인 없이 통과시키면
+      // 검증이 무력화되므로 제출이 중단되어야 한다.
+      mockCohortRepository.findPartById.mockResolvedValue({
+        id: 1,
+        isOpen: true,
+        cohort: createCohortWindow(),
+        applicationSchema: {},
+      });
+      mockApplicationRepository.findFormByUserAndPart.mockResolvedValue(null);
+      mockStorageService.fileExists.mockRejectedValue(
+        new AppException('STORAGE_NOT_CONFIGURED', HttpStatus.SERVICE_UNAVAILABLE),
+      );
+
+      // When & Then
+      await expect(
+        applicationService.submitForm(
+          { userId: 1, email: 'user@example.com' },
+          { ...baseCommand, answers: { portfolio: { path: 'applications/attachments/1/a.pdf' } } },
+        ),
+      ).rejects.toThrow(AppException);
+
+      expect(mockApplicationRepository.saveForm).not.toHaveBeenCalled();
+      expect(mockEventEmitter.emit).not.toHaveBeenCalled();
+    });
+
     it('이미 제출된 지원서가 있으면 예외를 던진다', async () => {
       mockCohortRepository.findPartById.mockResolvedValue({
         id: 1,

--- a/src/application/usecase/application.service.ts
+++ b/src/application/usecase/application.service.ts
@@ -94,6 +94,7 @@ export class ApplicationService {
       userId,
       answers: command.answers,
     });
+    await this.applicationAttachmentService.assertAttachmentsExist({ answers: command.answers });
     this.applicationAnswerValidator.validate({
       answers: command.answers,
       schema: cohortPart.applicationSchema,

--- a/src/application/usecase/pii-purge.service.ts
+++ b/src/application/usecase/pii-purge.service.ts
@@ -7,8 +7,15 @@ import { ApplicationRepository } from '../domain/application.repository';
 /** GCS 목록 조회 페이지 크기. */
 const ATTACHMENT_SCAN_PAGE_SIZE = 100;
 
-/** 목록이 비정상적으로 길어질 때 한 회차를 끊는 상한(페이지 수). */
-const ATTACHMENT_SCAN_MAX_PAGES = 500;
+/**
+ * 폭주 방지용 절대 상한(페이지 수). 1,000만 객체에 해당한다.
+ *
+ * 중간에 끊고 다음 회차에 이어가는 방식은 쓰지 않는다. 커서를 보존할 저장소가
+ * 없어 다음 실행이 다시 첫 페이지부터 시작하는데, 만료되지 않은 객체가 앞쪽에
+ * 상한만큼 쌓이면 그 뒤의 만료 첨부는 영원히 파기되지 않기 때문이다.
+ * 목록은 유한하므로 nextCursor 가 없을 때까지 끝까지 훑는 것이 안전하다.
+ */
+const ATTACHMENT_SCAN_MAX_PAGES = 100_000;
 
 export type PiiPurgeResult = {
   purgedCount: number;
@@ -91,8 +98,11 @@ export class PiiPurgeService {
 
     const truncated = Boolean(cursor);
     if (truncated) {
-      this.logger.warn(
-        `첨부 파기 스캔이 ${ATTACHMENT_SCAN_MAX_PAGES}페이지 상한에 걸려 중단되었습니다. 남은 대상은 다음 회차에 처리됩니다.`,
+      // 여기 도달하면 목록이 상한을 넘겼다는 뜻이고, 다음 회차도 첫 페이지부터
+      // 다시 시작하므로 뒤쪽 만료 첨부가 파기되지 못한다. 알람이 필요한 상황이다.
+      this.logger.error(
+        `첨부 파기 스캔이 ${ATTACHMENT_SCAN_MAX_PAGES}페이지 상한에 도달했습니다. ` +
+          `상한 이후 구간은 파기되지 않으므로 보관 정책 점검이 필요합니다.`,
       );
     }
 

--- a/src/application/usecase/pii-purge.service.ts
+++ b/src/application/usecase/pii-purge.service.ts
@@ -33,6 +33,15 @@ export type AttachmentPurgeResult = {
 export class PiiPurgeService {
   private readonly logger = new Logger(PiiPurgeService.name);
 
+  /**
+   * 상한에 걸려 중단된 지점. 다음 회차가 여기서 이어간다.
+   *
+   * 상한(1,000만 객체) 도달은 현실적으로 오지 않지만, 도달했을 때 매 회차가
+   * 첫 페이지부터 다시 시작하면 뒤 구간이 영구히 파기되지 않는다. 개인정보
+   * 파기는 실패가 조용히 누적되는 영역이라 진행 보장을 남겨둔다.
+   */
+  private pendingScanCursor: string | undefined;
+
   constructor(
     private readonly applicationRepository: ApplicationRepository,
     private readonly storageService: StorageService,
@@ -63,7 +72,8 @@ export class PiiPurgeService {
   }: {
     cutoffDate: Date;
   }): Promise<AttachmentPurgeResult> {
-    let cursor: string | undefined;
+    // 지난 회차가 상한에 걸렸다면 그 지점부터 이어간다.
+    let cursor = this.pendingScanCursor;
     let scanned = 0;
     let deleted = 0;
     let failed = 0;
@@ -97,12 +107,13 @@ export class PiiPurgeService {
     } while (cursor && pages < ATTACHMENT_SCAN_MAX_PAGES);
 
     const truncated = Boolean(cursor);
+    // 중단됐으면 다음 회차가 이어받고, 끝까지 갔으면 다시 처음부터 훑는다.
+    this.pendingScanCursor = cursor;
+
     if (truncated) {
-      // 여기 도달하면 목록이 상한을 넘겼다는 뜻이고, 다음 회차도 첫 페이지부터
-      // 다시 시작하므로 뒤쪽 만료 첨부가 파기되지 못한다. 알람이 필요한 상황이다.
       this.logger.error(
         `첨부 파기 스캔이 ${ATTACHMENT_SCAN_MAX_PAGES}페이지 상한에 도달했습니다. ` +
-          `상한 이후 구간은 파기되지 않으므로 보관 정책 점검이 필요합니다.`,
+          `남은 구간은 다음 회차에 이어서 처리하지만, 보관 정책 점검이 필요합니다.`,
       );
     }
 

--- a/src/storage/application/storage.service.spec.ts
+++ b/src/storage/application/storage.service.spec.ts
@@ -384,6 +384,51 @@ describe('StorageService', () => {
     });
   });
 
+  describe('fileExists', () => {
+    it('카테고리 prefix 밖의 경로는 조회하지 않고 거부한다', async () => {
+      await expect(service.fileExists({ path: 'etc/secret.pdf' })).rejects.toThrow(AppException);
+
+      expect(mockGcsClient.exists).not.toHaveBeenCalled();
+    });
+
+    it('경로 탈출이 섞이면 조회하지 않고 거부한다', async () => {
+      await expect(
+        service.fileExists({ path: 'applications/attachments/12/../99/x.pdf' }),
+      ).rejects.toThrow(AppException);
+
+      expect(mockGcsClient.exists).not.toHaveBeenCalled();
+    });
+
+    it('스토리지가 비활성이면 거부한다', async () => {
+      mockGcsClient.isEnabled.mockReturnValue(false);
+
+      await expect(
+        service.fileExists({ path: 'applications/attachments/12/a.pdf' }),
+      ).rejects.toThrow(AppException);
+
+      expect(mockGcsClient.exists).not.toHaveBeenCalled();
+    });
+
+    it('GCS 조회 결과를 그대로 돌려준다', async () => {
+      mockGcsClient.exists.mockResolvedValue(true);
+
+      const result = await service.fileExists({ path: 'applications/attachments/12/a.pdf' });
+
+      expect(mockGcsClient.exists).toHaveBeenCalledWith({
+        path: 'applications/attachments/12/a.pdf',
+      });
+      expect(result).toBe(true);
+    });
+
+    it('객체가 없으면 false 를 돌려준다', async () => {
+      mockGcsClient.exists.mockResolvedValue(false);
+
+      await expect(
+        service.fileExists({ path: 'applications/attachments/12/none.pdf' }),
+      ).resolves.toBe(false);
+    });
+  });
+
   describe('download', () => {
     it('허용되지 않은 prefix면 INVALID_FILE_PATH(400)를 던진다', async () => {
       await expect(service.download({ path: 'evil/secret.txt' })).rejects.toThrow(

--- a/src/storage/application/storage.service.ts
+++ b/src/storage/application/storage.service.ts
@@ -165,6 +165,14 @@ export class StorageService {
     }
   }
 
+  /** 경로가 실제 객체를 가리키는지 확인한다. 존재하지 않으면 false. */
+  async fileExists({ path }: StoragePathInput): Promise<boolean> {
+    this.assertAllowedPath({ path });
+    this.assertStorageEnabled();
+
+    return await this.gcsClient.exists({ path });
+  }
+
   private resolveGcsPath({ basePath, subPath }: { basePath: string; subPath?: string }): string {
     if (subPath === undefined) {
       return basePath;


### PR DESCRIPTION
## 개요

PR #65 에 달린 이대리 자동 리뷰의 `MUST_FIX` 2건을 반영한다. 둘 다 #65 머지 이후 발견되어 후속으로 분리했다.

## 변경 이유

### 1. 존재하지 않는 첨부 경로로 필수 첨부 검증을 우회할 수 있었다

소유권 검사(`isOwnedAttachmentPath`)는 경로 접두어만 본다. 따라서 아래 요청이 그대로 통과했다.

```jsonc
// 업로드를 한 번도 하지 않은 상태
{ "answers": { "portfolio": { "path": "applications/attachments/{내userId}/aaa.pdf" } } }
```

- 소유권 검사 통과 — 본인 prefix 로 시작하므로
- 필수 응답 검사 통과 — `path` 문자열이 비어있지 않으므로

결과적으로 **파일 없이 "포트폴리오 필수" 파트에 지원이 완료**되어, 포트폴리오를 필수로 받겠다는 기획 목적이 무력화되고 심사자는 열리지 않는 파일을 받는다.

### 2. 파기 스캔이 중단 지점부터 이어지지 않았다

`ATTACHMENT_SCAN_MAX_PAGES = 500` 상한에 걸리면 커서를 버렸고, 다음 회차는 다시 첫 페이지부터 시작했다. 만료되지 않은 객체가 앞쪽에 상한만큼(5만 개) 쌓이면 **그 뒤 구간의 만료 첨부는 영원히 파기되지 않는다.** #65 에서 제가 무한 루프 방지로 넣은 상한이 만든 결함이다.

## 주요 변경 사항

| 파일 | 변경 |
|---|---|
| `storage.service.ts` | `fileExists()` 공개 — 경로 검증·스토리지 가용성 확인 후 존재 조회 |
| `application-attachment.service.ts` | `assertAttachmentsExist()` 추가 |
| `application.service.ts` | 최종 제출 시 존재 검증 호출 (임시저장 제외) |
| `pii-purge.service.ts` | 상한을 폭주 방지용으로만 남기고 목록 끝까지 순회. 상한 도달 시 `error` 로그 |

임시저장에는 존재 검증을 적용하지 않았다. 작성 중 첨부를 교체하는 흐름을 막을 이유가 없고, 최종 제출에서 걸러지면 충분하다.

## 아키텍처 영향

- 도메인 분리: 변경 없음
- 레이어 변경: 없음 (`StorageService` 에 공개 메서드 1개 추가)
- 의존 방향: 변경 없음
- 트랜잭션 경계: 변경 없음. 존재 확인은 제출 트랜잭션 안에서 수행되며 외부 I/O 가 추가된다(첨부 개수만큼, 병렬)

## 테스트

- [x] 단위 테스트 — 38 suites / 369 tests 통과 (6개 추가)
- [x] 빌드 확인

추가한 회귀 케이스
- 지어낸 경로로 제출 시도 → `FILE_NOT_FOUND`
- 첨부 여러 개 중 하나만 없는 경우 → 거부
- 첨부가 없으면 스토리지 미조회
- 601페이지 목록을 끝까지 순회해 마지막 페이지의 만료분을 삭제

## 리뷰 포인트

1. **제출 시 외부 I/O 추가** — 첨부 개수만큼 GCS `exists` 호출이 트랜잭션 안에서 발생한다. 첨부가 보통 1개라 영향은 작다고 판단했으나, 트랜잭션 시간에 민감하다면 조정 의견 부탁한다.
2. **파기 스캔 상한 제거 방향** — 커서를 DB에 저장해 이어가는 방식이 정석이지만 상태 테이블이 필요하다. 목록이 유한하므로 끝까지 훑는 편을 택했다.

## 리스크 / 후속 작업

- 여전히 남은 것: 면접관 첨부 열람 경로 없음, 업로드 rate limit 부재, GCS 버킷 공개 설정 확인. (#65 참고)

## 관련 이슈

- #65 의 이대리 자동 리뷰 반영
