### PR TITLE
fix(notification): 운영 이메일 미발송과 거짓 성공 기록 정정

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,11 +43,15 @@ CLIENT_REDIRECT_URL=          # e.g. https://dddsite.co.kr/auth/callback
 ENCRYPTION_KEY=
 
 # ============================================================
-# Email  (EMAIL_PROVIDER=resend 일 때 하위 항목 필요)
+# Email  (EMAIL_PROVIDER=gmail 일 때 하위 3개 필수 — 없으면 앱이 부팅하지 못한다)
+# console 은 로그만 찍는 로컬 개발용이며, 운영(NODE_ENV=production)에서는
+# 발송 시점에 예외로 실패한다. 안 나간 메일이 성공으로 기록되는 것을 막기 위함이다.
 # ============================================================
-EMAIL_PROVIDER=console        # console | resend
-RESEND_API_KEY=
+EMAIL_PROVIDER=console        # console | gmail
+GMAIL_USER=                   # e.g. noreply@dddsite.co.kr (Gmail 계정)
+GMAIL_APP_PASSWORD=           # Google 계정 > 보안 > 앱 비밀번호 16자
 EMAIL_FROM=                   # e.g. noreply@dddsite.co.kr
+EMAIL_FROM_NAME=DDD           # 수신자에게 보이는 발신자 이름 (기본 DDD)
 
 # 운영 알림 수신 메일 (외부 연동 실패 시 발송, 미설정 시 logger.warn 만)
 OPS_ALERT_EMAIL=              # e.g. ops@dddsite.co.kr

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -341,33 +341,27 @@ jobs:
             # Email (Gmail SMTP)
             # 여기에 console 이 박혀 있는 동안 사전 알림/면접 안내 메일이 운영에서 한 통도
             # 나가지 않았다. 발송 로그는 SUCCESS 로 쌓여 어드민 화면에 '발송 완료' 로 보였다.
-            # 시크릿을 넣지 않으면 여전히 console 로 떨어지지만, 이제는 발송 시점에 예외로 드러난다.
-            EMAIL_PROVIDER_VALUE="${EMAIL_PROVIDER:-console}"
-            # 앱 env 검증(EMAIL_PROVIDER 화이트리스트)이 거부하는 값이면 컨테이너를 교체한 뒤
-            # 부팅에서 죽는다. 교체 전에 여기서 걸러 운영을 건드리지 않는다.
-            case "$EMAIL_PROVIDER_VALUE" in
-              console|gmail) ;;
-              *)
-                echo "ERROR: EMAIL_PROVIDER 시크릿 값이 console|gmail 이 아닙니다: '$EMAIL_PROVIDER_VALUE'"
-                echo "       이 값으로는 앱이 부팅하지 못합니다. 컨테이너는 교체하지 않았습니다."
-                rm -f "$ENV_TMP"
-                exit 1
-                ;;
-            esac
-            if [ "$EMAIL_PROVIDER_VALUE" = "gmail" ]; then
-              if [ -z "${GMAIL_USER:-}" ] || [ -z "${GMAIL_APP_PASSWORD:-}" ] || [ -z "${EMAIL_FROM:-}" ]; then
-                echo "ERROR: EMAIL_PROVIDER=gmail 인데 GMAIL_USER, GMAIL_APP_PASSWORD, EMAIL_FROM 중 비어 있는 시크릿이 있습니다."
-                echo "       이 상태로 배포하면 앱이 env 검증에서 부팅하지 못합니다. 컨테이너는 교체하지 않았습니다."
-                rm -f "$ENV_TMP"
-                exit 1
-              fi
-            else
-              echo "::warning::EMAIL_PROVIDER=$EMAIL_PROVIDER_VALUE 로 배포합니다. 운영 메일 발송은 예외로 실패합니다(EMAIL_PROVIDER/GMAIL_* 시크릿을 확인하세요)."
+            #
+            # 운영은 gmail 만 허용한다. console 로도 앱은 정상 부팅하고 발송만 전부 예외가
+            # 되므로, 배포는 초록불인데 이메일 기능만 죽은 상태가 된다. 경고로 남기면
+            # 아무도 보지 않는다 - 2026-08 무배포 사고와 같은 실패 유형이다.
+            if [ "${EMAIL_PROVIDER:-}" != "gmail" ]; then
+              echo "ERROR: 운영 배포는 EMAIL_PROVIDER=gmail 이어야 합니다 (현재 '${EMAIL_PROVIDER:-미설정}')."
+              echo "       GitHub Secrets 의 EMAIL_PROVIDER 를 gmail 로 설정하세요."
+              echo "       컨테이너는 교체하지 않았습니다."
+              rm -f "$ENV_TMP"
+              exit 1
             fi
