### PR TITLE
fix(storage): 업로드·본문 크기 정책의 빈틈 3건 정리

### DIFF
--- a/src/config/body-parser.config.spec.ts
+++ b/src/config/body-parser.config.spec.ts
@@ -1,0 +1,83 @@
+import { Body, Controller, HttpStatus, INestApplication, Post, Req } from '@nestjs/common';
+import type { NestExpressApplication } from '@nestjs/platform-express';
+import { Test } from '@nestjs/testing';
+import cookieParser from 'cookie-parser';
+import type { Request } from 'express';
+import request from 'supertest';
+
+import { ErrorMessage } from '../common/error/error-message';
+import { HttpExceptionFilter } from '../common/exception/http-exception.filter';
+import { JSON_BODY_LIMIT } from './body-parser.config';
+
+@Controller('drafts')
+class DraftProbeController {
+  @Post()
+  save(@Body() body: unknown, @Req() req: Request) {
+    return { size: JSON.stringify(body).length, cookies: req.cookies };
+  }
+}
+
+// 한글 한 글자는 UTF-8 로 3 바이트다.
+const koreanTextOf = ({ bytes }: { bytes: number }): string => '가'.repeat(Math.ceil(bytes / 3));
+
+describe('JSON_BODY_LIMIT', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [DraftProbeController],
+    }).compile();
+
+    // main.ts 와 같은 순서로 구성한다. 부트스트랩 코드는 직접 테스트할 수 없으므로 재현한다.
+    app = moduleRef.createNestApplication<NestExpressApplication>();
+    (app as NestExpressApplication).useBodyParser('json', { limit: JSON_BODY_LIMIT });
+    app.use(cookieParser());
+    app.useGlobalFilters(new HttpExceptionFilter());
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('express 기본값 100kb 를 넘는 본문도 설정된 한도 안이면 통과한다', async () => {
+    // 이 단언이 깨지면 useBodyParser 호출이 사라졌거나 listen() 이후로 밀렸다는 뜻이다.
+    // Given
+    const draft = { answers: koreanTextOf({ bytes: 500 * 1024 }) };
+
+    // When
+    const response = await request(app.getHttpServer()).post('/drafts').send(draft);
+
+    // Then
+    expect(response.status).toBe(HttpStatus.CREATED);
+  });
+
+  it('한도를 넘는 본문은 413 과 한국어 안내로 거절한다', async () => {
+    // Given
+    const oversizedDraft = { answers: koreanTextOf({ bytes: 2 * 1024 * 1024 }) };
+
+    // When
+    const response = await request(app.getHttpServer()).post('/drafts').send(oversizedDraft);
+
+    // Then
+    expect(response.status).toBe(HttpStatus.PAYLOAD_TOO_LARGE);
+    expect(response.body).toEqual({
+      code: 'PAYLOAD_TOO_LARGE',
+      message: ErrorMessage.PAYLOAD_TOO_LARGE,
+      data: null,
+    });
+  });
+
+  it('본문 파서를 교체해도 쿠키 파싱은 그대로 동작한다', async () => {
+    // 인증이 쿠키 기반이므로, useBodyParser 를 cookieParser 앞에 둔 순서가 쿠키를 밀어내면 안 된다.
+    // Given & When
+    const response = await request(app.getHttpServer())
+      .post('/drafts')
+      .set('Cookie', 'sid=abc123')
+      .send({ answers: '가' });
+
+    // Then
+    expect(response.status).toBe(HttpStatus.CREATED);
+    expect(response.body.cookies).toEqual({ sid: 'abc123' });
+  });
+});

--- a/src/config/body-parser.config.ts
+++ b/src/config/body-parser.config.ts
@@ -1,0 +1,6 @@
+// express.json() 기본값은 100kb 라 우리가 정한 값이 아니었다. 지원서 answers 는 자유 형식이고
+// 길이 상한도 없어서 장문 문항이 여러 개면 도달할 수 있다. 넘으면 413 과 한국어 안내가 나간다.
+//
+// urlencoded 는 대상이 아니다. useBodyParser('json') 은 json 슬롯만 교체하므로 urlencoded 는
+// 기본값(100kb)으로 남는데, form-urlencoded 를 받는 엔드포인트가 없어 문제되지 않는다.
+export const JSON_BODY_LIMIT = '1mb';

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,17 +6,15 @@ import cookieParser from 'cookie-parser';
 import { initializeTransactionalContext } from 'typeorm-transactional';
 
 import { AppModule } from './app.module';
