### PR TITLE
feat(infra): 운영 자동 DDL 제거 및 TypeORM 마이그레이션 체계 도입

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,11 @@ dist
 .git
 .github
 .omc
+.worktrees
+# 이미지 런타임에 쓰이지 않는 개발/CI 스크립트. 빌드 컨텍스트에서 뺀다.
+# 특히 여기에 .ts 가 들어오면 tsc 가 rootDir 을 넓혀 산출물이 dist/ 대신 dist/src/ 로 나오고,
+# CMD 의 node dist/main 과 마이그레이션 글롭이 동시에 어긋난다(로컬에 그런 파일을 둔 사람이 있었다).
+scripts
 coverage
 *.log
 *.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,3 +121,45 @@ jobs:
             exit 1
           fi
           echo "정합성 확인: 엔티티와 마이그레이션이 일치합니다."
+
+      # 베이스라인은 운영 스키마에 적용됨으로 표시만 되어 있어, revert 하면 up() 이 만들지
+      # 않은 운영 테이블과 데이터를 지운다. down() 에 가드를 넣어 뒀는데 그 가드가 실제로
+      # 막는지, 그리고 막다가 스키마를 훼손하지 않는지를 확인한다.
+      # 가드가 조용히 사라지면 `migration:revert` 한 번이 전체 삭제가 된다.
+      - name: 베이스라인 롤백 차단 확인
+        run: |
+          set -uo pipefail
+          count_tables() {
+            psql "postgresql://ci:ci@localhost:5432/ci" -tAc \
+              "SELECT count(*) FROM information_schema.tables WHERE table_schema='public'"
+          }
+          BEFORE="$(count_tables)" || BEFORE=""
+          # 값이 없으면 아래 비교가 ''=''  로 통과해 검사가 통째로 무의미해진다.
+          case "$BEFORE" in
+            ''|*[!0-9]*) echo "::error::테이블 수를 세지 못했습니다(psql 부재 등): '$BEFORE'"; exit 1 ;;
+          esac
+          if [ "$BEFORE" -lt 2 ]; then
+            echo "::error::마이그레이션이 적용되지 않은 상태입니다(테이블 ${BEFORE}개). 검사 전제가 깨졌습니다."
+            exit 1
+          fi
+          if yarn migration:revert > revert.log 2>&1; then
+            echo "::error::베이스라인이 되돌려졌습니다. down() 가드가 동작하지 않습니다."
+            tail -20 revert.log
+            exit 1
+          fi
+          AFTER="$(count_tables)" || AFTER=""
+          case "$AFTER" in
+            ''|*[!0-9]*) echo "::error::롤백 후 테이블 수를 세지 못했습니다: '$AFTER'"; exit 1 ;;
+          esac
+          if [ "$BEFORE" != "$AFTER" ]; then
+            echo "::error::롤백은 실패했지만 스키마가 변했습니다 (${BEFORE} -> ${AFTER}개)."
+            exit 1
+          fi
+          # 실패 사유가 가드인지 확인한다. 다른 이유(연결 실패 등)로 실패한 것을
+          # 통과로 세면 검사 자체가 거짓말이 된다.
+          if ! grep -q '베이스라인 마이그레이션은 되돌릴 수 없습니다' revert.log; then
+            echo "::error::가드가 아닌 다른 이유로 실패했습니다."
+            tail -20 revert.log
+            exit 1
+          fi
+          echo "롤백 차단 확인: 테이블 ${AFTER}개 유지, 기록도 그대로."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,66 @@ jobs:
           push: false
           tags: ${{ steps.image.outputs.tag }}
           cache-from: type=registry,ref=${{ steps.image.outputs.latest }}