-            printf 'EMAIL_PROVIDER=%s\n'     "$EMAIL_PROVIDER_VALUE"   >> "$ENV_TMP"
-            printf 'GMAIL_USER=%s\n'         "${GMAIL_USER:-}"         >> "$ENV_TMP"
-            printf 'GMAIL_APP_PASSWORD=%s\n' "${GMAIL_APP_PASSWORD:-}" >> "$ENV_TMP"
-            printf 'EMAIL_FROM=%s\n'         "${EMAIL_FROM:-}"         >> "$ENV_TMP"
+            if [ -z "${GMAIL_USER:-}" ] || [ -z "${GMAIL_APP_PASSWORD:-}" ] || [ -z "${EMAIL_FROM:-}" ]; then
+              echo "ERROR: GMAIL_USER, GMAIL_APP_PASSWORD, EMAIL_FROM 중 비어 있는 시크릿이 있습니다."
+              echo "       이 상태로 배포하면 앱이 env 검증에서 부팅하지 못합니다. 컨테이너는 교체하지 않았습니다."
+              rm -f "$ENV_TMP"
+              exit 1
+            fi
+            printf 'EMAIL_PROVIDER=%s\n'     "gmail"                   >> "$ENV_TMP"
+            printf 'GMAIL_USER=%s\n'         "$GMAIL_USER"             >> "$ENV_TMP"
+            printf 'GMAIL_APP_PASSWORD=%s\n' "$GMAIL_APP_PASSWORD"     >> "$ENV_TMP"
+            printf 'EMAIL_FROM=%s\n'         "$EMAIL_FROM"             >> "$ENV_TMP"
             printf 'EMAIL_FROM_NAME=%s\n'    "${EMAIL_FROM_NAME:-DDD}" >> "$ENV_TMP"
 
             # Interview & Calendar

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -110,6 +110,7 @@ jobs:
             JWT_SECRET,JWT_EXPIRES_IN,ADMIN_BOOTSTRAP_TOKEN,ADMIN_BOOTSTRAP_TOKEN_EXPIRES_AT,
             GOOGLE_CLIENT_ID,GOOGLE_CLIENT_SECRET,GOOGLE_CALLBACK_URL,
             CLIENT_REDIRECT_URL,ENCRYPTION_KEY,GOOGLE_CALENDAR_ID,
+            EMAIL_PROVIDER,GMAIL_USER,GMAIL_APP_PASSWORD,EMAIL_FROM,EMAIL_FROM_NAME,
             GCS_BUCKET_NAME,GCP_SERVICE_ACCOUNT_JSON,DISCORD_CLIENT_ID,DISCORD_CLIENT_SECRET,
             DISCORD_CALLBACK_URL,DISCORD_BOT_TOKEN,DISCORD_GUILD_ID,DISCORD_INVITE_URL,
             DISCORD_ROLE_ID_PM,DISCORD_ROLE_ID_PD,DISCORD_ROLE_ID_BE,DISCORD_ROLE_ID_FE,
@@ -337,8 +338,37 @@ jobs:
             printf 'CLIENT_REDIRECT_URL=%s\n' "$CLIENT_REDIRECT_URL" >> "$ENV_TMP"
             printf 'ENCRYPTION_KEY=%s\n'     "$ENCRYPTION_KEY"       >> "$ENV_TMP"
 
