### PR TITLE
fix(error): 프레임워크 영문 문구가 지원자에게 노출되던 경로 정정 (413 포함)

### DIFF
--- a/src/common/error/error-message.ts
+++ b/src/common/error/error-message.ts
@@ -4,7 +4,7 @@ export const ErrorMessage = {
   FORBIDDEN: '접근 권한이 없습니다.',
   NOT_FOUND: '요청한 리소스를 찾을 수 없습니다.',
   BAD_REQUEST: '잘못된 요청입니다.',
-  PAYLOAD_TOO_LARGE: '요청 용량이 제한을 초과했습니다. 첨부파일 크기를 확인해주세요.',
+  PAYLOAD_TOO_LARGE: '요청 용량이 제한을 초과했습니다.',
 
   USER_NOT_FOUND: '사용자를 찾을 수 없습니다.',
   USER_DELETED: '탈퇴 처리된 사용자입니다.',

--- a/src/common/error/error-message.ts
+++ b/src/common/error/error-message.ts
@@ -4,6 +4,7 @@ export const ErrorMessage = {
   FORBIDDEN: '접근 권한이 없습니다.',
   NOT_FOUND: '요청한 리소스를 찾을 수 없습니다.',
   BAD_REQUEST: '잘못된 요청입니다.',
+  PAYLOAD_TOO_LARGE: '요청 용량이 제한을 초과했습니다. 첨부파일 크기를 확인해주세요.',
 
   USER_NOT_FOUND: '사용자를 찾을 수 없습니다.',
   USER_DELETED: '탈퇴 처리된 사용자입니다.',

--- a/src/common/exception/http-exception.filter.spec.ts
+++ b/src/common/exception/http-exception.filter.spec.ts
@@ -3,6 +3,7 @@ import {
   BadRequestException,
   HttpException,
   HttpStatus,
+  PayloadTooLargeException,
   UnauthorizedException,
   ValidationPipe,
 } from '@nestjs/common';
@@ -93,6 +94,20 @@ describe('HttpExceptionFilter', () => {
 
     expect(payload.status).toBe(HttpStatus.BAD_REQUEST);
     expect((payload.body as { message: string }).message).toContain('이름은 필수입니다.');
+  });
+
+  it('multer 의 파일 크기 초과(413)는 영문 대신 한국어로, code 도 413 에 맞게 내려준다', () => {
+    // multer 가 실제로 던지는 형태. 설명이 붙어 있어 '프레임워크 기본 문구' 판별을 통과하지 못한다.
+    const { host, payload } = captureResponse();
+
+    filter.catch(new PayloadTooLargeException('File too large'), host);
+
+    expect(payload.status).toBe(HttpStatus.PAYLOAD_TOO_LARGE);
+    expect(payload.body).toEqual({
+      code: 'PAYLOAD_TOO_LARGE',
+      message: ErrorMessage.PAYLOAD_TOO_LARGE,
+      data: null,
+    });
   });
 
   it('AppException 은 기존대로 도메인 코드와 메시지를 그대로 내려준다', () => {

--- a/src/common/exception/http-exception.filter.spec.ts
+++ b/src/common/exception/http-exception.filter.spec.ts
@@ -6,6 +6,7 @@ import {
   HttpException,
   HttpStatus,
   INestApplication,
+  ParseIntPipe,
   PayloadTooLargeException,
   Post,
   UnauthorizedException,
@@ -64,19 +65,22 @@ describe('HttpExceptionFilter', () => {
     });
   });
 
-  it('설명을 직접 지정한 예외는 그 문구를 그대로 유지한다', () => {
+  it('설명을 붙여 던진 내장 예외도 영문이 새지 않게 공통 문구로 덮는다', () => {
+    // multer 가 필드명 불일치에 내는 예외다. 내장 예외는 설명을 붙이면 error 키가 함께 붙으므로
+    // '설명 없는 기본 문구인지' 로는 프레임워크 영문을 가려낼 수 없다. 이 케이스를 원문 보존으로
+    // 취급하면 'File too large', 'Unexpected field - x' 가 그대로 지원자에게 나간다.
     const { host, payload } = captureResponse();
 
-    filter.catch(new BadRequestException('cohortPartId 는 숫자여야 합니다.'), host);
+    filter.catch(new BadRequestException('Unexpected field - portfolio'), host);
 
     expect(payload.body).toMatchObject({
       code: 'BAD_REQUEST',
-      message: 'cohortPartId 는 숫자여야 합니다.',
+      message: ErrorMessage.BAD_REQUEST,
     });
   });
 
-  it('error 없이 객체로 만든 커스텀 예외는 그 message 를 보존한다', () => {
-    // 판별 기준이 'error 필드 부재' 였다면 이 메시지가 공통 문구로 덮여 회귀가 났다.
+  it('문구를 직접 지정하려면 code 를 함께 실은 본문을 쓴다', () => {
+    // 원문 보존의 유일한 통로다. 이 판별이 깨지면 도메인 문구가 공통 문구로 덮인다.
     const { host, payload } = captureResponse();
 
     filter.catch(
@@ -103,7 +107,7 @@ describe('HttpExceptionFilter', () => {
   });
 
   it('multer 의 파일 크기 초과(413)는 영문 대신 한국어로, code 도 413 에 맞게 내려준다', () => {
-    // multer 가 실제로 던지는 형태. 설명이 붙어 있어 '프레임워크 기본 문구' 판별을 통과하지 못한다.
+    // @nestjs/platform-express 의 transformException 이 실제로 만드는 형태 그대로다.
     const { host, payload } = captureResponse();
 
     filter.catch(new PayloadTooLargeException('File too large'), host);
@@ -113,6 +117,25 @@ describe('HttpExceptionFilter', () => {
       code: 'PAYLOAD_TOO_LARGE',
       message: ErrorMessage.PAYLOAD_TOO_LARGE,
       data: null,
+    });
+  });
+
+  it('ParseIntPipe 의 영문 검증 문구도 한국어로 덮는다', async () => {
+    // 공개 컨트롤러 3곳이 경로 파라미터에 쓰고 있어 지원자에게 그대로 노출되던 경로다.
+    const pipe = new ParseIntPipe();
+    const parseError = await pipe
+      .transform('abc', { type: 'param' })
+      .then(() => null)
+      .catch((error: unknown) => error);
+
+    const { host, payload } = captureResponse();
+
+    filter.catch(parseError, host);
+
+    expect(payload.status).toBe(HttpStatus.BAD_REQUEST);
+    expect(payload.body).toMatchObject({
+      code: 'BAD_REQUEST',
+      message: ErrorMessage.BAD_REQUEST,
     });
   });
 

--- a/src/common/exception/http-exception.filter.spec.ts
+++ b/src/common/exception/http-exception.filter.spec.ts
@@ -1,13 +1,19 @@
 import {
   ArgumentsHost,
   BadRequestException,
+  Body,
+  Controller,
   HttpException,
   HttpStatus,
+  INestApplication,
   PayloadTooLargeException,
+  Post,
   UnauthorizedException,
   ValidationPipe,
 } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
 import { IsNotEmpty, IsString } from 'class-validator';
+import request from 'supertest';
 
 import { ErrorMessage } from '../error/error-message';
 import { AppException } from './app.exception';
@@ -121,5 +127,60 @@ describe('HttpExceptionFilter', () => {
       message: ErrorMessage.ALREADY_SUBMITTED,
       data: null,
     });
+  });
+});
+
+@Controller('drafts')
+class DraftProbeController {
+  @Post()
+  save(@Body() body: unknown) {
+    return { size: JSON.stringify(body).length };
+  }
+}
+
+describe('HttpExceptionFilter — Express 미들웨어가 던진 오류', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [DraftProbeController],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.useGlobalFilters(new HttpExceptionFilter());
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('본문이 express.json() 한도를 넘으면 500 이 아니라 413 으로 내려준다', async () => {
+    // 긴 지원서를 임시저장·제출하는 경로다. body-parser 는 NestJS HttpException 이 아니라
+    // http-errors 객체를 던지므로, 걸러내지 않으면 지원자가 원인 모를 500 을 받고 작성분을 잃는다.
+    // Given
+    const oversizedDraft = { answers: '가'.repeat(200_000) };
+
+    // When
+    const response = await request(app.getHttpServer()).post('/drafts').send(oversizedDraft);
+
+    // Then
+    expect(response.status).toBe(HttpStatus.PAYLOAD_TOO_LARGE);
+    expect(response.body).toEqual({
+      code: 'PAYLOAD_TOO_LARGE',
+      message: ErrorMessage.PAYLOAD_TOO_LARGE,
+      data: null,
+    });
+  });
+
+  it('한도 안쪽 본문은 정상 처리된다', async () => {
+    // Given
+    const draft = { answers: '가'.repeat(100) };
+
+    // When
+    const response = await request(app.getHttpServer()).post('/drafts').send(draft);
+
+    // Then
+    expect(response.status).toBe(HttpStatus.CREATED);
   });
 });

--- a/src/common/exception/http-exception.filter.ts
+++ b/src/common/exception/http-exception.filter.ts
@@ -39,6 +39,19 @@ export class HttpExceptionFilter implements ExceptionFilter {
       return;
     }
 
+    // body-parser 같은 Express 미들웨어는 NestJS HttpException 이 아니라 http-errors 객체를
+    // 던진다. 대표적으로 본문이 express.json() 한도를 넘으면 status 413 짜리 객체가 올라오는데,
+    // 여기서 걸러내지 않으면 아래 일반 처리로 떨어져 500 이 나간다. 긴 지원서를 임시저장·제출하는
+    // 경로가 정확히 이것이라, 지원자는 원인도 모른 채 작성분을 잃는다.
+    // 5xx 는 넘기지 않는다. 서버 잘못은 아래에서 스택과 함께 로그로 남아야 한다.
+    const middlewareStatus = this.resolveMiddlewareErrorStatus(exception);
+
+    if (middlewareStatus) {
+      const code = this.resolveCode(HttpStatus[middlewareStatus], middlewareStatus);
+      response.status(middlewareStatus).json(ApiResponse.fail(code, ErrorMessage[code]));
+      return;
+    }
+
     this.logger.error(
       `Unhandled exception on ${request.method} ${request.url}`,
       exception instanceof Error ? exception.stack : String(exception),
@@ -47,6 +60,22 @@ export class HttpExceptionFilter implements ExceptionFilter {
     response
       .status(HttpStatus.INTERNAL_SERVER_ERROR)
       .json(ApiResponse.fail('INTERNAL_SERVER_ERROR', ErrorMessage.INTERNAL_SERVER_ERROR));
+  }
+
+  // http-errors 규약상 클라이언트 잘못은 status 4xx 로 실려온다. 그 범위만 받아 상태 코드를
+  // 살리고, 문구는 프레임워크 영문이 섞이지 않도록 ErrorMessage 에서만 가져온다.
+  private resolveMiddlewareErrorStatus(exception: unknown): number | null {
+    if (typeof exception !== 'object' || exception === null) {
+      return null;
+    }
+
+    const status = (exception as { status?: unknown }).status;
+
+    if (typeof status !== 'number' || status < 400 || status >= 500) {
+      return null;
+    }
+
+    return status;
   }
 
   private resolveMessage(

--- a/src/common/exception/http-exception.filter.ts
+++ b/src/common/exception/http-exception.filter.ts
@@ -71,6 +71,13 @@ export class HttpExceptionFilter implements ExceptionFilter {
       return ErrorMessage[code];
     }
 
+    // multer 의 파일 크기 초과는 PayloadTooLargeException('File too large') 로 올라온다. 설명이
+    // 붙어 있어 위 판별을 통과하지만 영문이므로 사용자에게 그대로 보이면 안 된다. 413 은 우리
+    // 코드가 직접 던지지 않으니(전부 AppException) 항상 프레임워크발로 보고 한국어로 덮는다.
+    if (code === 'PAYLOAD_TOO_LARGE') {
+      return ErrorMessage[code];
+    }
+
     const raw = responseBody.message;
 
     if (Array.isArray(raw)) {

--- a/src/common/exception/http-exception.filter.ts
+++ b/src/common/exception/http-exception.filter.ts
@@ -88,32 +88,23 @@ export class HttpExceptionFilter implements ExceptionFilter {
     }
 
     const responseBody = exceptionResponse as Record<string, unknown>;
-
-    // NestJS 가 설명 없이 만든 예외의 응답 본문은 message 와 statusCode 딱 두 키다. 이때 message 는
-    // 'Unauthorized' 같은 프레임워크 영문 문구이므로 사용자에게 그대로 노출하지 않는다.
-    // 설명을 직접 넘기면 error 가, 커스텀 객체를 넘기면 그 밖의 키가 함께 오므로 원문을 보존한다.
-    const isFrameworkDefault = Object.keys(responseBody).every(
-      (key) => key === 'message' || key === 'statusCode',
-    );
-
-    if (isFrameworkDefault) {
-      return ErrorMessage[code];
-    }
-
-    // multer 의 파일 크기 초과는 PayloadTooLargeException('File too large') 로 올라온다. 설명이
-    // 붙어 있어 위 판별을 통과하지만 영문이므로 사용자에게 그대로 보이면 안 된다. 413 은 우리
-    // 코드가 직접 던지지 않으니(전부 AppException) 항상 프레임워크발로 보고 한국어로 덮는다.
-    if (code === 'PAYLOAD_TOO_LARGE') {
-      return ErrorMessage[code];
-    }
-
     const raw = responseBody.message;
 
+    // ValidationPipe 는 DTO 데코레이터에 적은 문구를 배열로 싣는다. 아래 판별보다 먼저 걸러야 한다.
     if (Array.isArray(raw)) {
       return raw.join(', ');
     }
 
-    return raw?.toString() ?? exception.message;
+    // 우리 예외는 전부 AppException 이고 위에서 이미 처리됐다. 프로덕션 코드에는 NestJS 내장 예외를
+    // 직접 만드는 곳이 없으므로, 여기까지 온 message 는 'Unauthorized', 'File too large',
+    // 'Validation failed (numeric string is expected)' 같은 프레임워크 영문이다.
+    // 설명을 붙여 던지면 error 키가 함께 붙어 '설명 없는 기본 문구인지' 로는 가려낼 수 없다.
+    // 그래서 우리가 만든 본문임을 나타내는 code 키가 있을 때만 원문을 보존한다.
+    if ('code' in responseBody) {
+      return raw?.toString() ?? exception.message;
+    }
+
+    return ErrorMessage[code];
   }
 
   private resolveCode(statusName: string | undefined, status: number): ErrorMessageKey {


### PR DESCRIPTION
## 개요

첨부파일 용량 초과 시 영문 `File too large` 가 지원자 화면에 노출되던 문제(#78)에서 출발해, **같은 버그 클래스의 근본 원인**까지 정정합니다. 리뷰 2건을 반영해 범위가 넓어졌습니다.

## 변경 이유

`HttpExceptionFilter.resolveMessage` 는 "응답 본문의 키가 `message` 와 `statusCode` 뿐인가"로 프레임워크 기본 문구를 가려냈습니다. 그런데 **NestJS 내장 예외는 설명을 붙이면 `error` 키가 함께 붙어 키가 3개가 됩니다.** 즉 설명이 달린 프레임워크 영문은 전부 이 판별을 빠져나가 그대로 사용자에게 도달했습니다.

실제로 노출되던 것들:

| 경로 | 노출 문구 |
|---|---|
| multer `LIMIT_FILE_SIZE` (이슈 #78) | `File too large` |
| multer `LIMIT_UNEXPECTED_FILE` — 프론트가 필드명을 틀리면 발생 | `Unexpected field - <field>` |
| multer boundary 누락 | `Multipart: Boundary not found` |
| `ParseIntPipe` — 공개 컨트롤러 3곳 포함 36곳 | `Validation failed (numeric string is expected)` |
| `ParseUUIDPipe` | `Validation failed (uuid is expected)` |
| 404 | `Cannot GET /<경로>` |

추가로 `HttpStatus[413] = 'PAYLOAD_TOO_LARGE'` 가 `ErrorMessage` 에 없어 413 응답에 `code: 'BAD_REQUEST'` 가 붙었고, express `json()` 한도(기본 100kb) 초과는 아예 **413이 아니라 500**으로 나가고 있었습니다.

## 주요 변경 사항

커밋 3개로 나눠 두었습니다.

**1. `d1c8831` — 413 code 오분류 + multer 영문 노출**
`ErrorMessage` 에 `PAYLOAD_TOO_LARGE` 추가. `resolveCode` 가 이미 `HttpStatus[status]` 이름으로 조회하므로 키 추가만으로 code 매핑이 따라옵니다.

**2. `1f296aa` — body-parser 413이 500으로 나가던 문제**
body-parser 가 던지는 것은 `HttpException` 이 아니라 `http-errors` 객체라 `instanceof HttpException` 분기를 통과하지 못하고 미처리 분기로 떨어졌습니다. 결과는 클라이언트 오류(413)의 500 분류 + 매 요청 `logger.error` 스택 기록이었습니다. 4xx `http-errors` 만 흡수하는 분기를 추가했습니다(5xx 는 그대로 스택과 함께 로그로 남깁니다).

**3. `c699102` — 판별식 전환 (근본 원인)**
`code` 키가 있을 때만 원문을 보존하는 화이트리스트로 뒤집었습니다. 프로덕션 코드에 NestJS 내장 예외 직접 생성이 **0건**이고 우리 예외는 전부 `AppException`(필터 첫 분기에서 처리)이라 이 전제가 성립합니다. `ValidationPipe` 의 배열은 DTO 에 적은 문구이므로 판별보다 앞에서 보존합니다. 이 전환으로 위 표의 6개 경로가 한 번에 닫히고, 1번의 413 특례 분기는 삭제됐습니다.

문구는 `'요청 용량이 제한을 초과했습니다.'` 로 중립화했습니다. 2번으로 body-parser 경로도 413 이 되었기 때문에, 첨부가 없는 임시저장 요청에 "첨부파일 크기를 확인해주세요" 가 나가면 오답 안내가 됩니다.

## 이슈 #78 의 해결 방향 2번을 택하지 않은 이유

`FileInterceptor` 의 `limits` 를 제거하고 `StorageService` 검증에 일임하면, 20MB PDF 를 전부 메모리에 버퍼링한 뒤에야 거부하게 됩니다. 구글 로그인만으로 도달 가능한 공개 경로라 신뢰 경계의 검증을 뒤로 미루지 않았습니다.

## 아키텍처 영향

- 도메인 분리: 변경 없음
- 레이어 변경: 없음 (`src/common/error`, `src/common/exception` 내부)
- 의존 방향 영향: 없음
- 트랜잭션 경계 영향: 없음

## 테스트

- [x] 단위 테스트
- [x] 통합 테스트 (supertest 로 실제 Nest 앱을 띄워 body-parser 413 검증)
- [ ] 수동 테스트
- 확인 내용: `yarn test` 44 suite / 416 tests 통과, `yarn lint`·`yarn build` 통과. 필터 스펙 9건 중 신규 4건 — multer 413, multer 필드명 불일치, `ParseIntPipe`, body-parser 413(+한도 안쪽 정상 처리).

## 리뷰 포인트

- **판별식 전환이 이 PR의 핵심입니다.** 근거는 "프로덕션 코드에 `new *Exception(...)` 직접 호출 0건" 이며 리뷰 2건이 각각 독립적으로 검증했습니다. 앞으로 내장 예외에 한국어 설명을 직접 붙여 던질 계획이 있다면 이 전제가 깨집니다 — 그때는 `new HttpException({ code, message }, status)` 형태를 쓰면 원문이 보존됩니다.
- **에러 계약 변경 2건** — 413 응답의 `code` 가 `BAD_REQUEST` → `PAYLOAD_TOO_LARGE` 로, 설명이 달린 프레임워크 예외의 `message` 가 영문 → 한국어 공통 문구로 바뀝니다. 프론트가 `code` 나 영문 `message` 로 분기하고 있다면 확인이 필요합니다. HTTP 상태코드는 그대로입니다.
- `ParseIntPipe` 의 "어느 파라미터가 틀렸는가" 정보가 사라집니다. 어차피 영문이라 사용자에게 실행 가능한 정보가 아니었다고 판단했습니다.

## 리스크 / 후속 작업

- **`ValidationPipe` 배열은 여전히 영문입니다.** DTO 77개 validator 중 `message:` 오버라이드는 1개뿐이고 그마저 영문이라, 지원서 제출 실패 시 `applicantName should not be empty` 같은 문구가 그대로 나갑니다. 노출 빈도로는 이번 이슈보다 높을 수 있어 별도 티켓 권장.
- **파일 용량 초과 계약이 두 갈래입니다** — 지원자 경로는 multer 가 먼저 걸려 413/`PAYLOAD_TOO_LARGE`, `StorageService` 는 400/`FILE_SIZE_EXCEEDED`. 프론트와 한 번 맞출 필요가 있습니다.
- **`admin.storage.controller.ts:54` 에는 `limits` 가 없습니다.** 공개 경로에서 `limits` 를 유지한 메모리 논거가 여기에도 적용됩니다(관리자 롤 게이트 뒤라 위협도는 낮음).
- `main.ts` 에 body limit 이 명시돼 있지 않아 암묵적 100kb 입니다. 명시적 한도 설정을 권장합니다.

## 관련 이슈

- Closes #78