+
+  # 운영은 DB_SYNCHRONIZE=false 라 엔티티를 고쳐도 마이그레이션이 없으면 스키마가 바뀌지 않는다.
+  # 그 누락은 배포가 성공한 뒤 런타임 쿼리에서야 드러나므로, 머지 전에 여기서 잡는다.
+  migration-drift:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: ci
+          POSTGRES_PASSWORD: ci
+          POSTGRES_DB: ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U ci"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DB_HOST: localhost
+      DB_PORT: 5432
+      DB_USERNAME: ci
+      DB_PASSWORD: ci
+      DB_NAME: ci
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      # 빈 DB 에 전부 적용해 본다. 마이그레이션이 맨바닥에서 실행되는지도 함께 검증된다
+      # (운영 DB 를 복원하는 재해 복구 경로가 실제로 동작하는지에 대한 답이기도 하다).
+      - name: 마이그레이션 적용
+        run: yarn migration:run
+
+      # 적용된 스키마와 엔티티를 비교한다. 차이가 있으면 generate 가 파일을 만들고,
+      # 없으면 종료코드 1 과 함께 "No changes..." 를 출력한다. 즉 성공 종료가 곧 실패다.
+      - name: 엔티티-마이그레이션 정합성 검사
+        run: |
+          set -uo pipefail
+          if yarn migration:generate src/config/migrations/__DriftCheck > drift.log 2>&1; then
+            echo "::error::엔티티가 마이그레이션 없이 변경됐습니다. yarn migration:generate 로 마이그레이션을 만들어 커밋하세요."
+            echo "--- 누락된 변경 ---"
+            grep 'queryRunner.query' src/config/migrations/*__DriftCheck*.ts || cat drift.log
+            exit 1
+          fi
+          if ! grep -q 'No changes in database schema were found' drift.log; then
+            echo "::error::정합성 검사를 수행하지 못했습니다(연결 실패 등). 통과로 처리하지 않습니다."
+            cat drift.log
+            exit 1
+          fi
+          echo "정합성 확인: 엔티티와 마이그레이션이 일치합니다."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -319,6 +319,10 @@ jobs:
             printf 'DB_USERNAME=%s\n' "$DB_USERNAME" >> "$ENV_TMP"
             printf 'DB_PASSWORD=%s\n' "$DB_PASSWORD" >> "$ENV_TMP"
             printf 'DB_NAME=%s\n'     "$DB_NAME"     >> "$ENV_TMP"
+            # 운영에서 자동 DDL 을 끈다. 엔티티만 고치면 부팅할 때 스키마가 따라 바뀌던 동작이
+            # 사라지고, 스키마 변경 경로는 src/config/migrations 의 마이그레이션 하나만 남는다.
+            # 앱은 이 값이 false 일 때 부팅 중 미적용 마이그레이션을 실행한다(migrationsRun).
+            printf 'DB_SYNCHRONIZE=%s\n' "false"     >> "$ENV_TMP"
             printf 'APP_IMAGE=%s\n'   "$APP_IMAGE"   >> "$ENV_TMP"
             # APP_VERSION 은 여기에 쓰지 않는다.
             # env_file 은 이미지 ENV 를 덮어쓰므로, 여기에 쓰면 우리가 써넣은 값을 우리가 되읽어
@@ -382,6 +386,14 @@ jobs:
               rm -f "$ENV_TMP"
               exit 1
             fi
+            # 이 줄이 빠지면 앱이 기본값(true)으로 부팅해 운영 DB 에 자동 DDL 이 되살아난다.
+            # 조용히 되살아나는 종류라 배포 로그로는 알아챌 수 없으므로 여기서 막는다.
+            if ! grep -q '^DB_SYNCHRONIZE=false$' "$ENV_TMP"; then
+              echo "ERROR: .env.production 에 DB_SYNCHRONIZE=false 가 없습니다."
+              echo "       이대로 두면 운영에서 엔티티 기준 자동 DDL 이 다시 실행됩니다."
+              rm -f "$ENV_TMP"
+              exit 1
+            fi
             # 미래에 누가 APP_VERSION 을 다시 넣으면 버전 검증이 통째로 무력화된다. 기계적으로 막는다.
             if grep -q '^APP_VERSION=' "$ENV_TMP"; then
               echo "ERROR: .env.production 에 APP_VERSION 이 있으면 버전 검증이 무력화됩니다."
@@ -396,7 +408,9 @@ jobs:
             sudo APP_ENV_FILE=.env.production docker compose --env-file .env.production up -d
 
             echo "==> [7/8] 헬스체크 + 버전 검증"
-            # postgres 재생성 + 자동 DDL 이 겹치는 첫 배포는 평소보다 느리다. 3분까지 기다린다.
+            # 미적용 마이그레이션이 있으면 부팅 중에 실행되므로 첫 배포는 평소보다 느리다. 3분까지 기다린다.
+            # 마이그레이션이 실패하면 앱이 부팅하지 못해 이 루프가 타임아웃되고 배포가 실패한다.
+            # 스키마 문제를 조용히 넘기지 않는 것이 이 구조의 목적이다.
             for i in $(seq 1 36); do
               if curl -sf "${BASE}/api/v1/health" > /dev/null 2>&1; then
                 echo "헬스체크 통과 (${i}회차)"

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -48,8 +48,9 @@ class EnvironmentVariables {
   @IsOptional()
   APP_VERSION: string = 'unknown';
 
-  // 운영에서 자동 DDL(synchronize) 을 끄기 위한 스위치.
-  // 마이그레이션 체계가 갖춰지기 전까지 기본값은 기존 동작(true) 을 유지한다.
+  // 운영에서 자동 DDL(synchronize) 을 끄기 위한 스위치. false 면 마이그레이션이 대신 돈다.
+  // 운영은 deploy.yml 이 .env.production 에 false 를 써 넣는다.
+  // 기본값이 true 인 것은 로컬 개발 편의를 위해서다(빈 DB 에 엔티티만으로 바로 붙는다).
   // 환경변수는 항상 문자열로 들어오므로 boolean 대신 명시적 문자열로 검증한다.
   // (boolean 으로 선언하면 enableImplicitConversion 이 'false' 를 true 로 뒤집는다)
   // 빈 문자열이 들어오면 @IsIn 이 실패해 앱이 부팅조차 못 하므로 미설정과 동일하게 취급한다.

--- a/src/config/migrations/1786880782440-Baseline.ts
+++ b/src/config/migrations/1786880782440-Baseline.ts
@@ -1,0 +1,375 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Baseline1786880782440 implements MigrationInterface {
+  name = 'Baseline1786880782440';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."user_roles_role_enum" AS ENUM('계정관리', '운영자', '면접자', '면접관')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "user_roles" ("id" SERIAL NOT NULL, "uuid" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP, "userId" integer NOT NULL, "role" "public"."user_roles_role_enum" array NOT NULL DEFAULT '{}', CONSTRAINT "UQ_d60df0e0fc8413e406f54da4df8" UNIQUE ("uuid"), CONSTRAINT "PK_8acd5cf26ebd158416f477de799" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_cf223fcbddb2d25c4a1dee61fd" ON "user_roles" ("deletedAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_e4cc3c68edf1bd70f2afb84664" ON "user_roles" ("createdAt", "id") `,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "uq_user_roles_user_active" ON "user_roles" ("userId") WHERE "deletedAt" IS NULL`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "users" ("id" SERIAL NOT NULL, "uuid" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP, "email" character varying NOT NULL, "firstName" character varying NOT NULL, "lastName" character varying, "sub" character varying NOT NULL, "refreshToken" character varying, "googleAccessToken" character varying, "googleRefreshToken" character varying, CONSTRAINT "UQ_951b8f1dfc94ac1d0301a14b7e1" UNIQUE ("uuid"), CONSTRAINT "UQ_97672ac88f789774dd47f7c8be3" UNIQUE ("email"), CONSTRAINT "UQ_2ca016813ffcce3392b3eb8ed0c" UNIQUE ("sub"), CONSTRAINT "PK_a3ffb1c0c8416b9fc6f907b7433" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_2a32f641edba1d0f973c19cc94" ON "users" ("deletedAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_603379383366b71239acc25e26" ON "users" ("createdAt", "id") `,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."cohort_parts_partname_enum" AS ENUM('PM', 'PD', 'BE', 'FE', 'IOS', 'AND')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "cohort_parts" ("id" SERIAL NOT NULL, "uuid" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP, "partName" "public"."cohort_parts_partname_enum" NOT NULL, "isOpen" boolean NOT NULL DEFAULT false, "applicationSchema" jsonb NOT NULL, "cohortId" integer NOT NULL, CONSTRAINT "UQ_21345fcfd769e96ccd8a569078a" UNIQUE ("uuid"), CONSTRAINT "PK_8e5118e539134e7f87486b544c0" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_73ab5d5fa4ed7bffa22b1c263a" ON "cohort_parts" ("deletedAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_0669fe31f04d3589ef62fe908c" ON "cohort_parts" ("createdAt", "id") `,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."cohorts_status_enum" AS ENUM('UPCOMING', 'RECRUITING', 'ACTIVE', 'CLOSED')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "cohorts" ("id" SERIAL NOT NULL, "uuid" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP, "name" character varying NOT NULL, "recruitStartAt" TIMESTAMP NOT NULL, "recruitEndAt" TIMESTAMP NOT NULL, "process" jsonb, "curriculum" jsonb, "applicationForm" jsonb, "status" "public"."cohorts_status_enum" NOT NULL DEFAULT 'UPCOMING', CONSTRAINT "UQ_ca6284247654b3b61dfc73106da" UNIQUE ("uuid"), CONSTRAINT "PK_fd38f76b135e907b834fda1e752" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_d927f1723f57884ab698875577" ON "cohorts" ("deletedAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_ac828c6222cbdb1368634f1e78" ON "cohorts" ("createdAt", "id") `,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "project_members" ("id" SERIAL NOT NULL, "name" character varying NOT NULL, "part" character varying NOT NULL, "projectId" integer NOT NULL, CONSTRAINT "PK_0b2f46f804be4aea9234c78bcc9" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."projects_platforms_enum" AS ENUM('IOS', 'AOS', 'WEB')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "projects" ("id" SERIAL NOT NULL, "uuid" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP, "cohortId" integer NOT NULL, "platforms" "public"."projects_platforms_enum" array NOT NULL, "name" character varying NOT NULL, "description" text NOT NULL, "thumbnailUrl" character varying, "pdfUrl" character varying, CONSTRAINT "UQ_fc9f1e64d4626f18beff534a9f3" UNIQUE ("uuid"), CONSTRAINT "PK_6271df0a7aed1d6c0691ce6ac50" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_c1b301d927158ef7015f7f7123" ON "projects" ("deletedAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_f698c0dc133d86e4fd5c8d4883" ON "projects" ("createdAt", "id") `,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."notification_campaigns_status_enum" AS ENUM('SCHEDULED', 'RUNNING', 'DONE', 'PAUSED', 'FAILED')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "notification_campaigns" ("id" SERIAL NOT NULL, "uuid" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP, "cohortId" integer NOT NULL, "subject" character varying NOT NULL, "html" text NOT NULL, "text" text NOT NULL, "scheduledAt" TIMESTAMP WITH TIME ZONE NOT NULL, "sentAt" TIMESTAMP WITH TIME ZONE, "status" "public"."notification_campaigns_status_enum" NOT NULL DEFAULT 'SCHEDULED', "result" jsonb, CONSTRAINT "UQ_cec17513296b54b6dcd62644fe1" UNIQUE ("uuid"), CONSTRAINT "PK_6bd3e0649c6f3fb8caa63dd39ea" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_29054742392c5ca9cd034b0a3e" ON "notification_campaigns" ("deletedAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_163b34f7a92a1a1b25c2890d24" ON "notification_campaigns" ("createdAt", "id") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_3e5ab891d879faf0a4cc3fe285" ON "notification_campaigns" ("status", "scheduledAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_aec76505497c488d1e6cc6e78a" ON "notification_campaigns" ("cohortId", "status") `,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."email_logs_status_enum" AS ENUM('SUCCESS', 'FAILED')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "email_logs" ("id" SERIAL NOT NULL, "uuid" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP, "recipientEmail" character varying NOT NULL, "subject" character varying NOT NULL, "status" "public"."email_logs_status_enum" NOT NULL, "errorMessage" text, CONSTRAINT "UQ_ffc157050e4aa489a7757c42233" UNIQUE ("uuid"), CONSTRAINT "PK_999382218924e953a790d340571" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_9cf65fb4764d15ddcb72da5307" ON "email_logs" ("deletedAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_c73a819e23f1316b2a0463ec23" ON "email_logs" ("createdAt", "id") `,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "general_early_notifications" ("id" SERIAL NOT NULL, "uuid" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP, "email" character varying NOT NULL, "promotedAt" TIMESTAMP WITH TIME ZONE, "promotedToCohortId" integer, CONSTRAINT "UQ_e6be95370f3f227ac6ccd2cb661" UNIQUE ("uuid"), CONSTRAINT "PK_858b990bf1ec3c3e35b1a930003" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_d83feb21dd749a093a53ee0501" ON "general_early_notifications" ("deletedAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_b546a2af85b291f1263e66ceaa" ON "general_early_notifications" ("createdAt", "id") `,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "uq_general_early_notifications_active_pending_email" ON "general_early_notifications" ("email") WHERE "deletedAt" IS NULL AND "promotedAt" IS NULL`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "early_notifications" ("id" SERIAL NOT NULL, "uuid" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP, "cohortId" integer NOT NULL, "email" character varying NOT NULL, "notifiedAt" TIMESTAMP WITH TIME ZONE, CONSTRAINT "UQ_407e86a41983063f9c43a778612" UNIQUE ("uuid"), CONSTRAINT "PK_31d354ddaf99f0de6c1eb656250" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_17f024503b13f2c8b65d2949e8" ON "early_notifications" ("deletedAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_aff9b1a748744e636777cfa1c6" ON "early_notifications" ("createdAt", "id") `,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "uq_early_notifications_active_cohort_email" ON "early_notifications" ("cohortId", "email") WHERE "deletedAt" IS NULL`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "interview_reservations" ("id" SERIAL NOT NULL, "uuid" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP, "slotId" integer NOT NULL, "applicationFormId" integer NOT NULL, "calendarEventId" character varying, CONSTRAINT "UQ_5a98b0bb2b0d85ff20ba0345dbb" UNIQUE ("uuid"), CONSTRAINT "PK_6da00e094b846aa569ade12ec5f" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_fb5688ee35fcb7e412e53e04d9" ON "interview_reservations" ("deletedAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_ceb7375353f06e2986e7f61b46" ON "interview_reservations" ("createdAt", "id") `,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "uq_interview_reservations_slot_application_active" ON "interview_reservations" ("slotId", "applicationFormId") WHERE "deletedAt" IS NULL`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "uq_interview_reservations_application_active" ON "interview_reservations" ("applicationFormId") WHERE "deletedAt" IS NULL`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "interview_slots" ("id" SERIAL NOT NULL, "uuid" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP, "cohortId" integer NOT NULL, "cohortPartId" integer NOT NULL, "startAt" TIMESTAMP NOT NULL, "endAt" TIMESTAMP NOT NULL, "capacity" integer NOT NULL DEFAULT '1', "location" character varying, "description" text, CONSTRAINT "UQ_2039965ad93dfcaf22da8af22dc" UNIQUE ("uuid"), CONSTRAINT "PK_ae5d7926afb757f3dd0452e9eeb" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_74a6e6b17f74ca7f31104636f2" ON "interview_slots" ("deletedAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_e2b4a6eb20149e32f8b72703e9" ON "interview_slots" ("createdAt", "id") `,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "discord_links" ("id" SERIAL NOT NULL, "uuid" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP, "applicationFormId" integer NOT NULL, "discordUserId" character varying NOT NULL, "discordUsername" character varying NOT NULL, "rolesAssigned" jsonb NOT NULL DEFAULT '[]', "invitedAt" TIMESTAMP, CONSTRAINT "UQ_7506ce9f3575e0800d50acf1791" UNIQUE ("uuid"), CONSTRAINT "PK_55be1809ef7f84527b5ec444a75" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_b4803bd31ebd99e94239cf05fe" ON "discord_links" ("deletedAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_266e1b3009f5655dabaac6062e" ON "discord_links" ("createdAt", "id") `,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "uq_discord_links_discord_user_active" ON "discord_links" ("discordUserId") WHERE "deletedAt" IS NULL`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "uq_discord_links_application_active" ON "discord_links" ("applicationFormId") WHERE "deletedAt" IS NULL`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "blog_posts" ("id" SERIAL NOT NULL, "uuid" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP, "title" character varying NOT NULL, "excerpt" text NOT NULL, "thumbnail" character varying, "externalUrl" character varying NOT NULL, CONSTRAINT "UQ_f2d8f1b6b22a453dc32d4546b0c" UNIQUE ("uuid"), CONSTRAINT "PK_dd2add25eac93daefc93da9d387" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_c65a47b4e08a2fefcabdb6f655" ON "blog_posts" ("deletedAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_ac4ab6c58c14de5a96e2a7f79d" ON "blog_posts" ("createdAt", "id") `,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."audit_logs_action_enum" AS ENUM('CREATE', 'UPDATE', 'STATUS_CHANGE', 'DELETE')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "audit_logs" ("id" SERIAL NOT NULL, "uuid" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP, "entityType" character varying NOT NULL, "entityId" integer NOT NULL, "action" "public"."audit_logs_action_enum" NOT NULL, "field" character varying, "fromValue" character varying, "toValue" character varying, "adminId" integer NOT NULL, CONSTRAINT "UQ_809d3a75a6776bfecf54c8aab35" UNIQUE ("uuid"), CONSTRAINT "PK_1bb179d048bbc581caa3b013439" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_837e716a5ff0fef88e3947c3df" ON "audit_logs" ("deletedAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_b264140e1eb1308c5a58bd972d" ON "audit_logs" ("createdAt", "id") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_13c69424c440a0e765053feb4b" ON "audit_logs" ("entityType", "entityId") `,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."application_forms_status_enum" AS ENUM('서류심사대기', '서류합격', '서류불합격', '최종합격', '최종불합격', '활동중', '활동완료', '활동중단')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "application_forms" ("id" SERIAL NOT NULL, "uuid" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP, "userId" integer NOT NULL, "cohortPartId" integer NOT NULL, "status" "public"."application_forms_status_enum" NOT NULL DEFAULT '서류심사대기', "applicantName" character varying NOT NULL, "applicantPhone" character varying NOT NULL, "applicantBirthDate" character varying, "applicantRegion" character varying, "answers" jsonb NOT NULL, "privacyAgreedAt" TIMESTAMP NOT NULL, "announcedAt" TIMESTAMP, "activityEndedAt" TIMESTAMP, "updatedByAdminId" integer, CONSTRAINT "UQ_80082bd8f4f2ec88db2e5f8e2e1" UNIQUE ("uuid"), CONSTRAINT "PK_0b74653a69d3de79ed8040c646a" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_20be170dfba3c0e1658d06dee5" ON "application_forms" ("deletedAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_7bc60aea9496fff440339166eb" ON "application_forms" ("createdAt", "id") `,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "uq_application_forms_user_part_active" ON "application_forms" ("userId", "cohortPartId") WHERE "deletedAt" IS NULL`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "application_drafts" ("id" SERIAL NOT NULL, "uuid" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP, "userId" integer NOT NULL, "cohortPartId" integer NOT NULL, "answers" jsonb NOT NULL, CONSTRAINT "UQ_4e72814d6f72c5417b28089f6e9" UNIQUE ("uuid"), CONSTRAINT "PK_84ad3f106f3e3fbbcbed285f31b" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_79980a886876d571f2f73b8f6e" ON "application_drafts" ("deletedAt") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_30ca22407dd8b51328ccfb79fd" ON "application_drafts" ("createdAt", "id") `,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "uq_application_drafts_user_part_active" ON "application_drafts" ("userId", "cohortPartId") WHERE "deletedAt" IS NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_roles" ADD CONSTRAINT "FK_472b25323af01488f1f66a06b67" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "cohort_parts" ADD CONSTRAINT "FK_d3708657c0857fe8399c89ef44b" FOREIGN KEY ("cohortId") REFERENCES "cohorts"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_members" ADD CONSTRAINT "FK_d19892d8f03928e5bfc7313780c" FOREIGN KEY ("projectId") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "projects" ADD CONSTRAINT "FK_4a92b8f3d250ef1f988e5756310" FOREIGN KEY ("cohortId") REFERENCES "cohorts"("id") ON DELETE RESTRICT ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notification_campaigns" ADD CONSTRAINT "FK_a7eb67ae06e8c08768e2c2846ee" FOREIGN KEY ("cohortId") REFERENCES "cohorts"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "general_early_notifications" ADD CONSTRAINT "FK_ce6f79915ad690db28b2cd1735b" FOREIGN KEY ("promotedToCohortId") REFERENCES "cohorts"("id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "early_notifications" ADD CONSTRAINT "FK_a7d043863de628f075674d4d682" FOREIGN KEY ("cohortId") REFERENCES "cohorts"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "interview_reservations" ADD CONSTRAINT "FK_5e46b39b00ca14d5639eeaea86c" FOREIGN KEY ("slotId") REFERENCES "interview_slots"("id") ON DELETE RESTRICT ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "interview_slots" ADD CONSTRAINT "FK_59bdc5d9ff707f14250c7c72a19" FOREIGN KEY ("cohortId") REFERENCES "cohorts"("id") ON DELETE RESTRICT ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "interview_slots" ADD CONSTRAINT "FK_46a37bfe410dddfdca67636da6e" FOREIGN KEY ("cohortPartId") REFERENCES "cohort_parts"("id") ON DELETE RESTRICT ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "application_forms" ADD CONSTRAINT "FK_888d2c204feb5a13c21dedc898b" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "application_forms" ADD CONSTRAINT "FK_2525898247af7f81d7ceb55de99" FOREIGN KEY ("cohortPartId") REFERENCES "cohort_parts"("id") ON DELETE RESTRICT ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "application_drafts" ADD CONSTRAINT "FK_2557b41bd8945f424a9be23d6e0" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "application_drafts" ADD CONSTRAINT "FK_cd88dcc52e907a4b9383f32b421" FOREIGN KEY ("cohortPartId") REFERENCES "cohort_parts"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "application_drafts" DROP CONSTRAINT "FK_cd88dcc52e907a4b9383f32b421"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "application_drafts" DROP CONSTRAINT "FK_2557b41bd8945f424a9be23d6e0"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "application_forms" DROP CONSTRAINT "FK_2525898247af7f81d7ceb55de99"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "application_forms" DROP CONSTRAINT "FK_888d2c204feb5a13c21dedc898b"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "interview_slots" DROP CONSTRAINT "FK_46a37bfe410dddfdca67636da6e"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "interview_slots" DROP CONSTRAINT "FK_59bdc5d9ff707f14250c7c72a19"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "interview_reservations" DROP CONSTRAINT "FK_5e46b39b00ca14d5639eeaea86c"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "early_notifications" DROP CONSTRAINT "FK_a7d043863de628f075674d4d682"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "general_early_notifications" DROP CONSTRAINT "FK_ce6f79915ad690db28b2cd1735b"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "notification_campaigns" DROP CONSTRAINT "FK_a7eb67ae06e8c08768e2c2846ee"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "projects" DROP CONSTRAINT "FK_4a92b8f3d250ef1f988e5756310"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "project_members" DROP CONSTRAINT "FK_d19892d8f03928e5bfc7313780c"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "cohort_parts" DROP CONSTRAINT "FK_d3708657c0857fe8399c89ef44b"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user_roles" DROP CONSTRAINT "FK_472b25323af01488f1f66a06b67"`,
+    );
+    await queryRunner.query(`DROP INDEX "public"."uq_application_drafts_user_part_active"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_30ca22407dd8b51328ccfb79fd"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_79980a886876d571f2f73b8f6e"`);
+    await queryRunner.query(`DROP TABLE "application_drafts"`);
+    await queryRunner.query(`DROP INDEX "public"."uq_application_forms_user_part_active"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_7bc60aea9496fff440339166eb"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_20be170dfba3c0e1658d06dee5"`);
+    await queryRunner.query(`DROP TABLE "application_forms"`);
+    await queryRunner.query(`DROP TYPE "public"."application_forms_status_enum"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_13c69424c440a0e765053feb4b"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_b264140e1eb1308c5a58bd972d"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_837e716a5ff0fef88e3947c3df"`);
+    await queryRunner.query(`DROP TABLE "audit_logs"`);
+    await queryRunner.query(`DROP TYPE "public"."audit_logs_action_enum"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_ac4ab6c58c14de5a96e2a7f79d"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_c65a47b4e08a2fefcabdb6f655"`);
+    await queryRunner.query(`DROP TABLE "blog_posts"`);
+    await queryRunner.query(`DROP INDEX "public"."uq_discord_links_application_active"`);
+    await queryRunner.query(`DROP INDEX "public"."uq_discord_links_discord_user_active"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_266e1b3009f5655dabaac6062e"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_b4803bd31ebd99e94239cf05fe"`);
+    await queryRunner.query(`DROP TABLE "discord_links"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_e2b4a6eb20149e32f8b72703e9"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_74a6e6b17f74ca7f31104636f2"`);
+    await queryRunner.query(`DROP TABLE "interview_slots"`);
+    await queryRunner.query(`DROP INDEX "public"."uq_interview_reservations_application_active"`);
+    await queryRunner.query(
+      `DROP INDEX "public"."uq_interview_reservations_slot_application_active"`,
+    );
+    await queryRunner.query(`DROP INDEX "public"."IDX_ceb7375353f06e2986e7f61b46"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_fb5688ee35fcb7e412e53e04d9"`);
+    await queryRunner.query(`DROP TABLE "interview_reservations"`);
+    await queryRunner.query(`DROP INDEX "public"."uq_early_notifications_active_cohort_email"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_aff9b1a748744e636777cfa1c6"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_17f024503b13f2c8b65d2949e8"`);
+    await queryRunner.query(`DROP TABLE "early_notifications"`);
+    await queryRunner.query(
+      `DROP INDEX "public"."uq_general_early_notifications_active_pending_email"`,
+    );
+    await queryRunner.query(`DROP INDEX "public"."IDX_b546a2af85b291f1263e66ceaa"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_d83feb21dd749a093a53ee0501"`);
+    await queryRunner.query(`DROP TABLE "general_early_notifications"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_c73a819e23f1316b2a0463ec23"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_9cf65fb4764d15ddcb72da5307"`);
+    await queryRunner.query(`DROP TABLE "email_logs"`);
+    await queryRunner.query(`DROP TYPE "public"."email_logs_status_enum"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_aec76505497c488d1e6cc6e78a"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_3e5ab891d879faf0a4cc3fe285"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_163b34f7a92a1a1b25c2890d24"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_29054742392c5ca9cd034b0a3e"`);
+    await queryRunner.query(`DROP TABLE "notification_campaigns"`);
+    await queryRunner.query(`DROP TYPE "public"."notification_campaigns_status_enum"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_f698c0dc133d86e4fd5c8d4883"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_c1b301d927158ef7015f7f7123"`);
+    await queryRunner.query(`DROP TABLE "projects"`);
+    await queryRunner.query(`DROP TYPE "public"."projects_platforms_enum"`);
+    await queryRunner.query(`DROP TABLE "project_members"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_ac828c6222cbdb1368634f1e78"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_d927f1723f57884ab698875577"`);
+    await queryRunner.query(`DROP TABLE "cohorts"`);
+    await queryRunner.query(`DROP TYPE "public"."cohorts_status_enum"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_0669fe31f04d3589ef62fe908c"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_73ab5d5fa4ed7bffa22b1c263a"`);
+    await queryRunner.query(`DROP TABLE "cohort_parts"`);
+    await queryRunner.query(`DROP TYPE "public"."cohort_parts_partname_enum"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_603379383366b71239acc25e26"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_2a32f641edba1d0f973c19cc94"`);
+    await queryRunner.query(`DROP TABLE "users"`);
+    await queryRunner.query(`DROP INDEX "public"."uq_user_roles_user_active"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_e4cc3c68edf1bd70f2afb84664"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_cf223fcbddb2d25c4a1dee61fd"`);
+    await queryRunner.query(`DROP TABLE "user_roles"`);
+    await queryRunner.query(`DROP TYPE "public"."user_roles_role_enum"`);
+  }
+}

--- a/src/config/migrations/1786880782440-Baseline.ts
+++ b/src/config/migrations/1786880782440-Baseline.ts
@@ -255,121 +255,28 @@ export class Baseline1786880782440 implements MigrationInterface {
     );
   }
 
-  public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(
-      `ALTER TABLE "application_drafts" DROP CONSTRAINT "FK_cd88dcc52e907a4b9383f32b421"`,
+  // 되돌릴 수 없다. 의도적으로 막아 둔 것이다.
+  //
+  // 이 마이그레이션은 "빈 DB 에 스키마를 세우는 방법" 의 기록이지, 운영 스키마를
+  // 실제로 만든 주체가 아니다. 운영 테이블은 synchronize 가 수개월에 걸쳐 만들었고
+  // 이 마이그레이션은 적용됨으로 표시만 되어 있다.
+  //
+  // 따라서 생성된 down() 을 그대로 두면 revert 가 up() 이 만들지 않은 테이블 17개와
+  // 그 안의 운영 데이터를 지운다. 게다가 지금은 적용된 마이그레이션이 이것 하나뿐이라
+  // `migration:revert` 한 번이 곧 전체 삭제다 - 배포를 되돌리려는 사람이 가장 먼저
+  // 떠올릴 명령이 하필 가장 파괴적인 동작이 된다.
+  //
+  // 스키마를 정말로 비워야 한다면 의도를 드러내는 별도 수단을 쓴다(예: DROP SCHEMA).
+  // await 할 것이 없으므로 async 를 붙이지 않는다(@typescript-eslint/require-await).
+  // TypeORM 은 down() 의 반환값을 await 하므로 거부된 Promise 가 그대로 예외가 되고,
+  // 마이그레이션 트랜잭션은 롤백된다.
+  public down(): Promise<never> {
+    return Promise.reject(
+      new Error(
+        '베이스라인 마이그레이션은 되돌릴 수 없습니다. ' +
+          '이 마이그레이션은 기존 스키마에 적용됨으로 표시된 것이라 revert 는 ' +
+          'up() 이 만들지 않은 운영 테이블과 데이터를 삭제합니다.',
+      ),
     );
-    await queryRunner.query(
-      `ALTER TABLE "application_drafts" DROP CONSTRAINT "FK_2557b41bd8945f424a9be23d6e0"`,
-    );
-    await queryRunner.query(
-      `ALTER TABLE "application_forms" DROP CONSTRAINT "FK_2525898247af7f81d7ceb55de99"`,
-    );
-    await queryRunner.query(
-      `ALTER TABLE "application_forms" DROP CONSTRAINT "FK_888d2c204feb5a13c21dedc898b"`,
-    );
-    await queryRunner.query(
-      `ALTER TABLE "interview_slots" DROP CONSTRAINT "FK_46a37bfe410dddfdca67636da6e"`,
-    );
-    await queryRunner.query(
-      `ALTER TABLE "interview_slots" DROP CONSTRAINT "FK_59bdc5d9ff707f14250c7c72a19"`,
-    );
-    await queryRunner.query(
-      `ALTER TABLE "interview_reservations" DROP CONSTRAINT "FK_5e46b39b00ca14d5639eeaea86c"`,
-    );
-    await queryRunner.query(
-      `ALTER TABLE "early_notifications" DROP CONSTRAINT "FK_a7d043863de628f075674d4d682"`,
-    );
-    await queryRunner.query(
-      `ALTER TABLE "general_early_notifications" DROP CONSTRAINT "FK_ce6f79915ad690db28b2cd1735b"`,
-    );
-    await queryRunner.query(
-      `ALTER TABLE "notification_campaigns" DROP CONSTRAINT "FK_a7eb67ae06e8c08768e2c2846ee"`,
-    );
-    await queryRunner.query(
-      `ALTER TABLE "projects" DROP CONSTRAINT "FK_4a92b8f3d250ef1f988e5756310"`,
-    );
-    await queryRunner.query(
-      `ALTER TABLE "project_members" DROP CONSTRAINT "FK_d19892d8f03928e5bfc7313780c"`,
-    );
-    await queryRunner.query(
-      `ALTER TABLE "cohort_parts" DROP CONSTRAINT "FK_d3708657c0857fe8399c89ef44b"`,
-    );
-    await queryRunner.query(
-      `ALTER TABLE "user_roles" DROP CONSTRAINT "FK_472b25323af01488f1f66a06b67"`,
-    );
-    await queryRunner.query(`DROP INDEX "public"."uq_application_drafts_user_part_active"`);
-    await queryRunner.query(`DROP INDEX "public"."IDX_30ca22407dd8b51328ccfb79fd"`);
-    await queryRunner.query(`DROP INDEX "public"."IDX_79980a886876d571f2f73b8f6e"`);
-    await queryRunner.query(`DROP TABLE "application_drafts"`);
-    await queryRunner.query(`DROP INDEX "public"."uq_application_forms_user_part_active"`);
-    await queryRunner.query(`DROP INDEX "public"."IDX_7bc60aea9496fff440339166eb"`);
-    await queryRunner.query(`DROP INDEX "public"."IDX_20be170dfba3c0e1658d06dee5"`);
-    await queryRunner.query(`DROP TABLE "application_forms"`);
-    await queryRunner.query(`DROP TYPE "public"."application_forms_status_enum"`);
-    await queryRunner.query(`DROP INDEX "public"."IDX_13c69424c440a0e765053feb4b"`);
-    await queryRunner.query(`DROP INDEX "public"."IDX_b264140e1eb1308c5a58bd972d"`);
-    await queryRunner.query(`DROP INDEX "public"."IDX_837e716a5ff0fef88e3947c3df"`);
-    await queryRunner.query(`DROP TABLE "audit_logs"`);
-    await queryRunner.query(`DROP TYPE "public"."audit_logs_action_enum"`);
-    await queryRunner.query(`DROP INDEX "public"."IDX_ac4ab6c58c14de5a96e2a7f79d"`);
-    await queryRunner.query(`DROP INDEX "public"."IDX_c65a47b4e08a2fefcabdb6f655"`);
-    await queryRunner.query(`DROP TABLE "blog_posts"`);
-    await queryRunner.query(`DROP INDEX "public"."uq_discord_links_application_active"`);
-    await queryRunner.query(`DROP INDEX "public"."uq_discord_links_discord_user_active"`);
-    await queryRunner.query(`DROP INDEX "public"."IDX_266e1b3009f5655dabaac6062e"`);
-    await queryRunner.query(`DROP INDEX "public"."IDX_b4803bd31ebd99e94239cf05fe"`);
-    await queryRunner.query(`DROP TABLE "discord_links"`);
-    await queryRunner.query(`DROP INDEX "public"."IDX_e2b4a6eb20149e32f8b72703e9"`);
-    await queryRunner.query(`DROP INDEX "public"."IDX_74a6e6b17f74ca7f31104636f2"`);
-    await queryRunner.query(`DROP TABLE "interview_slots"`);
-    await queryRunner.query(`DROP INDEX "public"."uq_interview_reservations_application_active"`);
-    await queryRunner.query(
-      `DROP INDEX "public"."uq_interview_reservations_slot_application_active"`,
-    );
-    await queryRunner.query(`DROP INDEX "public"."IDX_ceb7375353f06e2986e7f61b46"`);
-    await queryRunner.query(`DROP INDEX "public"."IDX_fb5688ee35fcb7e412e53e04d9"`);
-    await queryRunner.query(`DROP TABLE "interview_reservations"`);
-    await queryRunner.query(`DROP INDEX "public"."uq_early_notifications_active_cohort_email"`);
-    await queryRunner.query(`DROP INDEX "public"."IDX_aff9b1a748744e636777cfa1c6"`);
-    await queryRunner.query(`DROP INDEX "public"."IDX_17f024503b13f2c8b65d2949e8"`);
-    await queryRunner.query(`DROP TABLE "early_notifications"`);
-    await queryRunner.query(
-      `DROP INDEX "public"."uq_general_early_notifications_active_pending_email"`,
-    );
-    await queryRunner.query(`DROP INDEX "public"."IDX_b546a2af85b291f1263e66ceaa"`);
-    await queryRunner.query(`DROP INDEX "public"."IDX_d83feb21dd749a093a53ee0501"`);
-    await queryRunner.query(`DROP TABLE "general_early_notifications"`);
-    await queryRunner.query(`DROP INDEX "public"."IDX_c73a819e23f1316b2a0463ec23"`);
-    await queryRunner.query(`DROP INDEX "public"."IDX_9cf65fb4764d15ddcb72da5307"`);
-    await queryRunner.query(`DROP TABLE "email_logs"`);
-    await queryRunner.query(`DROP TYPE "public"."email_logs_status_enum"`);
-    await queryRunner.query(`DROP INDEX "public"."IDX_aec76505497c488d1e6cc6e78a"`);
-    await queryRunner.query(`DROP INDEX "public"."IDX_3e5ab891d879faf0a4cc3fe285"`);
-    await queryRunner.query(`DROP INDEX "public"."IDX_163b34f7a92a1a1b25c2890d24"`);
-    await queryRunner.query(`DROP INDEX "public"."IDX_29054742392c5ca9cd034b0a3e"`);
-    await queryRunner.query(`DROP TABLE "notification_campaigns"`);
-    await queryRunner.query(`DROP TYPE "public"."notification_campaigns_status_enum"`);
-    await queryRunner.query(`DROP INDEX "public"."IDX_f698c0dc133d86e4fd5c8d4883"`);
-    await queryRunner.query(`DROP INDEX "public"."IDX_c1b301d927158ef7015f7f7123"`);
-    await queryRunner.query(`DROP TABLE "projects"`);
-    await queryRunner.query(`DROP TYPE "public"."projects_platforms_enum"`);
-    await queryRunner.query(`DROP TABLE "project_members"`);
-    await queryRunner.query(`DROP INDEX "public"."IDX_ac828c6222cbdb1368634f1e78"`);
-    await queryRunner.query(`DROP INDEX "public"."IDX_d927f1723f57884ab698875577"`);
-    await queryRunner.query(`DROP TABLE "cohorts"`);
-    await queryRunner.query(`DROP TYPE "public"."cohorts_status_enum"`);
-    await queryRunner.query(`DROP INDEX "public"."IDX_0669fe31f04d3589ef62fe908c"`);
-    await queryRunner.query(`DROP INDEX "public"."IDX_73ab5d5fa4ed7bffa22b1c263a"`);
-    await queryRunner.query(`DROP TABLE "cohort_parts"`);
-    await queryRunner.query(`DROP TYPE "public"."cohort_parts_partname_enum"`);
-    await queryRunner.query(`DROP INDEX "public"."IDX_603379383366b71239acc25e26"`);
-    await queryRunner.query(`DROP INDEX "public"."IDX_2a32f641edba1d0f973c19cc94"`);
-    await queryRunner.query(`DROP TABLE "users"`);
-    await queryRunner.query(`DROP INDEX "public"."uq_user_roles_user_active"`);
-    await queryRunner.query(`DROP INDEX "public"."IDX_e4cc3c68edf1bd70f2afb84664"`);
-    await queryRunner.query(`DROP INDEX "public"."IDX_cf223fcbddb2d25c4a1dee61fd"`);
-    await queryRunner.query(`DROP TABLE "user_roles"`);
-    await queryRunner.query(`DROP TYPE "public"."user_roles_role_enum"`);
   }
 }

--- a/src/config/typeorm.config.ts
+++ b/src/config/typeorm.config.ts
@@ -1,11 +1,12 @@
+import { join } from 'node:path';
+
 import { ConfigService } from '@nestjs/config';
 import { TypeOrmModuleOptions } from '@nestjs/typeorm';
 import { DataSourceOptions } from 'typeorm';
 
 export const createTypeOrmModuleOptions = (config: ConfigService): TypeOrmModuleOptions => {
   // synchronize 는 부팅할 때마다 엔티티 정의에 맞춰 DDL 을 자동 실행한다.
-  // 운영에서는 DB_SYNCHRONIZE=false 로 꺼야 하지만, 마이그레이션이 아직 없으므로
-  // 기본값은 기존 동작(true) 을 유지한다. 마이그레이션 도입 후 운영 환경변수만 바꾸면 된다.
+  // 운영(DB_SYNCHRONIZE=false)에서는 스키마 변경 경로가 마이그레이션 하나뿐이 된다.
   const synchronize = config.get<string>('DB_SYNCHRONIZE') !== 'false';
 
   return {
@@ -16,12 +17,24 @@ export const createTypeOrmModuleOptions = (config: ConfigService): TypeOrmModule
     password: config.getOrThrow<string>('DB_PASSWORD'),
     database: config.getOrThrow<string>('DB_NAME'),
     autoLoadEntities: true,
+    // 경로를 문자열로 박으면 안 된다. 빌드 산출물 위치가 워크스페이스 구성에 따라
+    // dist/ 와 dist/src/ 로 갈리기 때문이다(루트에 src 밖 .ts 가 있으면 tsc 가 rootDir 을 넓힌다).
+    // __dirname 기준이면 개발(src/config)과 운영(dist/config) 양쪽에서 항상 맞는다.
+    migrations: [join(__dirname, 'migrations', '*{.ts,.js}')],
     synchronize,
-    migrationsRun: false,
+    // synchronize 와 함께 켜서는 안 된다. TypeORM 은 synchronize 를 먼저 끝낸 뒤
+    // 마이그레이션을 돌리므로, 둘 다 켜면 이미 만들어진 스키마에 베이스라인의
+    // CREATE TABLE 이 실행돼 앱이 부팅하지 못한다.
+    // 반대로 이 값을 빠뜨리면 synchronize 를 끈 채 마이그레이션도 돌지 않아
+    // 스키마 변경이 조용히 유실된다 - 자동 DDL 을 끄는 것보다 위험한 상태다.
+    migrationsRun: !synchronize,
   };
 };
 
 // NOTE :: CLI/마이그레이션 컨텍스트는 NestJS DI 밖에서 실행되므로 process.env 직접 접근을 허용한다.
+// 이 DataSource 는 typeorm-ts-node-commonjs 로만 실행되므로 글롭은 .ts 만 본다.
+// dist 글롭을 함께 두면 빌드 산출물이 있는 워크스페이스에서 같은 엔티티가 두 번 등록돼
+// migration:generate 가 엉뚱한 스키마를 만든다. 런타임 경로는 아래 모듈 옵션이 따로 담당한다.
 export const createTypeOrmDataSourceOptions = (): DataSourceOptions => ({
   type: 'postgres',
   host: process.env.DB_HOST!,
@@ -29,8 +42,8 @@ export const createTypeOrmDataSourceOptions = (): DataSourceOptions => ({
   username: process.env.DB_USERNAME!,
   password: process.env.DB_PASSWORD!,
   database: process.env.DB_NAME!,
-  entities: ['src/**/*.entity.ts', 'dist/**/*.entity.js'],
-  migrations: ['src/config/migrations/*.ts', 'dist/config/migrations/*.js'],
+  entities: ['src/**/*.entity.ts'],
+  migrations: ['src/config/migrations/*.ts'],
   synchronize: false,
   migrationsRun: false,
 });