-            # Email (console 모드 - Resend 미사용)
-            printf 'EMAIL_PROVIDER=%s\n'     "console"               >> "$ENV_TMP"
+            # Email (Gmail SMTP)
+            # 여기에 console 이 박혀 있는 동안 사전 알림/면접 안내 메일이 운영에서 한 통도
+            # 나가지 않았다. 발송 로그는 SUCCESS 로 쌓여 어드민 화면에 '발송 완료' 로 보였다.
+            # 시크릿을 넣지 않으면 여전히 console 로 떨어지지만, 이제는 발송 시점에 예외로 드러난다.
+            EMAIL_PROVIDER_VALUE="${EMAIL_PROVIDER:-console}"
+            # 앱 env 검증(EMAIL_PROVIDER 화이트리스트)이 거부하는 값이면 컨테이너를 교체한 뒤
+            # 부팅에서 죽는다. 교체 전에 여기서 걸러 운영을 건드리지 않는다.
+            case "$EMAIL_PROVIDER_VALUE" in
+              console|gmail) ;;
+              *)
+                echo "ERROR: EMAIL_PROVIDER 시크릿 값이 console|gmail 이 아닙니다: '$EMAIL_PROVIDER_VALUE'"
+                echo "       이 값으로는 앱이 부팅하지 못합니다. 컨테이너는 교체하지 않았습니다."
+                rm -f "$ENV_TMP"
+                exit 1
+                ;;
+            esac
+            if [ "$EMAIL_PROVIDER_VALUE" = "gmail" ]; then
+              if [ -z "${GMAIL_USER:-}" ] || [ -z "${GMAIL_APP_PASSWORD:-}" ] || [ -z "${EMAIL_FROM:-}" ]; then
+                echo "ERROR: EMAIL_PROVIDER=gmail 인데 GMAIL_USER, GMAIL_APP_PASSWORD, EMAIL_FROM 중 비어 있는 시크릿이 있습니다."
+                echo "       이 상태로 배포하면 앱이 env 검증에서 부팅하지 못합니다. 컨테이너는 교체하지 않았습니다."
+                rm -f "$ENV_TMP"
+                exit 1
+              fi
+            else
+              echo "::warning::EMAIL_PROVIDER=$EMAIL_PROVIDER_VALUE 로 배포합니다. 운영 메일 발송은 예외로 실패합니다(EMAIL_PROVIDER/GMAIL_* 시크릿을 확인하세요)."
+            fi
+            printf 'EMAIL_PROVIDER=%s\n'     "$EMAIL_PROVIDER_VALUE"   >> "$ENV_TMP"
+            printf 'GMAIL_USER=%s\n'         "${GMAIL_USER:-}"         >> "$ENV_TMP"
+            printf 'GMAIL_APP_PASSWORD=%s\n' "${GMAIL_APP_PASSWORD:-}" >> "$ENV_TMP"
+            printf 'EMAIL_FROM=%s\n'         "${EMAIL_FROM:-}"         >> "$ENV_TMP"
+            printf 'EMAIL_FROM_NAME=%s\n'    "${EMAIL_FROM_NAME:-DDD}" >> "$ENV_TMP"
 
             # Interview & Calendar
             printf 'INTERVIEW_BOOKING_URL=%s\n' "https://admin.dddstudy.kr/interview" >> "$ENV_TMP"
@@ -508,6 +538,11 @@ jobs:
           CLIENT_REDIRECT_URL: ${{ secrets.CLIENT_REDIRECT_URL }}
           ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
           GOOGLE_CALENDAR_ID: ${{ secrets.GOOGLE_CALENDAR_ID }}
