### PR TITLE
fix(auth): 지원서 임시저장·제출 Unauthorized 해소 (크로스사이트 인증 쿠키 정정)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,6 @@
 import { Module, OnModuleInit } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
-import { APP_FILTER } from '@nestjs/core';
+import { APP_FILTER, APP_GUARD } from '@nestjs/core';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { ScheduleModule } from '@nestjs/schedule';
 import { InjectDataSource, TypeOrmModule } from '@nestjs/typeorm';
@@ -12,6 +12,7 @@ import { AuditModule } from './audit/audit.module';
 import { BlogModule } from './blog/blog.module';
 import { CohortModule } from './cohort/cohort.module';
 import { HttpExceptionFilter } from './common/exception/http-exception.filter';
+import { OriginGuard } from './common/guard/origin.guard';
 import { EncryptionTransformer } from './common/util/encryption.transformer';
 import { validate } from './config/env.validation';
 import { createTypeOrmModuleOptions } from './config/typeorm.config';
@@ -49,7 +50,10 @@ const ENV_FILE_PATHS = ['.env.production', '.env.staging', '.env.test', '.env.de
     InterviewModule,
     DiscordModule,
   ],
-  providers: [{ provide: APP_FILTER, useClass: HttpExceptionFilter }],
+  providers: [
+    { provide: APP_FILTER, useClass: HttpExceptionFilter },
+    { provide: APP_GUARD, useClass: OriginGuard },
+  ],
 })
 export class AppModule implements OnModuleInit {
   constructor(

--- a/src/common/exception/http-exception.filter.spec.ts
+++ b/src/common/exception/http-exception.filter.spec.ts
@@ -1,0 +1,97 @@
+import {
+  ArgumentsHost,
+  BadRequestException,
+  HttpStatus,
+  UnauthorizedException,
+  ValidationPipe,
+} from '@nestjs/common';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+import { ErrorMessage } from '../error/error-message';
+import { AppException } from './app.exception';
+import { HttpExceptionFilter } from './http-exception.filter';
+
+class SampleDto {
+  @IsString()
+  @IsNotEmpty({ message: '이름은 필수입니다.' })
+  name!: string;
+}
+
+const captureResponse = () => {
+  const payload: { status?: number; body?: unknown } = {};
+  const response = {
+    status(code: number) {
+      payload.status = code;
+      return this;
+    },
+    json(body: unknown) {
+      payload.body = body;
+      return this;
+    },
+  };
+
+  const host = {
+    switchToHttp: () => ({
+      getResponse: () => response,
+      getRequest: () => ({ method: 'POST', url: '/api/v1/applications/draft' }),
+    }),
+  } as unknown as ArgumentsHost;
+
+  return { host, payload };
+};
+
+describe('HttpExceptionFilter', () => {
+  const filter = new HttpExceptionFilter();
+
+  it('가드가 던진 기본 401은 프레임워크 영문 문구 대신 한국어 메시지로 응답한다', () => {
+    const { host, payload } = captureResponse();
+
+    filter.catch(new UnauthorizedException(), host);
+
+    expect(payload.status).toBe(HttpStatus.UNAUTHORIZED);
+    expect(payload.body).toEqual({
+      code: 'UNAUTHORIZED',
+      message: ErrorMessage.UNAUTHORIZED,
+      data: null,
+    });
+  });
+
+  it('설명을 직접 지정한 예외는 그 문구를 그대로 유지한다', () => {
+    const { host, payload } = captureResponse();
+
+    filter.catch(new BadRequestException('cohortPartId 는 숫자여야 합니다.'), host);
+
+    expect(payload.body).toMatchObject({
+      code: 'BAD_REQUEST',
+      message: 'cohortPartId 는 숫자여야 합니다.',
+    });
+  });
+
+  it('ValidationPipe 가 만든 검증 메시지 배열은 삼키지 않고 합쳐서 내려준다', async () => {
+    const pipe = new ValidationPipe({ whitelist: true, transform: true });
+    const validationError = await pipe
+      .transform({}, { type: 'body', metatype: SampleDto })
+      .then(() => null)
+      .catch((error: unknown) => error);
+
+    const { host, payload } = captureResponse();
+
+    filter.catch(validationError, host);
+
+    expect(payload.status).toBe(HttpStatus.BAD_REQUEST);
+    expect((payload.body as { message: string }).message).toContain('이름은 필수입니다.');
+  });
+
+  it('AppException 은 기존대로 도메인 코드와 메시지를 그대로 내려준다', () => {
+    const { host, payload } = captureResponse();
+
+    filter.catch(new AppException('ALREADY_SUBMITTED', HttpStatus.CONFLICT), host);
+
+    expect(payload.status).toBe(HttpStatus.CONFLICT);
+    expect(payload.body).toEqual({
+      code: 'ALREADY_SUBMITTED',
+      message: ErrorMessage.ALREADY_SUBMITTED,
+      data: null,
+    });
+  });
+});

--- a/src/common/exception/http-exception.filter.spec.ts
+++ b/src/common/exception/http-exception.filter.spec.ts
@@ -1,6 +1,7 @@
 import {
   ArgumentsHost,
   BadRequestException,
+  HttpException,
   HttpStatus,
   UnauthorizedException,
   ValidationPipe,
@@ -65,6 +66,18 @@ describe('HttpExceptionFilter', () => {
       code: 'BAD_REQUEST',
       message: 'cohortPartId 는 숫자여야 합니다.',
     });
+  });
+
+  it('error 없이 객체로 만든 커스텀 예외는 그 message 를 보존한다', () => {
+    // 판별 기준이 'error 필드 부재' 였다면 이 메시지가 공통 문구로 덮여 회귀가 났다.
+    const { host, payload } = captureResponse();
+
+    filter.catch(
+      new HttpException({ code: 'CUSTOM_CASE', message: '커스텀 문구' }, HttpStatus.BAD_REQUEST),
+      host,
+    );
+
+    expect((payload.body as { message: string }).message).toBe('커스텀 문구');
   });
 
   it('ValidationPipe 가 만든 검증 메시지 배열은 삼키지 않고 합쳐서 내려준다', async () => {

--- a/src/common/exception/http-exception.filter.ts
+++ b/src/common/exception/http-exception.filter.ts
@@ -58,15 +58,20 @@ export class HttpExceptionFilter implements ExceptionFilter {
       return exceptionResponse;
     }
 
-    const response = exceptionResponse as Record<string, unknown>;
+    const responseBody = exceptionResponse as Record<string, unknown>;
 
-    // NestJS 는 설명을 직접 넘긴 예외에만 error 필드를 채운다. error 가 없다는 것은 message 가
-    // 'Unauthorized' 같은 프레임워크 기본 문구라는 뜻이므로 사용자에게 그대로 노출하지 않는다.
-    if (!('error' in response)) {
+    // NestJS 가 설명 없이 만든 예외의 응답 본문은 message 와 statusCode 딱 두 키다. 이때 message 는
+    // 'Unauthorized' 같은 프레임워크 영문 문구이므로 사용자에게 그대로 노출하지 않는다.
+    // 설명을 직접 넘기면 error 가, 커스텀 객체를 넘기면 그 밖의 키가 함께 오므로 원문을 보존한다.
+    const isFrameworkDefault = Object.keys(responseBody).every(
+      (key) => key === 'message' || key === 'statusCode',
+    );
+
+    if (isFrameworkDefault) {
       return ErrorMessage[code];
     }
 
-    const raw = response.message;
+    const raw = responseBody.message;
 
     if (Array.isArray(raw)) {
       return raw.join(', ');

--- a/src/common/exception/http-exception.filter.ts
+++ b/src/common/exception/http-exception.filter.ts
@@ -32,8 +32,8 @@ export class HttpExceptionFilter implements ExceptionFilter {
     if (exception instanceof HttpException) {
       const status = exception.getStatus();
       const exceptionResponse = exception.getResponse();
-      const message = this.resolveMessage(exceptionResponse, exception);
       const code = this.resolveCode(HttpStatus[status], status);
+      const message = this.resolveMessage(exceptionResponse, exception, code);
 
       response.status(status).json(ApiResponse.fail(code, message));
       return;
@@ -49,12 +49,24 @@ export class HttpExceptionFilter implements ExceptionFilter {
       .json(ApiResponse.fail('INTERNAL_SERVER_ERROR', ErrorMessage.INTERNAL_SERVER_ERROR));
   }
 
-  private resolveMessage(exceptionResponse: string | object, exception: HttpException): string {
+  private resolveMessage(
+    exceptionResponse: string | object,
+    exception: HttpException,
+    code: ErrorMessageKey,
+  ): string {
     if (typeof exceptionResponse === 'string') {
       return exceptionResponse;
     }
 
-    const raw = (exceptionResponse as Record<string, unknown>).message;
+    const response = exceptionResponse as Record<string, unknown>;
+
+    // NestJS 는 설명을 직접 넘긴 예외에만 error 필드를 채운다. error 가 없다는 것은 message 가
+    // 'Unauthorized' 같은 프레임워크 기본 문구라는 뜻이므로 사용자에게 그대로 노출하지 않는다.
+    if (!('error' in response)) {
+      return ErrorMessage[code];
+    }
+
+    const raw = response.message;
 
     if (Array.isArray(raw)) {
       return raw.join(', ');

--- a/src/common/guard/origin.guard.spec.ts
+++ b/src/common/guard/origin.guard.spec.ts
@@ -1,0 +1,60 @@
+import { ExecutionContext, HttpStatus } from '@nestjs/common';
+
+import { AppException } from '../exception/app.exception';
+import { OriginGuard } from './origin.guard';
+
+const createContext = ({ method, origin }: { method: string; origin?: string }) =>
+  ({
+    switchToHttp: () => ({
+      getRequest: () => ({ method, headers: origin ? { origin } : {} }),
+    }),
+  }) as unknown as ExecutionContext;
+
+describe('OriginGuard', () => {
+  const guard = new OriginGuard();
+
+  it('허용된 오리진의 상태 변경 요청은 통과시킨다', () => {
+    const context = createContext({ method: 'POST', origin: 'https://ddd-fe-web.vercel.app' });
+
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('허용되지 않은 오리진의 인증된 simple request 는 거부한다', () => {
+    // multipart/form-data 는 preflight 가 없어 CORS 로는 전송을 막을 수 없다. SameSite=None 이라
+    // 쿠키까지 실려 오므로 서버가 Origin 을 직접 보고 끊어야 한다.
+    const context = createContext({ method: 'POST', origin: 'https://evil.example.com' });
+
+    expect(() => guard.canActivate(context)).toThrow(AppException);
+
+    try {
+      guard.canActivate(context);
+    } catch (error) {
+      expect((error as AppException).getStatus()).toBe(HttpStatus.FORBIDDEN);
+    }
+  });
+
+  it('예전 화이트리스트를 통과하던 제3자 Vercel 프로젝트 오리진을 거부한다', () => {
+    // 이전 정규식 /^https:\/\/ddd-fe-web(-[\w-]+)?\.vercel\.app$/ 는 이 오리진을 허용했다.
+    // Vercel 프로젝트 이름은 팀 단위로만 유일해서 제3자가 같은 이름을 쓸 수 있다.
+    const context = createContext({
+      method: 'POST',
+      origin: 'https://ddd-fe-web-a1b2c3-attacker.vercel.app',
+    });
+
+    expect(() => guard.canActivate(context)).toThrow(AppException);
+  });
+
+  it('Origin 이 없는 요청은 브라우저가 만든 것이 아니므로 통과시킨다', () => {
+    // 브라우저는 GET/HEAD 외 모든 요청에 Origin 을 강제로 붙인다. 없으면 서버 간 호출이나 curl 이고
+    // 남의 쿠키를 실을 수 없어 CSRF 가 성립하지 않는다.
+    const context = createContext({ method: 'POST' });
+
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('안전한 메서드는 오리진을 따지지 않는다', () => {
+    const context = createContext({ method: 'GET', origin: 'https://evil.example.com' });
+
+    expect(guard.canActivate(context)).toBe(true);
+  });
+});

--- a/src/common/guard/origin.guard.ts
+++ b/src/common/guard/origin.guard.ts
@@ -1,0 +1,36 @@
+import { CanActivate, ExecutionContext, HttpStatus, Injectable } from '@nestjs/common';
+import type { Request } from 'express';
+
+import { isAllowedOrigin } from '../../config/cors.config';
+import { AppException } from '../exception/app.exception';
+
+// 인증 쿠키를 SameSite=None 으로 바꾸면서 Lax 가 덤으로 막아주던 CSRF 방어가 사라진다.
+// CORS 는 simple request(multipart 업로드, 폼 POST)의 "전송" 자체는 막지 못하고 응답 판독만
+// 막으므로, 상태를 바꾸는 요청은 서버가 Origin 을 직접 검증한다.
+//
+// 브라우저는 GET/HEAD 외의 모든 요청에 Origin 을 강제로 붙인다. 따라서 Origin 이 없는 요청은
+// 브라우저가 만든 것이 아니고(서버 간 호출, curl, 웹훅) 남의 쿠키를 실을 수도 없으므로 통과시킨다.
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+
+@Injectable()
+export class OriginGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<Request>();
+
+    if (SAFE_METHODS.has(request.method)) {
+      return true;
+    }
+
+    const origin = request.headers.origin;
+
+    if (!origin) {
+      return true;
+    }
+
+    if (!isAllowedOrigin({ origin })) {
+      throw new AppException('FORBIDDEN', HttpStatus.FORBIDDEN);
+    }
+
+    return true;
+  }
+}

--- a/src/config/cors.config.ts
+++ b/src/config/cors.config.ts
@@ -1,0 +1,21 @@
+// 인증 쿠키가 SameSite=None 으로 나가므로, 이 목록은 "쿠키를 실어 보내고 응답까지 읽을 수 있는
+// 오리진" 과 같은 뜻이 된다. 따라서 패턴 매칭이 아니라 정확히 일치하는 오리진만 둔다.
+//
+// 이전에는 /^https:\/\/ddd-fe-web(-[\w-]+)?\.vercel\.app$/ 를 썼는데, Vercel 프로젝트 이름은
+// 팀 단위로만 유일하다. 제3자가 자기 팀에 같은 이름의 프로젝트를 만들면
+// ddd-fe-web-<해시>-<남의팀>.vercel.app 를 얻어 이 정규식을 통과했다. SameSite=Lax 시절에는
+// 브라우저가 쿠키를 안 실어 실질 위험이 없었지만, None 으로 바꾸는 순간 그 오리진이 지원자
+// 인증으로 지원서를 읽고 덮어쓸 수 있게 된다. 그래서 쿠키 속성 변경과 같은 시점에 좁힌다.
+//
+// 프리뷰 배포에서 이 API 를 불러야 한다면 팀 슬러그를 고정한 형태
+// (ddd-fe-web-<해시>-<우리팀슬러그>.vercel.app) 로 다시 넣어야 한다. 슬러그 없이는
+// 우리 프리뷰와 남의 프로젝트를 구분할 수 없다.
+export const ALLOWED_ORIGINS = [
+  'http://localhost:3000',
+  'http://localhost:5173',
+  'https://admin.dddstudy.kr',
+  'https://ddd-fe-web.vercel.app',
+] as const;
+
+export const isAllowedOrigin = ({ origin }: { origin: string }): boolean =>
+  ALLOWED_ORIGINS.some((allowedOrigin) => allowedOrigin === origin);

--- a/src/google/interface/google-auth.controller.spec.ts
+++ b/src/google/interface/google-auth.controller.spec.ts
@@ -1,0 +1,63 @@
+import { ConfigService } from '@nestjs/config';
+import type { Response } from 'express';
+
+import type { GoogleAuthService } from '../application/google-auth.service';
+import { GoogleAuthController } from './google-auth.controller';
+
+type CookieCall = { name: string; options: Record<string, unknown> };
+
+const createController = ({ nodeEnv }: { nodeEnv: string }) => {
+  const configService = {
+    get: (key: string) => (key === 'NODE_ENV' ? nodeEnv : undefined),
+    getOrThrow: (key: string) => {
+      if (key === 'CLIENT_REDIRECT_URL') {
+        return 'https://ddd-fe-web.vercel.app';
+      }
+      throw new Error(`unexpected key: ${key}`);
+    },
+  } as unknown as ConfigService;
+
+  const googleAuthService = {
+    refresh: () => Promise.resolve({ accessToken: 'access', refreshToken: 'refresh' }),
+  } as unknown as GoogleAuthService;
+
+  return new GoogleAuthController(googleAuthService, configService);
+};
+
+const createResponse = () => {
+  const calls: CookieCall[] = [];
+  const response = {
+    cookie(name: string, _value: string, options: Record<string, unknown>) {
+      calls.push({ name, options });
+      return this;
+    },
+  } as unknown as Response;
+
+  return { response, calls };
+};
+
+describe('GoogleAuthController 인증 쿠키 속성', () => {
+  it('운영에서는 cross-site 프론트로도 전송되도록 SameSite=None + Secure 로 발급한다', async () => {
+    const controller = createController({ nodeEnv: 'production' });
+    const { response, calls } = createResponse();
+
+    await controller.refreshToken('refresh-token', response);
+
+    expect(calls.map((call) => call.name)).toEqual(['access_token', 'refresh_token']);
+    for (const call of calls) {
+      // SameSite=None 은 Secure 가 없으면 브라우저가 쿠키 자체를 거부하므로 항상 함께 간다.
+      expect(call.options).toMatchObject({ httpOnly: true, secure: true, sameSite: 'none' });
+    }
+  });
+
+  it('로컬에서는 Secure 를 못 쓰므로 SameSite=Lax 를 유지한다', async () => {
+    const controller = createController({ nodeEnv: 'development' });
+    const { response, calls } = createResponse();
+
+    await controller.refreshToken('refresh-token', response);
+
+    for (const call of calls) {
+      expect(call.options).toMatchObject({ httpOnly: true, secure: false, sameSite: 'lax' });
+    }
+  });
+});

--- a/src/google/interface/google-auth.controller.spec.ts
+++ b/src/google/interface/google-auth.controller.spec.ts
@@ -1,10 +1,13 @@
 import { ConfigService } from '@nestjs/config';
 import type { Response } from 'express';
 
+import type { JwtUser } from '../../auth/application/auth.type';
 import type { GoogleAuthService } from '../application/google-auth.service';
 import { GoogleAuthController } from './google-auth.controller';
 
 type CookieCall = { name: string; options: Record<string, unknown> };
+
+const REFRESH_TOKEN_PATH = '/api/v1/auth/refresh';
 
 const createController = ({ nodeEnv }: { nodeEnv: string }) => {
   const configService = {
@@ -19,45 +22,94 @@ const createController = ({ nodeEnv }: { nodeEnv: string }) => {
 
   const googleAuthService = {
     refresh: () => Promise.resolve({ accessToken: 'access', refreshToken: 'refresh' }),
+    logout: () => Promise.resolve(),
+    withdrawal: () => Promise.resolve(),
   } as unknown as GoogleAuthService;
 
   return new GoogleAuthController(googleAuthService, configService);
 };
 
 const createResponse = () => {
-  const calls: CookieCall[] = [];
+  const setCalls: CookieCall[] = [];
+  const clearCalls: CookieCall[] = [];
   const response = {
     cookie(name: string, _value: string, options: Record<string, unknown>) {
-      calls.push({ name, options });
+      setCalls.push({ name, options });
+      return this;
+    },
+    clearCookie(name: string, options: Record<string, unknown>) {
+      clearCalls.push({ name, options });
       return this;
     },
   } as unknown as Response;
 
-  return { response, calls };
+  return { response, setCalls, clearCalls };
 };
+
+const jwtUser: JwtUser = { id: 1, email: 'applicant@example.com', roles: [] };
 
 describe('GoogleAuthController 인증 쿠키 속성', () => {
   it('운영에서는 cross-site 프론트로도 전송되도록 SameSite=None + Secure 로 발급한다', async () => {
+    // Given
     const controller = createController({ nodeEnv: 'production' });
-    const { response, calls } = createResponse();
+    const { response, setCalls } = createResponse();
 
+    // When
     await controller.refreshToken('refresh-token', response);
 
-    expect(calls.map((call) => call.name)).toEqual(['access_token', 'refresh_token']);
-    for (const call of calls) {
+    // Then
+    expect(setCalls.map((call) => call.name)).toEqual(['access_token', 'refresh_token']);
+    for (const call of setCalls) {
       // SameSite=None 은 Secure 가 없으면 브라우저가 쿠키 자체를 거부하므로 항상 함께 간다.
       expect(call.options).toMatchObject({ httpOnly: true, secure: true, sameSite: 'none' });
     }
+    expect(setCalls[1].options).toMatchObject({ path: REFRESH_TOKEN_PATH });
   });
 
   it('로컬에서는 Secure 를 못 쓰므로 SameSite=Lax 를 유지한다', async () => {
+    // Given
     const controller = createController({ nodeEnv: 'development' });
-    const { response, calls } = createResponse();
+    const { response, setCalls } = createResponse();
 
+    // When
     await controller.refreshToken('refresh-token', response);
 
-    for (const call of calls) {
+    // Then
+    for (const call of setCalls) {
       expect(call.options).toMatchObject({ httpOnly: true, secure: false, sameSite: 'lax' });
     }
+  });
+
+  it('로그아웃의 쿠키 삭제는 발급과 같은 속성으로 나간다', async () => {
+    // 속성이 어긋나면 삭제용 Set-Cookie 가 cross-site 응답에서 거부되어, 서버는 204 를 주는데
+    // 브라우저에는 access_token 이 그대로 남는다. JWT 는 stateless 라 최대 24시간 인증이 유지된다.
+    // Given
+    const controller = createController({ nodeEnv: 'production' });
+    const { response, clearCalls } = createResponse();
+
+    // When
+    await controller.logout(jwtUser, response);
+
+    // Then
+    expect(clearCalls.map((call) => call.name)).toEqual(['access_token', 'refresh_token']);
+    for (const call of clearCalls) {
+      expect(call.options).toMatchObject({ httpOnly: true, secure: true, sameSite: 'none' });
+    }
+    expect(clearCalls[1].options).toMatchObject({ path: REFRESH_TOKEN_PATH });
+  });
+
+  it('회원 탈퇴의 쿠키 삭제도 발급과 같은 속성으로 나간다', async () => {
+    // Given
+    const controller = createController({ nodeEnv: 'production' });
+    const { response, clearCalls } = createResponse();
+
+    // When
+    await controller.withdrawal(jwtUser, response);
+
+    // Then
+    for (const call of clearCalls) {
+      expect(call.options).toMatchObject({ httpOnly: true, secure: true, sameSite: 'none' });
+    }
+    expect(clearCalls[1].options).toMatchObject({ path: REFRESH_TOKEN_PATH });
   });
 });

--- a/src/google/interface/google-auth.controller.ts
+++ b/src/google/interface/google-auth.controller.ts
@@ -160,10 +160,14 @@ export class GoogleAuthController {
     accessToken: string;
     refreshToken: string;
   }): void {
+    // 지원자 프론트(ddd-fe-web.vercel.app)와 API(admin.dddstudy.kr)는 등록 도메인이 서로 달라
+    // cross-site 다. Lax 로는 fetch/XHR 에 쿠키가 실리지 않아 임시저장·제출은 물론 401 이후의
+    // /auth/refresh 재발급까지 전부 막힌다. None 은 Secure 가 전제라 운영에서만 쓰고,
+    // 로컬은 localhost 끼리 same-site 라 Lax 를 유지한다(Secure 없이 None 을 쓰면 브라우저가 거부).
     const baseOptions = {
       httpOnly: true,
       secure: this.isProduction,
-      sameSite: 'lax' as const,
+      sameSite: this.isProduction ? ('none' as const) : ('lax' as const),
     };
 
     response.cookie('access_token', accessToken, {

--- a/src/google/interface/google-auth.controller.ts
+++ b/src/google/interface/google-auth.controller.ts
@@ -11,7 +11,7 @@ import {
 import { ConfigService } from '@nestjs/config';
 import { AuthGuard } from '@nestjs/passport';
 import { ApiExtraModels, ApiTags } from '@nestjs/swagger';
-import type { Response } from 'express';
+import type { CookieOptions, Response } from 'express';
 
 import type { JwtUser } from '../../auth/application/auth.type';
 import { AuthUser } from '../../common/decorator/auth-user.decorator';
@@ -31,6 +31,7 @@ import { GoogleAuthSwagger } from './google-auth.swagger';
 
 const ACCESS_TOKEN_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 const REFRESH_TOKEN_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+const REFRESH_TOKEN_COOKIE_PATH = '/api/v1/auth/refresh';
 
 @ApiTags('Auth')
 @ApiExtraModels(GoogleAuthCallbackResponseDto, GoogleRefreshResponseDto)
@@ -38,6 +39,7 @@ const REFRESH_TOKEN_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 export class GoogleAuthController {
   private readonly isProduction: boolean;
   private readonly clientRedirectUrl: string;
+  private readonly cookieBaseOptions: CookieOptions;
 
   constructor(
     private readonly googleAuthService: GoogleAuthService,
@@ -45,6 +47,21 @@ export class GoogleAuthController {
   ) {
     this.isProduction = configService.get<string>('NODE_ENV') === 'production';
     this.clientRedirectUrl = configService.getOrThrow<string>('CLIENT_REDIRECT_URL');
+
+    // 지원자 프론트(ddd-fe-web.vercel.app)와 API(admin.dddstudy.kr)는 등록 도메인이 서로 달라
+    // cross-site 다. Lax 로는 fetch/XHR 에 쿠키가 실리지 않아 임시저장·제출은 물론 401 이후의
+    // /auth/refresh 재발급까지 전부 막힌다. None 은 Secure 가 전제라 운영에서만 쓰고,
+    // 로컬은 localhost 끼리 same-site 라 Lax 를 유지한다(Secure 없이 None 을 쓰면 브라우저가 거부).
+    //
+    // 발급과 삭제가 반드시 같은 값을 쓰도록 한곳에 둔다. clearCookie 는 옵션을 넘기지 않으면
+    // sameSite 도 secure 도 붙이지 않는데, 속성 없는 삭제용 Set-Cookie 는 cross-site 응답에서
+    // 브라우저가 거부한다. 그러면 서버는 204 를 주는데 브라우저에는 쿠키가 남아 로그아웃이
+    // 무효가 된다(JWT 는 stateless 라 최대 24시간 유효).
+    this.cookieBaseOptions = {
+      httpOnly: true,
+      secure: this.isProduction,
+      sameSite: this.isProduction ? 'none' : 'lax',
+    };
   }
 
   @ApiDoc({
@@ -126,8 +143,7 @@ export class GoogleAuthController {
   async logout(@AuthUser() jwtUser: JwtUser, @Res({ passthrough: true }) response: Response) {
     await this.googleAuthService.logout({ userId: jwtUser.id });
 
-    response.clearCookie('access_token');
-    response.clearCookie('refresh_token', { path: '/api/v1/auth/refresh' });
+    this.clearAuthCookies({ response });
   }
 
   @ApiDoc({
@@ -147,8 +163,16 @@ export class GoogleAuthController {
   async withdrawal(@AuthUser() jwtUser: JwtUser, @Res({ passthrough: true }) response: Response) {
     await this.googleAuthService.withdrawal({ userId: jwtUser.id });
 
-    response.clearCookie('access_token');
-    response.clearCookie('refresh_token', { path: '/api/v1/auth/refresh' });
+    this.clearAuthCookies({ response });
+  }
+
+  // 삭제용 Set-Cookie 도 발급 때와 같은 속성으로 나가야 브라우저가 받아준다.
+  private clearAuthCookies({ response }: { response: Response }): void {
+    response.clearCookie('access_token', this.cookieBaseOptions);
+    response.clearCookie('refresh_token', {
+      ...this.cookieBaseOptions,
+      path: REFRESH_TOKEN_COOKIE_PATH,
+    });
   }
 
   private setAuthCookies({
@@ -160,23 +184,13 @@ export class GoogleAuthController {
     accessToken: string;
     refreshToken: string;
   }): void {
-    // 지원자 프론트(ddd-fe-web.vercel.app)와 API(admin.dddstudy.kr)는 등록 도메인이 서로 달라
-    // cross-site 다. Lax 로는 fetch/XHR 에 쿠키가 실리지 않아 임시저장·제출은 물론 401 이후의
-    // /auth/refresh 재발급까지 전부 막힌다. None 은 Secure 가 전제라 운영에서만 쓰고,
-    // 로컬은 localhost 끼리 same-site 라 Lax 를 유지한다(Secure 없이 None 을 쓰면 브라우저가 거부).
-    const baseOptions = {
-      httpOnly: true,
-      secure: this.isProduction,
-      sameSite: this.isProduction ? ('none' as const) : ('lax' as const),
-    };
-
     response.cookie('access_token', accessToken, {
-      ...baseOptions,
+      ...this.cookieBaseOptions,
       maxAge: ACCESS_TOKEN_MAX_AGE_MS,
     });
     response.cookie('refresh_token', refreshToken, {
-      ...baseOptions,
-      path: '/api/v1/auth/refresh',
+      ...this.cookieBaseOptions,
+      path: REFRESH_TOKEN_COOKIE_PATH,
       maxAge: REFRESH_TOKEN_MAX_AGE_MS,
     });
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import cookieParser from 'cookie-parser';
 import { initializeTransactionalContext } from 'typeorm-transactional';
 
 import { AppModule } from './app.module';
+import { ALLOWED_ORIGINS } from './config/cors.config';
 import { setupSwagger } from './config/swagger.config';
 
 const bootstrap = async () => {
@@ -14,12 +15,7 @@ const bootstrap = async () => {
   app.use(cookieParser());
 
   app.enableCors({
-    origin: [
-      'http://localhost:3000',
-      'http://localhost:5173',
-      'https://admin.dddstudy.kr',
-      /^https:\/\/ddd-fe-web(-[\w-]+)?\.vercel\.app$/,
-    ],
+    origin: [...ALLOWED_ORIGINS],
     credentials: true,
   });
 


### PR DESCRIPTION
## 개요

지원서 임시저장·제출 시 화면에 `Unauthorized` 가 노출되며 항상 실패하던 문제를 고칩니다. 원인은 인증 쿠키의 `SameSite` 설정이며 백엔드 변경만으로 해소됩니다. 프론트 **코드** 변경은 필요 없습니다(단, 아래 "프론트 영향" 참고).

## 변경 이유

배포된 프론트 번들과 API 설정을 직접 대조해 확인한 사실입니다.

| 확인 항목 | 실측 결과 |
|---|---|
| 지원자 프론트 | `ddd-fe-web.vercel.app` (`dddstudy.kr` / `www.dddstudy.kr` 은 응답 없음) |
| 프론트가 호출하는 API | 번들에서 `https://admin.dddstudy.kr` 단독 추출 |
| 인증 방식 | `openapi.json` → `apiKey / in: cookie / access_token` |
| 프론트 클라이언트 | `credentials ?? "include"` + 401 시 `/auth/refresh` 자동 재시도 |
| 백엔드 쿠키 | `SameSite=Lax` |

`vercel.app` 은 Public Suffix 라 두 호스트는 cross-site 입니다. `SameSite=Lax` 는 top-level GET 이동에서만 전송되고 fetch/XHR 에서는 전송되지 않으므로, 프론트가 `credentials: "include"` 로 보내도 브라우저가 쿠키를 제외합니다. `main.ts` 가 해당 오리진을 `credentials: true` 로 허용해둔 것과 쿠키 속성이 서로 모순된 상태였습니다.

**왜 임시저장·제출에서만 드러났는가** — 지원자 동선의 컨트롤러 중 가드가 걸린 것은 `public.application.controller.ts` 하나뿐입니다. 나머지는 무인증이라 폼은 정상적으로 뜨고, 첫 인증 호출인 임시저장·제출에서 처음 실패합니다. 401 이후 프론트가 자동 호출하는 `/auth/refresh` 도 `refresh_token` 이 동일하게 Lax 라 차단되어 자체 복구 경로까지 막혀 있었습니다.

## 주요 변경 사항

**1. 인증 쿠키 `SameSite=None` (운영 한정)** — `google-auth.controller.ts`
`None` 은 `Secure` 가 전제이며 운영은 `NODE_ENV=production` 이라 충족합니다. 로컬은 `Secure` 를 쓸 수 없어 `Lax` 를 유지합니다.

**2. 쿠키 삭제 속성 미러링** — `google-auth.controller.ts`
`clearCookie` 는 옵션을 넘기지 않으면 `sameSite`·`secure` 를 붙이지 않습니다. 속성 없는 삭제용 Set-Cookie 는 cross-site 응답에서 브라우저가 거부하므로, 서버는 204 를 주는데 `access_token` 은 그대로 남아 로그아웃이 무효가 됩니다(JWT 는 stateless 라 최대 24시간 유지). 발급·삭제가 같은 값을 쓰도록 `cookieBaseOptions` 로 모았습니다.

**3. CORS 오리진 축소** — `src/config/cors.config.ts` (신규), `main.ts`
기존 정규식 `/^https:\/\/ddd-fe-web(-[\w-]+)?\.vercel\.app$/` 은 `https://ddd-fe-web-<해시>-<남의팀>.vercel.app` 까지 통과시킵니다. Vercel 프로젝트 이름은 팀 단위로만 유일해서 제3자가 같은 이름을 쓸 수 있습니다. `Lax` 시절엔 쿠키가 안 실려 위험이 0이었지만 `None` 으로 바꾸면 그 오리진이 지원자 인증으로 지원서를 읽고 덮어쓸 수 있습니다. **노출 창이 생기지 않도록 쿠키 속성 변경과 같은 PR 에서** 정확 일치 목록으로 좁혔습니다.

**4. Origin 검증 전역 가드** — `src/common/guard/origin.guard.ts` (신규)
CORS 는 simple request(multipart 업로드·폼 POST)의 전송 자체는 막지 못하고 응답 판독만 막습니다. `Lax` 가 덤으로 해주던 CSRF 방어를 서버가 대신합니다. 브라우저는 GET/HEAD 외 모든 요청에 `Origin` 을 붙이므로, `Origin` 이 없는 요청은 브라우저 밖(서버 간 호출·웹훅)이라 통과시킵니다.

**5. 401 응답 문구 한국어화** — `http-exception.filter.ts`
NestJS 가 설명 없이 만든 응답 본문은 `message`·`statusCode` 두 키뿐이라는 점을 판별 기준으로 삼아 `ErrorMessage` 의 한국어 문구로 치환합니다. 설명을 직접 넘긴 예외나 객체형 커스텀 예외는 다른 키를 가지므로 원문이 보존됩니다.

실제 발급되는 헤더:

```
운영: access_token=...;  Path=/; HttpOnly; Secure; SameSite=None
      refresh_token=...; Path=/api/v1/auth/refresh; HttpOnly; Secure; SameSite=None
로컬: access_token=...;  Path=/; HttpOnly; SameSite=Lax
```

## ⚠️ 알려진 한계 — Chromium 계열에서만 복구됩니다

`SameSite=None` 은 지금 할 수 있는 최선의 백엔드 전용 조치지만, **완전한 해결이 아닙니다.**

- **Safari 13.1+** — Full Third-Party Cookie Blocking 이 기본이라 `SameSite=None; Secure` 여도 third-party 컨텍스트에서 쿠키를 보내지 않습니다.
- **Firefox** — Total Cookie Protection 이 third-party 쿠키를 top-level site 기준으로 파티셔닝합니다. 이 쿠키는 OAuth 콜백 시점(top-level = `admin.dddstudy.kr`) 파티션에 저장되므로 `vercel.app` 파티션에서 조회되지 않습니다.
- **iOS 는 모든 브라우저가 WebKit** 이므로 iOS 지원자는 전원 그대로 실패합니다.

`CHIPS`(`Partitioned`)도 해결책이 아닙니다 — 파티션 키가 발급 시점(`admin.dddstudy.kr`)과 사용 시점(`vercel.app`)이 어긋나 오히려 깨집니다.

**근본 해결**은 프론트를 `apply.dddstudy.kr` 같은 `dddstudy.kr` 서브도메인으로 옮겨 same-site 로 만드는 것입니다. 그러면 모든 브라우저에서 동작하고, 이 PR 의 `None` 분기를 `Lax` 로 되돌릴 수 있으며, 위 3번의 프리뷰 제약도 자연히 해소됩니다. 코드 변경 없이 Vercel 도메인 설정 + `CLIENT_REDIRECT_URL` + CORS 항목만 바꾸면 됩니다. 후속 티켓으로 분리합니다.

## 프론트 영향

프론트 **코드** 변경은 필요 없습니다. 다만 두 가지가 바뀝니다.

1. **Vercel 프리뷰 배포가 운영 API 를 호출할 수 없게 됩니다.** 위 3번의 결과입니다. 프리뷰에서 API 가 필요하면 팀 슬러그를 고정한 형태(`ddd-fe-web-<해시>-<팀슬러그>.vercel.app`)로 다시 추가해야 합니다. 슬러그 없이는 우리 프리뷰와 제3자 프로젝트를 구분할 수 없습니다.
2. **Safari·iOS·Firefox 사용자는 여전히 실패합니다.** 위 한계 항목 참고.

## 아키텍처 영향

- 도메인 분리: 변경 없음
- 레이어 변경: 없음. Interface / 공통 예외·가드 / config 계층
- 의존 방향 영향: 없음
- 트랜잭션 경계 영향: 없음

## 테스트

- [x] 단위 테스트
- [ ] 통합 테스트
- [x] 수동 테스트 (배포된 프론트 번들 대조, 실제 `Set-Cookie` 헤더 출력 확인)

확인 내용:
- `origin.guard.spec.ts` (신규) — 허용 오리진 통과 / 비허용 거부 / **예전 정규식을 통과하던 제3자 Vercel 오리진 거부** / `Origin` 없는 요청 통과 / 안전 메서드 미검사, 5 케이스
- `google-auth.controller.spec.ts` — 운영 `None`+`Secure` / 로컬 `Lax` / 로그아웃·탈퇴의 쿠키 삭제 속성 미러링, 4 케이스
- `http-exception.filter.spec.ts` — 기본 401 한국어화 / 커스텀 문구 보존 / **`error` 없는 객체형 예외 메시지 보존** / ValidationPipe 메시지 배열 보존 / `AppException` 무영향, 5 케이스
- 전체 유닛 **412 tests 통과**

## 리뷰 포인트

1. CORS 오리진 축소로 프리뷰 배포가 API 를 못 부르게 됩니다. 팀 워크플로에 영향이 있다면 팀 슬러그를 알려주세요.
2. `resolveMessage` 의 키 집합 판별이 `HttpException.createBody` 구현 세부에 의존합니다. Nest 마이너 업그레이드로 깨질 수 있으나 회귀 테스트가 결합을 고정합니다.

## 리스크 / 후속 작업

- **배포 시 전원 재로그인 필요.** 기존 쿠키는 `Lax` 속성 그대로라 재발급 경로까지 막혀 있어 자체 회복이 되지 않습니다. 쿠키 덮어쓰기 키는 (name, domain, path) 이고 양쪽 다 동일하므로, 재로그인 한 번이면 shadowing 없이 정상 복구됩니다.
- **후속**: 프론트 `apply.dddstudy.kr` 이관 (위 한계 해소 + `Lax` 복귀 + 프리뷰 제약 해소)
- **후속**: multer `LIMIT_FILE_SIZE` 가 `PayloadTooLargeException('File too large')` 로 영문 노출되고 `code` 도 `BAD_REQUEST` 로 잘못 붙습니다. 첨부 업로드 경로의 같은 버그 클래스이나 이번 티켓 범위 밖이라 분리합니다.

## 관련 이슈

- 지원서 임시저장/제출 시 Unauthorized 에러 노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)