--- a/src/discord/domain/discord-link.entity.ts
+++ b/src/discord/domain/discord-link.entity.ts
@@ -22,7 +22,12 @@ export class DiscordLink extends BaseEntity {
   @Column()
   discordUsername: string;
 
-  @Column({ type: 'jsonb', default: () => `'[]'::jsonb` })
+  // 캐스트(::jsonb) 를 붙이면 안 된다. TypeORM 은 DB 의 기본값을 읽을 때 캐스트를 떼고
+  // 비교하므로, 선언에만 캐스트가 남아 있으면 스키마가 동일한데도 매번 변경으로 판정한다.
+  // 그 상태로는 migration:generate 가 영원히 같은 노이즈 마이그레이션을 만들어
+  // CI 의 마이그레이션 누락 검사가 무의미해진다. 캐스트 없이 써도 Postgres 가
+  // jsonb 로 강제 변환하므로 실제 컬럼 기본값은 '[]'::jsonb 로 동일하다.
+  @Column({ type: 'jsonb', default: () => `'[]'` })
   rolesAssigned: string[];
 
   @Column({ nullable: true })


### PR DESCRIPTION
## 개요
운영에서 TypeORM `synchronize` 를 끄고 마이그레이션으로 스키마를 관리한다.

## 변경 이유
`synchronize` 가 켜져 있어 앱이 부팅할 때마다 엔티티 정의에 맞춰 DDL 이 자동 실행됐다.
엔티티에서 컬럼을 지우면 운영 데이터가 함께 사라지고, 그 사실이 배포 로그에 남지 않는다.

## 주요 변경 사항
- 현재 운영 스키마와 일치하는 베이스라인 마이그레이션 추가 (`src/config/migrations/`)
- 런타임 옵션에 `migrations` 글롭 추가. 이게 없으면 `migrationsRun` 을 켜도 마이그레이션
  0개를 실행하고 조용히 지나가, 스키마 변경이 영영 반영되지 않는다
- `migrationsRun: !synchronize`. 둘을 함께 켜면 `synchronize` 가 먼저 스키마를 맞춘 뒤
  베이스라인의 CREATE 가 충돌해 앱이 부팅하지 못한다
- `deploy.yml` 이 `.env.production` 에 `DB_SYNCHRONIZE=false` 를 기록하고, 누락 시 배포 중단
- CI 에 마이그레이션 누락 검사 잡 추가. 빈 DB 에 전부 적용한 뒤 엔티티와 비교해
  차이가 있으면 실패시킨다
- `discord_links.rolesAssigned` 기본값에서 `::jsonb` 캐스트 제거.
  TypeORM 은 DB 기본값을 읽을 때 캐스트를 떼고 비교하므로, 선언에만 남아 있으면
  스키마가 같은데도 매번 변경으로 판정한다. 그대로 두면 위 CI 검사가 매번 실패해
  무력화된다. 컬럼 기본값은 `'[]'::jsonb` 로 동일하다
- `.dockerignore` 에 `scripts` 추가. `src` 밖 `.ts` 가 빌드 컨텍스트에 들어오면 tsc 가
  rootDir 을 넓혀 산출물이 `dist/` 대신 `dist/src/` 로 나오고,
  `CMD node dist/main` 과 마이그레이션 글롭이 함께 어긋난다

## 아키텍처 영향
- 도메인 분리: 변화 없음
- 레이어 변경: 없음. `src/config` 의 인프라 설정과 워크플로만 수정
- 의존 방향 영향: 없음
- 트랜잭션 경계 영향: 없음. 마이그레이션은 TypeORM 기본값대로 트랜잭션 안에서 실행된다

## 운영 DB 선행 조치 (완료)
운영 DB 에는 베이스라인을 **적용됨으로 이미 표시**해 두었다. 따라서 배포 시 CREATE 는
실행되지 않는다. 표시하지 않은 상태로 배포하면 앱이 부팅하지 못한다.

```
migrations: id=1, timestamp=1786880782440, name=Baseline1786880782440
```

백업: VM `/var/tmp/pgdump_full_2026-08-16_1217.sql` + 로컬 회수본

## 테스트
- [x] 단위 테스트 — 395 tests / 41 suites 통과
- [x] 통합 테스트 — 운영 이미지로 리허설
- [x] 수동 테스트
- 확인 내용:
  - 운영 스키마 덤프를 복원한 DB 대상 `migration:generate` → `No changes`
  - 카탈로그(컬럼·제약·인덱스·enum) 309줄이 운영과 완전 일치
  - **리허설**: 운영과 동일 조건(스키마 + 시딩 + 데이터)에 운영 이미지 부팅 →
    DDL 0건, 컬럼 169개 무변화, 데이터 보존
  - 시딩 SQL 2회 실행 멱등성 확인, 컨테이너 재기동 시 중복 실행 없음
  - `DB_SYNCHRONIZE=true` 인 구 이미지가 `migrations` 테이블을 지우지 않음 확인
    (시딩 후 배포 전 구간 안전)
  - CI 가드 음성 테스트: 엔티티에만 컬럼 추가 시 실패 처리 확인
  - 시딩 없이 배포하면 앱이 부팅 실패 → 헬스체크 타임아웃으로 배포 실패
    (데이터 손상은 없으나 다운타임 발생. 그래서 선행 조치를 먼저 했다)

## 리뷰 포인트
- `src/config/typeorm.config.ts` 의 `migrations` 글롭과 `migrationsRun: !synchronize`
- `discord-link.entity.ts` 기본값 변경이 DB 기본값을 바꾸지 않는다는 점
- `ci.yml` 의 정합성 검사에서 **generate 성공 = 실패 처리** 인 종료코드 반전

## 리스크 / 후속 작업
- 앞으로 엔티티를 바꾸면 `yarn migration:generate` 로 마이그레이션을 만들어 함께 커밋해야
  한다. 빠뜨리면 CI 에서 막힌다
- 마이그레이션 실패 시 앱이 부팅하지 못해 배포가 실패한다. 조용히 넘어가지 않는 것이
  의도된 동작이다
