### PR TITLE
fix(validation): 지원서 입력 검증 실패 문구를 한국어로 전환

### DIFF
--- a/src/application/interface/dto/application.request.dto.ts
+++ b/src/application/interface/dto/application.request.dto.ts
@@ -39,7 +39,7 @@ export class SubmitApplicationRequestDto {
   @IsString()
   @IsNotEmpty()
   @Matches(/^01[0-9]-?\d{3,4}-?\d{4}$/, {
-    message: 'applicantPhone must be a valid Korean mobile number',
+    message: '휴대폰 번호 형식이 올바르지 않습니다.',
   })
   applicantPhone: string;
 

--- a/src/common/error/validation-message.spec.ts
+++ b/src/common/error/validation-message.spec.ts
@@ -1,5 +1,24 @@
-import { BadRequestException, ValidationPipe } from '@nestjs/common';
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  HttpStatus,
+  INestApplication,
+  Post,
+  ValidationPipe,
+} from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { Type } from 'class-transformer';
 import type { ValidationError } from 'class-validator';
+import {
+  ArrayMinSize,
+  ArrayUnique,
+  IsISO8601,
+  IsNotEmpty,
+  Length,
+  ValidateNested,
+} from 'class-validator';
+import request from 'supertest';
 
 import {
   ApplicationAdminFilterDto,
@@ -9,6 +28,8 @@ import {
 import { UpdateCohortPartsRequestDto } from '../../cohort/interface/dto/admin-cohort.request.dto';
 import { UpdateProjectMembersRequestDto } from '../../project/interface/dto/project.request.dto';
 import { AssignUserRolesRequestDto } from '../../user/interface/dto/bootstrap-user.request.dto';
+import { HttpExceptionFilter } from '../exception/http-exception.filter';
+import { ApiResponse } from '../response/api-response';
 import { toKoreanValidationMessages } from './validation-message';
 
 const runValidation = async ({
@@ -45,6 +66,31 @@ const descriptionOf = (message: string): string => {
 
   return separator === -1 ? message : message.slice(separator + 2);
 };
+
+class NestedProbeDto {
+  @IsNotEmpty()
+  name!: string;
+}
+
+// class-validator 의 제약 이름은 데코레이터 이름과 다를 수 있다(@IsISO8601 → isIso8601 등).
+// 매핑 키를 눈으로 유추하면 틀리므로 실제 데코레이터가 만드는 키로 검증한다.
+class ConstraintProbeDto {
+  @IsISO8601()
+  iso!: string;
+
+  @ArrayUnique()
+  unique!: string[];
+
+  @ArrayMinSize(1)
+  minSize!: string[];
+
+  @Length(2, 5)
+  length!: string;
+
+  @ValidateNested()
+  @Type(() => NestedProbeDto)
+  nested!: NestedProbeDto;
+}
 
 describe('toKoreanValidationMessages', () => {
   // 한글 enum(ApplicationStatus.서류합격, UserRole.운영자)을 쓰는 DTO 를 반드시 포함한다.
@@ -144,6 +190,33 @@ describe('toKoreanValidationMessages', () => {
     expect(messages).toEqual(['someField: 입력값이 올바르지 않습니다.']);
   });
 
+  it('제약 이름이 데코레이터 이름과 어긋나는 것들도 정확한 문구로 이어진다', async () => {
+    // 매핑 키를 잘못 적으면 폴백 문구로 조용히 떨어진다. '영문이 없다' 단언만으로는 그 회귀를
+    // 잡을 수 없으므로(폴백도 한국어다) 실제 데코레이터를 붙여 문구까지 대조한다.
+    // Given
+    const invalid = {
+      iso: 'not-a-date',
+      unique: ['a', 'a'],
+      minSize: [],
+      length: 'x',
+      nested: 'not-an-object',
+    };
+
+    // When
+    const messages = await runValidation({ metatype: ConstraintProbeDto, value: invalid });
+
+    // Then
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        'iso: 날짜 형식이 올바르지 않습니다.',
+        'unique: 중복된 항목이 있습니다.',
+        'minSize: 항목을 하나 이상 선택해주세요.',
+        'length: 입력 길이가 올바르지 않습니다.',
+        'nested: 하위 항목이 올바르지 않습니다.',
+      ]),
+    );
+  });
+
   it('property 가 없는 에러는 콜론만 남기지 않는다', () => {
     // forbidUnknownValues 로 걸리면 property 가 undefined 로 온다.
     // Given
@@ -156,5 +229,71 @@ describe('toKoreanValidationMessages', () => {
 
     // Then
     expect(messages).toEqual(['입력값이 올바르지 않습니다.']);
+  });
+});
+
+@Controller('applications')
+class ApplicationProbeController {
+  @Post()
+  submit(@Body() _command: SubmitApplicationRequestDto) {
+    return ApiResponse.ok(null, '지원서 제출이 완료되었습니다.');
+  }
+}
+
+// 위 테스트들은 ValidationPipe 만 본다. 파이프가 만든 예외가 전역 필터를 지나 실제 응답이 될 때
+// 공통 envelope 이 유지되는지는 별개 문제라 HTTP 레벨로 확인한다.
+describe('검증 실패 응답 (HTTP)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [ApplicationProbeController],
+    }).compile();
+
+    // main.ts 와 같은 구성이다. 부트스트랩 코드는 직접 테스트할 수 없으므로 재현한다.
+    app = moduleRef.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        transform: true,
+        exceptionFactory: (errors) => new BadRequestException(toKoreanValidationMessages(errors)),
+      }),
+    );
+    app.useGlobalFilters(new HttpExceptionFilter());
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('공통 envelope 을 유지하면서 message 만 한국어로 내려준다', async () => {
+    // When
+    const response = await request(app.getHttpServer()).post('/applications').send({});
+
+    // Then
+    expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+    expect(response.body.code).toBe('BAD_REQUEST');
+    expect(response.body.data).toBeNull();
+    expect(response.body.message).toContain('필수 항목입니다.');
+    expect(response.body.message).not.toMatch(/must be|should not|Validation failed/);
+  });
+
+  it('검증을 통과한 요청은 그대로 처리된다', async () => {
+    // Given
+    const validForm = {
+      cohortPartId: 1,
+      applicantName: '홍길동',
+      applicantPhone: '010-1234-5678',
+      answers: { motivation: '지원 동기' },
+      privacyAgreed: true,
+    };
+
+    // When
+    const response = await request(app.getHttpServer()).post('/applications').send(validForm);
+
+    // Then
+    expect(response.status).toBe(HttpStatus.CREATED);
+    expect(response.body.code).toBe('SUCCESS');
   });
 });