+          EMAIL_PROVIDER: ${{ secrets.EMAIL_PROVIDER }}
+          GMAIL_USER: ${{ secrets.GMAIL_USER }}
+          GMAIL_APP_PASSWORD: ${{ secrets.GMAIL_APP_PASSWORD }}
+          EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
+          EMAIL_FROM_NAME: ${{ secrets.EMAIL_FROM_NAME }}
           GCS_BUCKET_NAME: ${{ secrets.GCS_BUCKET_NAME }}
           GCP_SERVICE_ACCOUNT_JSON: ${{ secrets.GCP_SERVICE_ACCOUNT_JSON }}
           DISCORD_CLIENT_ID: ${{ secrets.DISCORD_CLIENT_ID }}

--- a/src/config/env.validation.spec.ts
+++ b/src/config/env.validation.spec.ts
@@ -116,6 +116,83 @@ describe('env validation', () => {
     });
   });
 
+  describe('EMAIL_PROVIDER 조건부 검증', () => {
+    // gmail 로 바꿔만 두고 자격증명을 안 넣으면 앱은 부팅되지만 메일은 한 통도 안 나간다.
+    // 그 상태를 발송 시점이 아니라 부팅 시점에 잡는다.
+    it('EMAIL_PROVIDER 미설정이면 기본값 console 로 통과한다', () => {
+      const config = createValidConfig();
+      delete config.EMAIL_PROVIDER;
+
+      const result = validate(config);
+
+      expect(result.EMAIL_PROVIDER).toBe('console');
+    });
+
+    // 시크릿이 비어 EMAIL_PROVIDER= 만 들어가는 경우다. 조용히 console 로 흘리지 않는다.
+    it('EMAIL_PROVIDER 가 빈 문자열이면 앱 시작 전에 실패한다', () => {
+      expect(() => validate({ ...createValidConfig(), EMAIL_PROVIDER: '' })).toThrow(
+        'EMAIL_PROVIDER',
+      );
+    });
+
+    it('EMAIL_PROVIDER=console 이면 GMAIL_* 없이 통과한다', () => {
+      expect(() => validate(createValidConfig())).not.toThrow();
+    });
+
+    it('EMAIL_PROVIDER=gmail 인데 GMAIL_USER가 없으면 실패한다', () => {
+      expect(() => {
+        validate({
+          ...createValidConfig(),
+          EMAIL_PROVIDER: 'gmail',
+          GMAIL_APP_PASSWORD: 'app-password',
+          EMAIL_FROM: 'noreply@dddstudy.kr',
+        });
+      }).toThrow('GMAIL_USER');
+    });
+
+    it('EMAIL_PROVIDER=gmail 인데 GMAIL_APP_PASSWORD가 없으면 실패한다', () => {
+      expect(() => {
+        validate({
+          ...createValidConfig(),
+          EMAIL_PROVIDER: 'gmail',
+          GMAIL_USER: 'noreply@dddstudy.kr',
+          EMAIL_FROM: 'noreply@dddstudy.kr',
+        });
+      }).toThrow('GMAIL_APP_PASSWORD');
+    });
+
+    it('EMAIL_PROVIDER=gmail 인데 EMAIL_FROM이 없으면 실패한다', () => {
+      expect(() => {
+        validate({
+          ...createValidConfig(),
+          EMAIL_PROVIDER: 'gmail',
+          GMAIL_USER: 'noreply@dddstudy.kr',
+          GMAIL_APP_PASSWORD: 'app-password',
+        });
+      }).toThrow('EMAIL_FROM');
+    });
+
+    it('EMAIL_PROVIDER=gmail 이고 자격증명이 모두 있으면 통과한다', () => {
+      expect(() =>
+        validate({
+          ...createValidConfig(),
+          EMAIL_PROVIDER: 'gmail',
+          GMAIL_USER: 'noreply@dddstudy.kr',
+          GMAIL_APP_PASSWORD: 'app-password',
+          EMAIL_FROM: 'noreply@dddstudy.kr',
+        }),
+      ).not.toThrow();
+    });
+
+    // resend 는 제거된 provider 다. .env.example 에 남아 있던 값이 조용히 통과하면
+    // 다시 console 과 같은 무발송 상태가 된다.
+    it('제거된 provider(resend)는 앱 시작 전에 실패한다', () => {
+      expect(() => {
+        validate({ ...createValidConfig(), EMAIL_PROVIDER: 'resend' });
+      }).toThrow('EMAIL_PROVIDER');
+    });
+  });
+
   describe('STORAGE_PROVIDER 화이트리스트 검증', () => {
     it('STORAGE_PROVIDER 미설정이면 기본값 console 로 통과한다', () => {
       const result = validate(createValidConfig());

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -15,6 +15,9 @@ import {
 export const STORAGE_PROVIDERS = ['console', 'gcs'] as const;
 export type StorageProvider = (typeof STORAGE_PROVIDERS)[number];
 
+export const EMAIL_PROVIDERS = ['console', 'gmail'] as const;
+export type EmailProvider = (typeof EMAIL_PROVIDERS)[number];
+
 class EnvironmentVariables {
   @IsNumber()
   @IsOptional()
@@ -92,17 +95,33 @@ class EnvironmentVariables {
   })
   ENCRYPTION_KEY: string;
 
-  @IsString()
+  // 실제 발송 경로는 gmail 뿐이다. console 은 로그만 찍는 로컬 개발용이며,
+  // 운영에서 console 로 남으면 메일이 안 나가고도 발송 로그가 SUCCESS 로 쌓인다.
+  // (GmailEmailClient 가 운영 + console 조합을 발송 시점에 거부한다)
+  @IsIn(EMAIL_PROVIDERS, {
+    message: `EMAIL_PROVIDER 는 ${EMAIL_PROVIDERS.join(' | ')} 중 하나여야 합니다.`,
+  })
   @IsOptional()
-  EMAIL_PROVIDER: string = 'console';
+  EMAIL_PROVIDER: EmailProvider = 'console';
 
-  @IsString()
-  @IsOptional()
-  RESEND_API_KEY?: string;
+  @ValidateIf((env: EnvironmentVariables) => env.EMAIL_PROVIDER === 'gmail')
+  @IsString({ message: 'EMAIL_PROVIDER=gmail 일 때 GMAIL_USER는 필수입니다.' })
+  @IsNotEmpty({ message: 'EMAIL_PROVIDER=gmail 일 때 GMAIL_USER는 필수입니다.' })
+  GMAIL_USER?: string;
 
-  @IsString()
-  @IsOptional()
+  @ValidateIf((env: EnvironmentVariables) => env.EMAIL_PROVIDER === 'gmail')
+  @IsString({ message: 'EMAIL_PROVIDER=gmail 일 때 GMAIL_APP_PASSWORD는 필수입니다.' })
+  @IsNotEmpty({ message: 'EMAIL_PROVIDER=gmail 일 때 GMAIL_APP_PASSWORD는 필수입니다.' })
+  GMAIL_APP_PASSWORD?: string;
+
+  @ValidateIf((env: EnvironmentVariables) => env.EMAIL_PROVIDER === 'gmail')
+  @IsString({ message: 'EMAIL_PROVIDER=gmail 일 때 EMAIL_FROM은 필수입니다.' })
+  @IsNotEmpty({ message: 'EMAIL_PROVIDER=gmail 일 때 EMAIL_FROM은 필수입니다.' })
   EMAIL_FROM?: string;
+
+  @IsString()
+  @IsOptional()
+  EMAIL_FROM_NAME?: string;
 
   @IsString()
   @IsOptional()

--- a/src/notification/infrastructure/gmail-email.client.spec.ts
+++ b/src/notification/infrastructure/gmail-email.client.spec.ts
@@ -1,0 +1,108 @@
+import { ConfigService } from '@nestjs/config';
+import { Test } from '@nestjs/testing';
+import * as nodemailer from 'nodemailer';
+
+import { GmailEmailClient } from './gmail-email.client';
+
+jest.mock('nodemailer', () => ({
+  createTransport: jest.fn(),
+}));
+
+const createClient = async (env: Record<string, string>): Promise<GmailEmailClient> => {
+  const module = await Test.createTestingModule({
+    providers: [
+      GmailEmailClient,
+      { provide: ConfigService, useValue: { get: (key: string) => env[key] } },
+    ],
+  }).compile();
+
+  return module.get(GmailEmailClient);
+};
+
+const emailPayload = {
+  to: 'applicant@example.com',
+  subject: '[DDD] 14기 모집 시작 안내',
+  html: '<p>모집이 시작되었습니다.</p>',
+  text: '모집이 시작되었습니다.',
+};
+
+const gmailEnv = {
+  NODE_ENV: 'production',
+  EMAIL_PROVIDER: 'gmail',
+  GMAIL_USER: 'noreply@dddstudy.kr',
+  GMAIL_APP_PASSWORD: 'app-password',
+  EMAIL_FROM: 'noreply@dddstudy.kr',
+};
+
+describe('GmailEmailClient', () => {
+  const sendMail = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sendMail.mockResolvedValue(undefined);
+    (nodemailer.createTransport as jest.Mock).mockReturnValue({ sendMail });
+  });
+
+  // 운영에서 console 모드가 조용히 성공하던 동작이 사전 알림 메일 미발송의 원인이었다.
+  // 호출자는 예외가 없는 것을 성공으로 보고 EmailLog 를 SUCCESS 로 남기고 notifiedAt 까지 찍어,
+  // 한 통도 나가지 않았는데 어드민 화면에는 '발송 완료' 로 보였다.
+  describe('운영에서 발송 불가 상태를 성공으로 기록하지 않는다', () => {
+    it('EMAIL_PROVIDER 가 gmail 이 아니면 예외를 던진다', async () => {
+      const client = await createClient({ NODE_ENV: 'production', EMAIL_PROVIDER: 'console' });
+
+      await expect(client.sendEmail(emailPayload)).rejects.toThrow('EMAIL_PROVIDER=console');
+      expect(sendMail).not.toHaveBeenCalled();
+    });
+
+    it('EMAIL_PROVIDER 미설정이어도 예외를 던진다', async () => {
+      const client = await createClient({ NODE_ENV: 'production' });
+
+      await expect(client.sendEmail(emailPayload)).rejects.toThrow(
+        '운영 메일을 발송할 수 없습니다',
+      );
+    });
+
+    it('EMAIL_PROVIDER=gmail 인데 자격증명이 비면 예외를 던진다', async () => {
+      const client = await createClient({
+        NODE_ENV: 'production',
+        EMAIL_PROVIDER: 'gmail',
+        GMAIL_USER: 'noreply@dddstudy.kr',
+      });
+
+      await expect(client.sendEmail(emailPayload)).rejects.toThrow('GMAIL_APP_PASSWORD');
+      expect(sendMail).not.toHaveBeenCalled();
+    });
+  });
+
+  it('로컬 개발에서는 console 모드로 로그만 남기고 통과한다', async () => {
+    const client = await createClient({ NODE_ENV: 'development', EMAIL_PROVIDER: 'console' });
+
+    await expect(client.sendEmail(emailPayload)).resolves.toBeUndefined();
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+
+  it('자격증명이 모두 있으면 Gmail 로 발송한다', async () => {
+    const client = await createClient(gmailEnv);
+
+    await client.sendEmail(emailPayload);
+
+    expect(nodemailer.createTransport).toHaveBeenCalledWith({
+      service: 'gmail',
+      auth: { user: gmailEnv.GMAIL_USER, pass: gmailEnv.GMAIL_APP_PASSWORD },
+    });
+    expect(sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: { name: 'DDD', address: gmailEnv.EMAIL_FROM },
+        to: emailPayload.to,
+        subject: emailPayload.subject,
+      }),
+    );
+  });
+
+  it('발송이 실패하면 예외를 그대로 전파한다', async () => {
+    sendMail.mockRejectedValue(new Error('Invalid login'));
+    const client = await createClient(gmailEnv);
+
+    await expect(client.sendEmail(emailPayload)).rejects.toThrow('Invalid login');
+  });
+});

--- a/src/notification/infrastructure/gmail-email.client.ts
+++ b/src/notification/infrastructure/gmail-email.client.ts
@@ -25,6 +25,15 @@ export class GmailEmailClient {
   async sendEmail({ to, subject, html, text, attachments }: SendEmailPayload): Promise<void> {
     const provider = (this.configService.get<string>('EMAIL_PROVIDER') ?? 'console').toLowerCase();
     if (provider !== 'gmail') {
+      // 운영에서 조용히 return 하면 안 된다. 호출자(NotificationService)는 예외가 없는 것을
+      // 발송 성공으로 보고 EmailLog 를 SUCCESS 로 남기며, 사전 알림은 notifiedAt 까지 찍어
+      // 어드민 화면에 '발송 완료' 로 표시된다. 메일은 안 갔는데 아무도 모르는 상태가 된다.
+      if (this.isProduction()) {
+        throw new Error(
+          `EMAIL_PROVIDER=${provider} 상태에서는 운영 메일을 발송할 수 없습니다. EMAIL_PROVIDER=gmail 과 GMAIL_USER/GMAIL_APP_PASSWORD/EMAIL_FROM 을 설정하세요.`,
+        );
+      }
+
       const attachmentSuffix = attachments?.length ? `, attachments=${attachments.length}` : '';
       this.logger.log(
         `[메일 미리보기] to=${this.maskEmail({ email: to })}, subject=${subject}${attachmentSuffix}`,
@@ -37,11 +46,11 @@ export class GmailEmailClient {
     const fromAddress = this.configService.get<string>('EMAIL_FROM');
     const fromName = this.configService.get<string>('EMAIL_FROM_NAME') ?? 'DDD';
 
+    // 부팅 시 env 검증이 이미 막지만, 런타임에 값이 비면 여기서도 성공으로 넘기지 않는다.
     if (!user || !pass || !fromAddress) {
-      this.logger.error(
+      throw new Error(
         'EMAIL_PROVIDER=gmail 이지만 GMAIL_USER, GMAIL_APP_PASSWORD 또는 EMAIL_FROM이 누락되었습니다.',
       );
-      return;
     }
 
     const transporter = nodemailer.createTransport({
@@ -75,6 +84,10 @@ export class GmailEmailClient {
       attachments: finalAttachments,
       textEncoding: 'quoted-printable',
     });
+  }
+
+  private isProduction(): boolean {
+    return this.configService.get<string>('NODE_ENV') === 'production';
   }
 
   private maskEmail({ email }: { email: string }): string {

--- a/src/notification/interface/admin.early-notification.controller.ts
+++ b/src/notification/interface/admin.early-notification.controller.ts
@@ -93,6 +93,14 @@ export class AdminEarlyNotificationController {
       html: body.html,
       text: body.text,
     });
-    return ApiResponse.ok(result, '발송이 완료되었습니다.');
+
+    // sendBulk 는 개별 발송 실패를 흡수해 카운트로만 돌려준다. 여기서 메시지를 고정하면
+    // 한 통도 못 나간 경우에도 '발송이 완료되었습니다' 가 그대로 노출돼,
+    // 이번에 없앤 거짓 성공이 API 응답에 남는다.
+    const message =
+      result.failed > 0
+        ? `발송 성공 ${result.success}건, 실패 ${result.failed}건`
+        : '발송이 완료되었습니다.';
+    return ApiResponse.ok(result, message);
   }
 }


### PR DESCRIPTION
## 문제

어드민 **사전 알림 신청 > 알림 발송**으로 보낸 메일을 수신자가 받지 못했습니다. 화면에는 "발송 완료"로 표시됩니다.

## 원인

`deploy.yml`이 `EMAIL_PROVIDER=console`을 하드코딩하고 있어, **2026-04-24에 등록된 Gmail 시크릿 4개가 한 번도 사용되지 않았습니다.** 사전 알림뿐 아니라 면접 안내 메일, 지원서 관련 메일까지 운영에서 전혀 발송되지 않았습니다.

실패가 보이지 않았던 경로는 이렇습니다.

1. `GmailEmailClient`가 `provider !== 'gmail'`이면 로그만 남기고 **정상 return**
2. 예외가 없으니 `NotificationService`가 `EmailLog`를 **SUCCESS**로 저장
3. `Promise.allSettled`가 fulfilled로 판정 → `markManyNotified`로 **`notifiedAt` 기록**
4. 어드민 화면에 **"발송 완료"**

한 통도 나가지 않았는데 성공으로 집계됐습니다.

## 변경

**`deploy.yml`** — 이메일 값 5개를 시크릿에서 주입합니다. `provider` 화이트리스트와 gmail 자격증명 누락을 **컨테이너 교체 전에** 검증해 부팅 실패로 어중간한 상태가 되는 것을 막고, `console`로 배포되면 워크플로 경고를 남깁니다.

**`GmailEmailClient`** — 운영에서 console 모드거나 자격증명이 비면 `return` 대신 `throw`합니다. 안 나간 메일이 성공으로 기록되지 않습니다. 로컬 개발의 콘솔 미리보기는 그대로입니다.

**`env.validation`** — `EMAIL_PROVIDER`를 `console|gmail`로 제한하고, gmail일 때 `GMAIL_USER`/`GMAIL_APP_PASSWORD`/`EMAIL_FROM`을 필수로 검증합니다. 제거된 provider인 `resend`는 이제 부팅 단계에서 거부됩니다. 미사용 `RESEND_API_KEY`를 지우고, 코드가 이미 읽고 있던 `EMAIL_FROM_NAME`을 추가했습니다.

## 검증

라이브 조건(`NODE_ENV=production`)에서 실제 발송 경로를 확인했습니다.

```
1) PASS  console 모드 차단 — EMAIL_PROVIDER=console 상태에서는 운영 메일을 발송할 수 없습니다…
2) PASS  자격증명 누락 차단 — GMAIL_USER, GMAIL_APP_PASSWORD 또는 EMAIL_FROM이 누락…
3) PASS  실제 발송 완료 (3434ms)
```

유닛 테스트 427개 통과(신규 14케이스 포함), `yarn build` 성공, 변경 파일 린트 클린.

## 배포 후 필요한 조치

**① 배포 로그 확인** — `::warning::EMAIL_PROVIDER=console 로 배포합니다` 경고가 뜨면 `EMAIL_PROVIDER` 시크릿 값이 `gmail`이 아닙니다. 경고가 없으면 정상입니다.

**② 운영 DB의 잘못된 `notifiedAt` 정정** — 이미 찍힌 레코드는 `onlyUnnotified` 조건 때문에 재발송 대상에서 빠집니다. 실제로는 발송되지 않았으므로 되돌려야 재발송됩니다.

```bash
cd /opt/ddd-be

# 사고 원인 직접 확인
grep '^EMAIL_PROVIDER=' .env.production
sudo docker logs ddd-be-app --since 72h | grep '메일 미리보기'

# 정정 대상 확인
sudo docker exec -i ddd-be-postgres sh -c 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"' <<'SQL'
SELECT id, email, "notifiedAt" FROM early_notifications
WHERE "notifiedAt" IS NOT NULL AND "deletedAt" IS NULL ORDER BY id;
SQL

# 목록이 예상과 맞으면 되돌리기
sudo docker exec -i ddd-be-postgres sh -c 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"' <<'SQL'
UPDATE early_notifications SET "notifiedAt" = NULL
WHERE "notifiedAt" IS NOT NULL AND "deletedAt" IS NULL;
SQL
```

`메일 미리보기` 로그가 있으면 콘솔 모드였다는 직접 증거이고, 그 경우 지금까지의 `notifiedAt`은 전부 무효입니다.

**③ 참고** — `GMAIL_APP_PASSWORD`가 공백 포함 형식(19자)입니다. nodemailer가 처리해주지만 공백을 제거해두는 편이 안전합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