+import { JSON_BODY_LIMIT } from './config/body-parser.config';
 import { ALLOWED_ORIGINS } from './config/cors.config';
 import { setupSwagger } from './config/swagger.config';
-
-// express.json() 기본값은 100kb 라 우리가 정한 값이 아니었다. 지원서 answers 는 자유 형식이고
-// 길이 상한도 없어서 장문 문항이 여러 개면 도달할 수 있다. 넘으면 413 과 한국어 안내가 나간다.
-const JSON_BODY_LIMIT = '1mb';
 
 const bootstrap = async () => {
   initializeTransactionalContext();
 
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
+  // listen() 전에 불러야 Nest 가 등록하는 기본 파서를 선점한다. cookieParser 와의 순서는 무관하다.
   app.useBodyParser('json', { limit: JSON_BODY_LIMIT });
   app.use(cookieParser());
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { Logger, ValidationPipe, VersioningType } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
+import type { NestExpressApplication } from '@nestjs/platform-express';
 import cookieParser from 'cookie-parser';
 import { initializeTransactionalContext } from 'typeorm-transactional';
 
@@ -8,10 +9,15 @@ import { AppModule } from './app.module';
 import { ALLOWED_ORIGINS } from './config/cors.config';
 import { setupSwagger } from './config/swagger.config';
 
+// express.json() 기본값은 100kb 라 우리가 정한 값이 아니었다. 지원서 answers 는 자유 형식이고
+// 길이 상한도 없어서 장문 문항이 여러 개면 도달할 수 있다. 넘으면 413 과 한국어 안내가 나간다.
+const JSON_BODY_LIMIT = '1mb';
+
 const bootstrap = async () => {
   initializeTransactionalContext();
 
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create<NestExpressApplication>(AppModule);
+  app.useBodyParser('json', { limit: JSON_BODY_LIMIT });
   app.use(cookieParser());
 
   app.enableCors({

--- a/src/storage/application/storage.service.spec.ts
+++ b/src/storage/application/storage.service.spec.ts
@@ -65,12 +65,13 @@ describe('StorageService', () => {
       ).rejects.toThrow(new AppException('FILE_TYPE_NOT_ALLOWED', HttpStatus.BAD_REQUEST));
     });
 
-    it('최대 크기 초과면 FILE_SIZE_EXCEEDED(400) 예외를 던진다', async () => {
+    it('최대 크기 초과면 FILE_SIZE_EXCEEDED(413) 예외를 던진다', async () => {
+      // 인터셉터의 limits 에 먼저 걸리면 413 이므로, 여기까지 온 경우도 같은 상태 코드로 맞춘다.
       const file = buildFile({ size: 100 * 1024 * 1024 });
 
       await expect(
         service.upload({ file, category: UploadCategory.PROJECT_THUMBNAIL }),
-      ).rejects.toThrow(new AppException('FILE_SIZE_EXCEEDED', HttpStatus.BAD_REQUEST));
+      ).rejects.toThrow(new AppException('FILE_SIZE_EXCEEDED', HttpStatus.PAYLOAD_TOO_LARGE));
     });
 
     it('PROJECT_PDF 카테고리는 application/pdf만 허용한다', async () => {

--- a/src/storage/application/storage.service.ts
+++ b/src/storage/application/storage.service.ts
@@ -234,9 +234,12 @@ export class StorageService {
     }
   }
 
+  // 같은 '용량 초과' 인데 인터셉터가 먼저 걸리면 413, 여기까지 오면 400 이라 프론트가 두 갈래로
+  // 분기해야 했다. 상태 코드를 413 으로 맞춰 한 조건으로 처리하게 한다. code 는 어느 쪽에서
+  // 걸렸는지 구분되도록 그대로 둔다.
   private validateFileSize({ size, maxSize }: { size: number; maxSize: number }) {
     if (size > maxSize) {
-      throw new AppException('FILE_SIZE_EXCEEDED', HttpStatus.BAD_REQUEST);
+      throw new AppException('FILE_SIZE_EXCEEDED', HttpStatus.PAYLOAD_TOO_LARGE);
     }
   }
 }

--- a/src/storage/domain/storage.type.ts
+++ b/src/storage/domain/storage.type.ts
@@ -38,6 +38,12 @@ export const ALLOWED_PATH_PREFIXES: readonly string[] = Object.values(UPLOAD_CAT
   (config) => config.gcsPath,
 );
 
+// 업로드 인터셉터는 어느 카테고리로 올지 모르는 시점에 걸리므로 카테고리별 상한 중 최댓값을 쓴다.
+// 카테고리별 정확한 상한은 StorageService 가 다시 검사한다.
+export const MAX_UPLOAD_SIZE_BYTES = Math.max(
+  ...Object.values(UPLOAD_CATEGORY_CONFIG).map((config) => config.maxSizeBytes),
+);
+
 const SAFE_PATH_PATTERN = /^[a-zA-Z0-9._\-/]+$/;
 
 const SAFE_SUB_PATH_PATTERN = /^[a-zA-Z0-9._-]+$/;

--- a/src/storage/domain/storage.type.ts
+++ b/src/storage/domain/storage.type.ts
@@ -38,9 +38,11 @@ export const ALLOWED_PATH_PREFIXES: readonly string[] = Object.values(UPLOAD_CAT
   (config) => config.gcsPath,
 );
 
-// 업로드 인터셉터는 어느 카테고리로 올지 모르는 시점에 걸리므로 카테고리별 상한 중 최댓값을 쓴다.
-// 카테고리별 정확한 상한은 StorageService 가 다시 검사한다.
-export const MAX_UPLOAD_SIZE_BYTES = Math.max(
+// 카테고리를 특정하지 않는 호출부가 쓰는 전체 상한이다. 카테고리별 정확한 상한이 아니므로
+// 이 값으로 크기 검사를 대신하면 5MB 카테고리가 20MB 를 통과한다. 검사는 StorageService 담당.
+// 카테고리별로 정확히 걸려면 요청마다 multer 인스턴스를 만들어야 하는데, 업로드 경로가 모두
+// 인증 가드 뒤에 있고 가드가 multer 보다 먼저 돌아 노출면이 좁아 그만한 값어치가 없다고 봤다.
+export const LARGEST_UPLOAD_SIZE_BYTES = Math.max(
   ...Object.values(UPLOAD_CATEGORY_CONFIG).map((config) => config.maxSizeBytes),
 );
 

--- a/src/storage/interface/admin.storage.controller.spec.ts
+++ b/src/storage/interface/admin.storage.controller.spec.ts
@@ -1,10 +1,15 @@
-import { StreamableFile } from '@nestjs/common';
+import { HttpStatus, INestApplication, StreamableFile } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
 import { Test } from '@nestjs/testing';
 import type { Response } from 'express';
 import { Readable } from 'stream';
+import request from 'supertest';
 
+import { ErrorMessage } from '../../common/error/error-message';
+import { HttpExceptionFilter } from '../../common/exception/http-exception.filter';
+import { RolesGuard } from '../../common/guard/roles.guard';
 import { StorageService } from '../application/storage.service';
-import { SignedUrlAction, UploadCategory } from '../domain/storage.type';
+import { LARGEST_UPLOAD_SIZE_BYTES, SignedUrlAction, UploadCategory } from '../domain/storage.type';
 import { AdminStorageController } from './admin.storage.controller';
 
 const mockStorageService = {
@@ -209,5 +214,74 @@ describe('AdminStorageController', () => {
         `attachment; filename*=UTF-8''${encodeURIComponent('한글.png')}`,
       );
     });
+  });
+});
+
+// limits 는 인터셉터 데코레이터라 컨트롤러 메서드를 직접 부르는 위 테스트로는 걸리지 않는다.
+describe('AdminStorageController 업로드 상한 (HTTP)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [AdminStorageController],
+      providers: [{ provide: StorageService, useValue: mockStorageService }],
+    })
+      .overrideGuard(AuthGuard('jwt'))
+      .useValue({ canActivate: () => true })
+      .overrideGuard(RolesGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    app.useGlobalFilters(new HttpExceptionFilter());
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStorageService.upload.mockResolvedValue({
+      url: 'https://storage.googleapis.com/bucket/projects/pdfs/a.pdf',
+      originalName: 'a.pdf',
+      mimeType: 'application/pdf',
+      size: 1024,
+    });
+  });
+
+  it('상한을 넘는 파일은 StorageService 에 닿기 전에 413 으로 거절한다', async () => {
+    // 상한이 없던 시절에는 이 파일이 전부 메모리에 버퍼링된 뒤에야 서비스에서 거부됐다.
+    // Given
+    const oversized = Buffer.alloc(LARGEST_UPLOAD_SIZE_BYTES + 1024);
+
+    // When
+    const response = await request(app.getHttpServer())
+      .post(`/admin/files/upload?category=${UploadCategory.PROJECT_PDF}`)
+      .attach('file', oversized, 'oversized.pdf');
+
+    // Then
+    expect(response.status).toBe(HttpStatus.PAYLOAD_TOO_LARGE);
+    expect(response.body).toEqual({
+      code: 'PAYLOAD_TOO_LARGE',
+      message: ErrorMessage.PAYLOAD_TOO_LARGE,
+      data: null,
+    });
+    expect(mockStorageService.upload).not.toHaveBeenCalled();
+  });
+
+  it('상한 안쪽 파일은 그대로 업로드된다', async () => {
+    // Given
+    const withinLimit = Buffer.alloc(1024 * 1024);
+
+    // When
+    const response = await request(app.getHttpServer())
+      .post(`/admin/files/upload?category=${UploadCategory.PROJECT_PDF}`)
+      .attach('file', withinLimit, 'small.pdf');
+
+    // Then
+    expect(response.status).toBe(HttpStatus.CREATED);
+    expect(mockStorageService.upload).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/storage/interface/admin.storage.controller.ts
+++ b/src/storage/interface/admin.storage.controller.ts
@@ -24,7 +24,7 @@ import { ApiResponse } from '../../common/response/api-response';
 import { ApiDoc } from '../../common/swagger/api-doc.decorator';
 import { UserRole } from '../../user/domain/user.role';
 import { StorageService } from '../application/storage.service';
-import { MAX_UPLOAD_SIZE_BYTES } from '../domain/storage.type';
+import { LARGEST_UPLOAD_SIZE_BYTES } from '../domain/storage.type';
 import {
   FilePathQueryDto,
   FileUploadQueryDto,
@@ -53,7 +53,7 @@ export class AdminStorageController {
   @ApiConsumes('multipart/form-data')
   @Post('upload')
   // 상한이 없으면 어떤 크기든 메모리에 전부 버퍼링한 뒤에야 StorageService 가 거부한다.
-  @UseInterceptors(FileInterceptor('file', { limits: { fileSize: MAX_UPLOAD_SIZE_BYTES } }))
+  @UseInterceptors(FileInterceptor('file', { limits: { fileSize: LARGEST_UPLOAD_SIZE_BYTES } }))
   async uploadFile(@UploadedFile() file: Express.Multer.File, @Query() query: FileUploadQueryDto) {
     const filePayload = file
       ? {

--- a/src/storage/interface/admin.storage.controller.ts
+++ b/src/storage/interface/admin.storage.controller.ts
@@ -24,6 +24,7 @@ import { ApiResponse } from '../../common/response/api-response';
 import { ApiDoc } from '../../common/swagger/api-doc.decorator';
 import { UserRole } from '../../user/domain/user.role';
 import { StorageService } from '../application/storage.service';
+import { MAX_UPLOAD_SIZE_BYTES } from '../domain/storage.type';
 import {
   FilePathQueryDto,
   FileUploadQueryDto,
@@ -51,7 +52,8 @@ export class AdminStorageController {
   })
   @ApiConsumes('multipart/form-data')
   @Post('upload')
-  @UseInterceptors(FileInterceptor('file'))
+  // 상한이 없으면 어떤 크기든 메모리에 전부 버퍼링한 뒤에야 StorageService 가 거부한다.
+  @UseInterceptors(FileInterceptor('file', { limits: { fileSize: MAX_UPLOAD_SIZE_BYTES } }))
   async uploadFile(@UploadedFile() file: Express.Multer.File, @Query() query: FileUploadQueryDto) {
     const filePayload = file
       ? {


### PR DESCRIPTION
## 개요

PR #79 리뷰에서 후속으로 남긴 항목 중 크기 제한과 관련된 3건을 정리합니다. 셋 다 같은 결의 문제입니다.

## 변경 이유 및 주요 변경 사항

### 1. 관리자 업로드에 상한이 없었습니다

`admin.storage.controller.ts` 의 `FileInterceptor` 에 `limits` 가 없어, **어떤 크기의 파일이든 메모리에 전부 버퍼링한 뒤에야** `StorageService` 가 거부합니다. 지원자 업로드 경로에서 `limits` 를 유지한 논거(#78 의 해결 방향 2번을 거부한 이유)가 그대로 적용됩니다.

카테고리는 쿼리 파라미터라 인터셉터 시점에도 읽을 수 있지만, 카테고리별로 정확히 걸려면 요청마다 multer 인스턴스를 만들어야 합니다. 업로드 경로가 모두 인증 가드 뒤에 있고 **가드가 multer 보다 먼저 돌아** 노출면이 좁으므로, 카테고리별 상한 중 최댓값(현재 20MB)만 걸고 정확한 검사는 `StorageService` 에 맡깁니다. `LARGEST_UPLOAD_SIZE_BYTES` 를 `UPLOAD_CATEGORY_CONFIG` 에서 파생시켜 카테고리가 추가돼도 따라오게 했습니다.

### 2. 같은 '용량 초과' 에 응답이 두 갈래였습니다

| 걸리는 지점 | 이전 | 이후 |
| --- | --- | --- |
| 인터셉터 `limits` | 413 / `PAYLOAD_TOO_LARGE` | 413 / `PAYLOAD_TOO_LARGE` |
| `StorageService.validateFileSize` | **400** / `FILE_SIZE_EXCEEDED` | **413** / `FILE_SIZE_EXCEEDED` |

프론트가 "파일이 너무 큼"을 두 조합으로 처리해야 했습니다. HTTP 의미상 413이 맞으므로 그쪽으로 맞췄습니다. `code` 는 어느 지점에서 걸렸는지 구분되도록 그대로 두었습니다.

### 3. 요청 본문 한도가 암묵적이었습니다

`main.ts` 에 설정이 없어 express 기본값 100kb 가 적용되고 있었습니다. `SubmitApplicationRequestDto.answers` 는 `@IsObject()` 뿐인 자유 형식이고 길이 상한도 없어, 장문 문항이 여러 개인 지원서라면 도달할 수 있습니다(한글 100kb ≈ 33,000자). `1mb` 로 명시했습니다.

PR #79 에서 body-parser 오류를 413 + 한국어 안내로 정정해 뒀으므로, 한도를 넘겨도 지원자는 "요청 용량이 제한을 초과했습니다." 를 받습니다.

## 리뷰 반영

리뷰 2건(자동 리뷰 포함)을 받아 `eca4ca4` 에서 반영했습니다.

- **주석이 틀린 근거로 옳은 결론을 정당화하고 있었습니다.** "인터셉터는 카테고리를 알 수 없다"고 적었는데 카테고리는 쿼리 파라미터라 사실이 아닙니다. 결론(최댓값 사용)은 유지하고 근거를 정정했습니다 — 틀린 주석을 두면 다음 사람이 재검토를 건너뜁니다. 상수명도 `MAX_UPLOAD_SIZE_BYTES` → `LARGEST_UPLOAD_SIZE_BYTES` 로 바꿨습니다(정책 상한으로 오해될 수 있어서).
- **3건 중 2건이 테스트로 잠기지 않았습니다.** `useBodyParser` 한 줄이나 `limits` 를 지워도 전체 테스트가 통과했습니다. HTTP 레벨 테스트 5건을 추가하고, `limits` 를 임시로 떼서 해당 테스트만 실패하는 것을 확인했습니다.
- `useBodyParser('json')` 은 json 슬롯만 교체하므로 urlencoded 는 기본값(100kb)으로 남습니다. form-urlencoded 를 받는 엔드포인트가 없어 무해하지만 주석에 명시했습니다.

## 아키텍처 영향

- 도메인 분리: 변경 없음 (`LARGEST_UPLOAD_SIZE_BYTES` 는 기존 `storage.type.ts` 설정에서 파생)
- 레이어 변경: `JSON_BODY_LIMIT` 을 `config/body-parser.config.ts` 로 분리 (기존 `cors.config.ts`·`swagger.config.ts` 패턴)
- 의존 방향 영향: 없음 — interface → domain 방향 참조만 추가
- 트랜잭션 경계 영향: 없음

## 테스트

- [x] 단위 테스트
- [x] 통합 테스트
- [ ] 수동 테스트
- 확인 내용: `yarn test` 46 suite / 425 tests 통과, `yarn lint`·`yarn build` 통과.
  - `body-parser.config.spec.ts` (신규 3건) — 기본값 100kb 를 넘는 500KB 본문 통과, 1mb 초과 시 413 + 한국어 안내, 본문 파서 교체 후에도 쿠키 파싱 유지(인증이 쿠키 기반이므로)
  - `admin.storage.controller.spec.ts` (신규 2건) — 상한 초과 시 `StorageService` 에 닿기 전 413, 상한 안쪽 정상 업로드
  - `storage.service.spec.ts` — 용량 초과 케이스를 413 기대로 갱신

## 리뷰 포인트

- **본문 한도 `1mb` 가 적절한지** 봐 주세요. "한글 33,000자로는 장문 지원서에 빠듯하다" 정도의 근거로 여유를 준 값입니다.
- **`FILE_SIZE_EXCEEDED` 의 상태 코드 변경(400 → 413)은 계약 변경입니다.** 프론트가 400으로 분기하고 있다면 확인이 필요합니다. `code` 는 유지했으므로 최악의 경우에도 안내 문구가 일반화되는 정도입니다.
- 관리자 업로드 상한을 최댓값(20MB)으로 건 것은, 5MB 카테고리에 20MB 파일을 올리면 여전히 20MB 까지 메모리에 받는다는 뜻입니다. 인증 가드 뒤라는 점을 근거로 감수한 절충입니다.

## 리스크 / 후속 작업

- `main.ts` 자체는 부트스트랩 코드라 직접 테스트할 수 없어, 신규 테스트가 **같은 구성을 재현**하는 방식입니다. 한도 값과 파서 교체 동작은 잠기지만, `main.ts` 에서 그 호출이 사라지는 회귀는 코드 리뷰가 잡아야 합니다.
- **`answers` 자체의 길이 상한이 없습니다.** 본문 한도가 사실상의 상한이라, 1MB 를 넘기면 body-parser 가 본문을 통째로 버려 "어느 문항이 문제인지" 알려줄 수 없습니다. 문항별 `MaxLength` 를 두면 필드 단위 안내가 가능해지고 1mb 는 그 뒤를 받는 안전망이 됩니다. 별도 티켓 권장.
- **rate limit(`ThrottlerModule`)이 전혀 없습니다.** 이 PR 이 만든 문제는 아니지만, 본문 한도를 10배로 올리면 같은 요청 수에 10배 메모리가 붙습니다. 별도 티켓 권장.
- 업로드 엔드포인트 Swagger 에 에러 응답이 하나도 선언돼 있지 않습니다(413 포함). `openapi.json` 은 배포 후 자동 재생성이라 수동 수정은 불필요합니다.

## 관련 이슈

- PR #79 리뷰의 후속 항목