--- a/src/common/error/validation-message.spec.ts
+++ b/src/common/error/validation-message.spec.ts
@@ -1,37 +1,82 @@
 import { BadRequestException, ValidationPipe } from '@nestjs/common';
 import type { ValidationError } from 'class-validator';
 
-import { SubmitApplicationRequestDto } from '../../application/interface/dto/application.request.dto';
+import {
+  ApplicationAdminFilterDto,
+  SubmitApplicationRequestDto,
+  UpdateApplicationStatusRequestDto,
+} from '../../application/interface/dto/application.request.dto';
+import { UpdateCohortPartsRequestDto } from '../../cohort/interface/dto/admin-cohort.request.dto';
+import { UpdateProjectMembersRequestDto } from '../../project/interface/dto/project.request.dto';
+import { AssignUserRolesRequestDto } from '../../user/interface/dto/bootstrap-user.request.dto';
 import { toKoreanValidationMessages } from './validation-message';
 
-const runValidation = async (value: unknown): Promise<string[]> => {
+const runValidation = async ({
+  metatype,
+  value,
+}: {
+  metatype: unknown;
+  value: unknown;
+}): Promise<string[]> => {
   const pipe = new ValidationPipe({
     whitelist: true,
     transform: true,
     exceptionFactory: (errors) => new BadRequestException(toKoreanValidationMessages(errors)),
   });
 
-  const error = await pipe
-    .transform(value, { type: 'body', metatype: SubmitApplicationRequestDto })
-    .then(() => null)
-    .catch((thrown: unknown) => thrown);
+  try {
+    await pipe.transform(value, {
+      type: 'body',
+      metatype: metatype as new () => unknown,
+    });
+  } catch (error) {
+    if (error instanceof BadRequestException) {
+      return (error.getResponse() as { message: string[] }).message;
+    }
+    throw error;
+  }
 
-  const response = (error as BadRequestException).getResponse() as { message: string[] };
+  throw new Error(`검증이 통과했다. 실패해야 하는 케이스다: ${JSON.stringify(value)}`);
+};
 
-  return response.message;
+// 메시지는 '필드경로: 문구' 형태다. 필드명은 영문이 정상이므로 문구 쪽만 검사한다.
+const descriptionOf = (message: string): string => {
+  const separator = message.indexOf(': ');
+
+  return separator === -1 ? message : message.slice(separator + 2);
 };
 
 describe('toKoreanValidationMessages', () => {
-  it('실제 지원서 제출 DTO 가 비어 있을 때 영문 문구가 하나도 남지 않는다', async () => {
-    // 지원자가 가장 자주 실패하는 화면이다. 예전에는 'applicantName should not be empty' 가 그대로 갔다.
+  // 한글 enum(ApplicationStatus.서류합격, UserRole.운영자)을 쓰는 DTO 를 반드시 포함한다.
+  // class-validator 가 enum 값을 기본 문구에 끼워 넣어 'must be one of the following values:
+  // 서류합격, ...' 처럼 한글 섞인 영문이 만들어지는데, 이게 판별을 통과해 노출된 적이 있다.
+  it.each([
+    ['SubmitApplicationRequestDto (필수 누락)', SubmitApplicationRequestDto, {}],
+    [
+      'UpdateApplicationStatusRequestDto (한글 enum)',
+      UpdateApplicationStatusRequestDto,
+      { status: 'not-a-status' },
+    ],
+    ['ApplicationAdminFilterDto (한글 enum)', ApplicationAdminFilterDto, { status: 'nope' }],
+    [
+      'AssignUserRolesRequestDto (한글 enum + 중복)',
+      AssignUserRolesRequestDto,
+      { roles: ['운영자', '운영자', 'nope'] },
+    ],
+    [
+      'UpdateProjectMembersRequestDto (중첩 검증)',
+      UpdateProjectMembersRequestDto,
+      { members: [{}] },
+    ],
+    ['UpdateCohortPartsRequestDto (배열 최소 크기)', UpdateCohortPartsRequestDto, { parts: [] }],
+  ])('%s 는 문구에 영문을 남기지 않는다', async (_label, metatype, value) => {
     // Given & When
-    const messages = await runValidation({});
+    const messages = await runValidation({ metatype, value });
 
     // Then
     expect(messages.length).toBeGreaterThan(0);
-    expect(messages.join(' ')).not.toMatch(/must be|should not|Validation failed/);
     messages.forEach((message) => {
-      expect(message).toMatch(/[가-힣]/);
+      expect(descriptionOf(message)).not.toMatch(/[A-Za-z]{2,}/);
     });
   });
 
@@ -40,10 +85,32 @@ describe('toKoreanValidationMessages', () => {
     const invalidPhone = { applicantPhone: '01012' };
 
     // When
-    const messages = await runValidation(invalidPhone);
+    const messages = await runValidation({
+      metatype: SubmitApplicationRequestDto,
+      value: invalidPhone,
+    });
 
     // Then
     expect(messages).toContain('applicantPhone: 휴대폰 번호 형식이 올바르지 않습니다.');
+  });
+
+  it('한글이 섞인 프레임워크 기본 문구는 우리 문구로 오인하지 않는다', () => {
+    // 한글 enum 값이 영문 템플릿에 치환된 형태다. 한글만 보고 판별하면 이 문구가 그대로 나간다.
+    // Given
+    const koreanEnumLeak = [
+      {
+        property: 'status',
+        constraints: {
+          isEnum: 'status must be one of the following values: 서류합격, 최종합격',
+        },
+      },
+    ] as unknown as ValidationError[];
+
+    // When
+    const messages = toKoreanValidationMessages(koreanEnumLeak);
+
+    // Then
+    expect(messages).toEqual(['status: 선택할 수 없는 값입니다.']);
   });
 
   it('중첩 객체는 경로를 점으로 이어 어느 항목인지 알려준다', () => {
@@ -75,5 +142,19 @@ describe('toKoreanValidationMessages', () => {
 
     // Then
     expect(messages).toEqual(['someField: 입력값이 올바르지 않습니다.']);
+  });
+
+  it('property 가 없는 에러는 콜론만 남기지 않는다', () => {
+    // forbidUnknownValues 로 걸리면 property 가 undefined 로 온다.
+    // Given
+    const withoutProperty = [
+      { constraints: { unknownValue: 'an unknown value was passed to the validate function' } },
+    ] as unknown as ValidationError[];
+
+    // When
+    const messages = toKoreanValidationMessages(withoutProperty);
+
+    // Then
+    expect(messages).toEqual(['입력값이 올바르지 않습니다.']);
   });
 });

--- a/src/common/error/validation-message.spec.ts
+++ b/src/common/error/validation-message.spec.ts
@@ -1,0 +1,79 @@
+import { BadRequestException, ValidationPipe } from '@nestjs/common';
+import type { ValidationError } from 'class-validator';
+
+import { SubmitApplicationRequestDto } from '../../application/interface/dto/application.request.dto';
+import { toKoreanValidationMessages } from './validation-message';
+
+const runValidation = async (value: unknown): Promise<string[]> => {
+  const pipe = new ValidationPipe({
+    whitelist: true,
+    transform: true,
+    exceptionFactory: (errors) => new BadRequestException(toKoreanValidationMessages(errors)),
+  });
+
+  const error = await pipe
+    .transform(value, { type: 'body', metatype: SubmitApplicationRequestDto })
+    .then(() => null)
+    .catch((thrown: unknown) => thrown);
+
+  const response = (error as BadRequestException).getResponse() as { message: string[] };
+
+  return response.message;
+};
+
+describe('toKoreanValidationMessages', () => {
+  it('실제 지원서 제출 DTO 가 비어 있을 때 영문 문구가 하나도 남지 않는다', async () => {
+    // 지원자가 가장 자주 실패하는 화면이다. 예전에는 'applicantName should not be empty' 가 그대로 갔다.
+    // Given & When
+    const messages = await runValidation({});
+
+    // Then
+    expect(messages.length).toBeGreaterThan(0);
+    expect(messages.join(' ')).not.toMatch(/must be|should not|Validation failed/);
+    messages.forEach((message) => {
+      expect(message).toMatch(/[가-힣]/);
+    });
+  });
+
+  it('DTO 에 직접 적은 한국어 문구는 제약별 공통 문구로 덮지 않는다', async () => {
+    // Given
+    const invalidPhone = { applicantPhone: '01012' };
+
+    // When
+    const messages = await runValidation(invalidPhone);
+
+    // Then
+    expect(messages).toContain('applicantPhone: 휴대폰 번호 형식이 올바르지 않습니다.');
+  });
+
+  it('중첩 객체는 경로를 점으로 이어 어느 항목인지 알려준다', () => {
+    // Given
+    const nested = [
+      {
+        property: 'answers',
+        children: [
+          { property: 'motivation', constraints: { isNotEmpty: 'motivation should not be empty' } },
+        ],
+      },
+    ] as ValidationError[];
+
+    // When
+    const messages = toKoreanValidationMessages(nested);
+
+    // Then
+    expect(messages).toEqual(['answers.motivation: 필수 항목입니다.']);
+  });
+
+  it('매핑에 없는 제약은 공통 문구로 내려간다', () => {
+    // Given
+    const unknownConstraint = [
+      { property: 'someField', constraints: { isSomethingNew: 'someField is invalid' } },
+    ] as unknown as ValidationError[];
+
+    // When
+    const messages = toKoreanValidationMessages(unknownConstraint);
+
+    // Then
+    expect(messages).toEqual(['someField: 입력값이 올바르지 않습니다.']);
+  });
+});

--- a/src/common/error/validation-message.ts
+++ b/src/common/error/validation-message.ts
@@ -1,0 +1,56 @@
+import type { ValidationError } from 'class-validator';
+
+// class-validator 는 제약이 깨지면 'applicantName should not be empty' 같은 영문을 만든다.
+// 이 문구는 지원서 제출 실패처럼 지원자가 가장 자주 마주치는 화면에 그대로 노출된다.
+// DTO 77 곳에 message 를 하나씩 다는 대신 제약 이름당 한 줄로 옮겨 둔다. DTO 가 늘어도 자동 적용된다.
+const CONSTRAINT_MESSAGE: Record<string, string> = {
+  isNotEmpty: '필수 항목입니다.',
+  arrayNotEmpty: '항목을 하나 이상 선택해주세요.',
+  isString: '문자로 입력해주세요.',
+  isNumber: '숫자로 입력해주세요.',
+  isInt: '정수로 입력해주세요.',
+  isPositive: '0 보다 큰 값을 입력해주세요.',
+  isBoolean: '참 또는 거짓 값이어야 합니다.',
+  isArray: '목록 형태여야 합니다.',
+  isObject: '올바른 형식이 아닙니다.',
+  isEnum: '선택할 수 없는 값입니다.',
+  isEmail: '이메일 형식이 올바르지 않습니다.',
+  isUrl: '주소(URL) 형식이 올바르지 않습니다.',
+  isDate: '날짜 형식이 올바르지 않습니다.',
+  isDateString: '날짜 형식이 올바르지 않습니다.',
+  matches: '형식이 올바르지 않습니다.',
+  min: '허용된 최솟값보다 작습니다.',
+  max: '허용된 최댓값보다 큽니다.',
+  minLength: '입력이 너무 짧습니다.',
+  maxLength: '입력이 너무 깁니다.',
+};
+
+const FALLBACK_MESSAGE = '입력값이 올바르지 않습니다.';
+
+// DTO 데코레이터에 우리가 직접 적은 문구는 제약별 공통 문구보다 구체적이므로 살린다.
+// class-validator 가 만드는 기본 문구는 항상 영문이라 한글 포함 여부로 갈라도 오판하지 않는다.
+const hasHangul = (message: string): boolean => /[가-힣]/.test(message);
+
+const resolveMessage = ({
+  constraint,
+  rawMessage,
+}: {
+  constraint: string;
+  rawMessage: string;
+}): string => {
+  if (hasHangul(rawMessage)) {
+    return rawMessage;
+  }
+
+  return CONSTRAINT_MESSAGE[constraint] ?? FALLBACK_MESSAGE;
+};
+
+export const toKoreanValidationMessages = (errors: ValidationError[], parentPath = ''): string[] =>
+  errors.flatMap((error) => {
+    const path = parentPath ? `${parentPath}.${error.property}` : error.property;
+    const own = Object.entries(error.constraints ?? {}).map(
+      ([constraint, rawMessage]) => `${path}: ${resolveMessage({ constraint, rawMessage })}`,
+    );
+
+    return [...own, ...toKoreanValidationMessages(error.children ?? [], path)];
+  });

--- a/src/common/error/validation-message.ts
+++ b/src/common/error/validation-message.ts
@@ -3,9 +3,14 @@ import type { ValidationError } from 'class-validator';
 // class-validator 는 제약이 깨지면 'applicantName should not be empty' 같은 영문을 만든다.
 // 이 문구는 지원서 제출 실패처럼 지원자가 가장 자주 마주치는 화면에 그대로 노출된다.
 // DTO 77 곳에 message 를 하나씩 다는 대신 제약 이름당 한 줄로 옮겨 둔다. DTO 가 늘어도 자동 적용된다.
+// 키는 데코레이터 이름이 아니라 class-validator 의 제약 이름이다. @ValidateNested 가
+// nestedValidation, @IsISO8601 이 isIso8601 처럼 어긋나는 것들이 있어 데코레이터 이름으로
+// 유추하면 조용히 폴백 문구로 떨어진다.
 const CONSTRAINT_MESSAGE: Record<string, string> = {
   isNotEmpty: '필수 항목입니다.',
   arrayNotEmpty: '항목을 하나 이상 선택해주세요.',
+  arrayMinSize: '항목을 하나 이상 선택해주세요.',
+  arrayUnique: '중복된 항목이 있습니다.',
   isString: '문자로 입력해주세요.',
   isNumber: '숫자로 입력해주세요.',
   isInt: '정수로 입력해주세요.',
@@ -14,22 +19,35 @@ const CONSTRAINT_MESSAGE: Record<string, string> = {
   isArray: '목록 형태여야 합니다.',
   isObject: '올바른 형식이 아닙니다.',
   isEnum: '선택할 수 없는 값입니다.',
+  isIn: '선택할 수 없는 값입니다.',
   isEmail: '이메일 형식이 올바르지 않습니다.',
-  isUrl: '주소(URL) 형식이 올바르지 않습니다.',
+  isUrl: '주소 형식이 올바르지 않습니다.',
   isDate: '날짜 형식이 올바르지 않습니다.',
   isDateString: '날짜 형식이 올바르지 않습니다.',
+  isIso8601: '날짜 형식이 올바르지 않습니다.',
   matches: '형식이 올바르지 않습니다.',
   min: '허용된 최솟값보다 작습니다.',
   max: '허용된 최댓값보다 큽니다.',
   minLength: '입력이 너무 짧습니다.',
   maxLength: '입력이 너무 깁니다.',
+  isLength: '입력 길이가 올바르지 않습니다.',
+  nestedValidation: '하위 항목이 올바르지 않습니다.',
 };
 
 const FALLBACK_MESSAGE = '입력값이 올바르지 않습니다.';
 
 // DTO 데코레이터에 우리가 직접 적은 문구는 제약별 공통 문구보다 구체적이므로 살린다.
-// class-validator 가 만드는 기본 문구는 항상 영문이라 한글 포함 여부로 갈라도 오판하지 않는다.
-const hasHangul = (message: string): boolean => /[가-힣]/.test(message);
+//
+// '한글이 있으면 우리 문구' 로는 부족하다. CODE_RULES 가 도메인 상태어에 한글 enum 을 허용해서
+// (ApplicationStatus.서류합격, UserRole.운영자) @IsEnum 의 기본 문구가
+// 'status must be one of the following values: 서류합격, ...' 처럼 한글을 품고 나온다.
+// 그래서 한글이 있고 + 영문 단어가 없어야 우리 문구로 본다.
+//
+// ponytail: 휴리스틱이다. 한국어 문구에 영문 약어를 섞으면('PDF 만 첨부할 수 있습니다')
+// 공통 문구로 덮인다. 그런 문구가 필요해지면 데코레이터의 context 옵션으로
+// 명시 마킹하는 방식으로 올린다.
+const isOurMessage = (message: string): boolean =>
+  /[가-힣]/.test(message) && !/[A-Za-z]{2,}/.test(message);
 
 const resolveMessage = ({
   constraint,
@@ -38,7 +56,7 @@ const resolveMessage = ({
   constraint: string;
   rawMessage: string;
 }): string => {
-  if (hasHangul(rawMessage)) {
+  if (isOurMessage(rawMessage)) {
     return rawMessage;
   }
 
@@ -47,10 +65,13 @@ const resolveMessage = ({
 
 export const toKoreanValidationMessages = (errors: ValidationError[], parentPath = ''): string[] =>
   errors.flatMap((error) => {
-    const path = parentPath ? `${parentPath}.${error.property}` : error.property;
-    const own = Object.entries(error.constraints ?? {}).map(
-      ([constraint, rawMessage]) => `${path}: ${resolveMessage({ constraint, rawMessage })}`,
-    );
+    // forbidUnknownValues 로 걸린 에러는 property 가 없다. 그대로 두면 'undefined: ...' 가 나간다.
+    const path = parentPath ? `${parentPath}.${error.property}` : (error.property ?? '');
+    const own = Object.entries(error.constraints ?? {}).map(([constraint, rawMessage]) => {
+      const message = resolveMessage({ constraint, rawMessage });
+
+      return path ? `${path}: ${message}` : message;
+    });
 
     return [...own, ...toKoreanValidationMessages(error.children ?? [], path)];
   });

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,11 @@
-import { Logger, ValidationPipe, VersioningType } from '@nestjs/common';
+import { BadRequestException, Logger, ValidationPipe, VersioningType } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
 import cookieParser from 'cookie-parser';
 import { initializeTransactionalContext } from 'typeorm-transactional';
 
 import { AppModule } from './app.module';
+import { toKoreanValidationMessages } from './common/error/validation-message';
 import { ALLOWED_ORIGINS } from './config/cors.config';
 import { setupSwagger } from './config/swagger.config';
 
@@ -19,7 +20,14 @@ const bootstrap = async () => {
     credentials: true,
   });
 
-  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      transform: true,
+      // 기본 문구는 'applicantName should not be empty' 같은 영문이라 지원자에게 그대로 나간다.
+      exceptionFactory: (errors) => new BadRequestException(toKoreanValidationMessages(errors)),
+    }),
+  );
   app.setGlobalPrefix('api');
   app.enableVersioning({ type: VersioningType.URI });
 


### PR DESCRIPTION
## 개요

지원서 제출·임시저장 시 입력 검증에 실패하면 `applicantName should not be empty` 같은 영문이 지원자에게 그대로 노출되던 문제를 정정합니다. PR #79 의 후속입니다.

## 변경 이유

PR #79 로 프레임워크가 **자동 생성**하는 영문은 모두 한국어로 덮었습니다. 다만 `ValidationPipe` 가 만드는 메시지 배열은 "DTO 에 우리가 직접 적은 문구"로 취급해 원문을 보존합니다 — 필드별 구체적인 안내를 살리기 위해서입니다.

문제는 **그 자리에 한국어가 없었다**는 점입니다. DTO 77 곳의 validator 중 `message` 를 지정한 곳이 1 곳뿐이었고, 그마저 영문이었습니다.

```
POST /api/v1/applications  (필수 항목 누락)
→ "cohortPartId must be a number conforming to the specified constraints,
   applicantName should not be empty, applicantName must be a string, ..."
```

지원자가 가장 자주 마주치는 실패 화면이라, 노출 빈도로는 이슈 #78(첨부파일 용량 초과)보다 높습니다.

## 주요 변경 사항

**DTO 77 곳에 `message` 를 하나씩 다는 대신, 제약 이름당 한 줄로 옮겼습니다.** 앞으로 DTO 가 늘어도 자동 적용되고, 문구가 한 파일에 모여 있어 톤을 맞추기 쉽습니다.

- `src/common/error/validation-message.ts` 신규 — 제약 이름 26 종의 한국어 문구, 중첩 객체 경로 처리(`answers.motivation: 필수 항목입니다.`)
- `main.ts` 의 `ValidationPipe` 에 `exceptionFactory` 연결
- 유일하게 `message` 가 붙어 있던 `applicantPhone` 의 영문 문구를 한국어로 교체

응답 형태는 그대로입니다.

```
{ "code": "BAD_REQUEST",
  "message": "applicantName: 필수 항목입니다., applicantPhone: 휴대폰 번호 형식이 올바르지 않습니다.",
  "data": null }
```

## 리뷰 반영

리뷰 2건(자동 리뷰 포함)이 **실제 결함 2건**을 잡았습니다.

### `f8df757` — 한글 enum 앞에서 판별이 무너졌습니다

처음 구현은 "한글이 포함되면 우리가 적은 문구"로 판별했고, 주석에 "class-validator 기본 문구는 항상 영문"이라 적었습니다. **이 저장소에서는 사실이 아닙니다.** `CODE_RULES.md` 가 도메인 상태어에 한글 enum 을 허용하므로(`ApplicationStatus.서류합격`, `UserRole.운영자`), `@IsEnum` 기본 문구가 enum 값을 그대로 끼워 넣습니다.

```
status must be one of the following values: 서류합격, 최종합격, ...
```

한글이 섞였으니 "우리 문구"로 오인해 **영문이 그대로 노출**됐습니다. 관리자 지원 상태 변경·목록 필터·역할 부여 3 개 엔드포인트가 해당됐고, 한글 enum 은 규칙상 앞으로도 늘어나므로 일회성이 아니라 구조적 결함이었습니다. → `한글이 있고 + 영문 단어가 없음` 으로 정정.

**제약 매핑 5 종도 누락돼 있었습니다.** 제약 이름이 데코레이터 이름과 다른 것들입니다 — `@ValidateNested`→`nestedValidation`, `@IsISO8601`→`isIso8601`, `@ArrayMinSize`→`arrayMinSize`, `@ArrayUnique`→`arrayUnique`, `@Length`→`isLength`. 전부 폴백 문구로 떨어지고 있었습니다.

### `fcee60f` — 테스트가 회귀를 잡지 못했습니다

- 초기 테스트의 "메시지에 한글이 있다" 단언은 **한글 enum 누수를 그대로 통과**시켜 무의미했습니다. "문구 쪽에 영문 단어가 없다"로 바꾸고, 한글 enum DTO 3 개를 포함한 실제 DTO 6 개를 훑게 했습니다. 판별을 정정 전으로 되돌리면 정확히 4 건이 실패합니다.
- 폴백도 한국어이므로 위 단언으로는 **매핑 키 오타 회귀**를 잡을 수 없습니다. 제약 이름이 어긋나는 5 종을 실제 데코레이터로 붙여 문구까지 대조하는 테스트를 추가했습니다.
- 파이프 단독 테스트는 **전역 필터를 지난 최종 응답 envelope** 을 확인하지 못합니다. HTTP 레벨 테스트를 추가했습니다.

## 아키텍처 영향

- 도메인 분리: 변경 없음
- 레이어 변경: 없음 (`src/common/error` 추가, `main.ts` 부트스트랩 설정)
- 의존 방향 영향: 없음 — 주입 지점이 컴포지션 루트 하나뿐
- 트랜잭션 경계 영향: 없음

## 테스트

- [x] 단위 테스트
- [x] 통합 테스트
- [ ] 수동 테스트
- 확인 내용: `yarn test` 46 suite / 434 tests 통과, `yarn lint`·`yarn build` 통과. 신규 14건 —
  - 실제 DTO 6 개(한글 enum 3 개 포함)를 훑어 문구에 영문이 남지 않음
  - DTO 직접 문구 보존, 한글 섞인 프레임워크 문구를 우리 문구로 오인하지 않음
  - 제약 이름이 데코레이터 이름과 어긋나는 5 종의 정확한 문구
  - 중첩 경로, 미매핑 제약 폴백, `property` 없는 에러
  - HTTP 레벨 — 공통 envelope 유지 + 검증 통과 요청 정상 처리

## 리뷰 포인트

- **문구 톤을 봐 주세요.** `필수 항목입니다.` / `숫자로 입력해주세요.` / `형식이 올바르지 않습니다.` 처럼 짧게 잡았습니다. 필드명은 영문 그대로 앞에 붙습니다(`applicantName: 필수 항목입니다.`) — 프론트가 필드별로 표시하므로 한글 라벨 사전은 과하다고 판단했습니다.
- **판별은 휴리스틱입니다.** 한국어 문구에 영문 약어를 섞으면(`PDF 만 첨부할 수 있습니다`) 공통 문구로 덮입니다. 그런 문구가 필요해지면 데코레이터의 `context` 옵션으로 명시 마킹하는 방식으로 올려야 합니다. 코드에 `ponytail:` 주석으로 이 천장을 남겨 뒀습니다.
- `min`/`max`/`minLength`/`maxLength` 는 **구체적인 숫자를 넣지 않았습니다.** 기본 문구에서 숫자를 정규식으로 파싱해야 하는데 라이브러리 버전에 취약해서 `입력이 너무 짧습니다.` 수준으로 두었습니다.

## 리스크 / 후속 작업

- 에러 응답의 `message` 문자열이 영문에서 한국어로 바뀝니다. 상태코드(400)와 `code`(`BAD_REQUEST`)는 그대로입니다. 프론트가 영문 문구를 파싱하고 있다면 확인이 필요하지만, 영문 노출 자체가 버그였으므로 가능성은 낮습니다.
- `main.ts` 자체는 부트스트랩 코드라 직접 테스트할 수 없어, HTTP 테스트가 **같은 구성을 재현**하는 방식입니다.
- "DTO 의 `message` 는 한국어로만 적는다"는 팀 규칙이 필요합니다. 영문으로 적으면 공통 문구로 조용히 덮입니다 — 신규 테스트가 그 집행 장치 역할을 합니다.
- `openapi.json` 은 이 변경의 영향을 받지 않습니다(응답 스키마 불변).

## 관련 이슈

- PR #79 리뷰에서 후속 과제로 지목된 항목입니다.
