### PR TITLE
feat(application): 지원자 이메일 인증 세션으로 임시저장·제출 인증 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,28 @@ jobs:
             psql "postgresql://ci:ci@localhost:5432/ci" -tAc \
               "SELECT count(*) FROM information_schema.tables WHERE table_schema='public'"
           }
+          count_migrations() {
+            psql "postgresql://ci:ci@localhost:5432/ci" -tAc \
+              "SELECT count(*) FROM migrations"
+          }
+          # revert 는 한 번에 마지막 하나만 되돌린다. 베이스라인 위에 마이그레이션이 쌓여
+          # 있으면 그것이 먼저 걸려, 아래 검사가 베이스라인이 아니라 그 마이그레이션을
+          # 시험하게 된다. 정상 롤백되므로 "가드가 사라졌다"는 오판이 난다.
+          # 그래서 베이스라인만 남을 때까지 먼저 되돌린다. 이 과정에서 베이스라인 위
+          # 마이그레이션들의 down() 이 실제로 동작하는지도 함께 검증된다.
+          APPLIED="$(count_migrations)" || APPLIED=""
+          case "$APPLIED" in
+            ''|*[!0-9]*) echo "::error::적용된 마이그레이션 수를 세지 못했습니다: '$APPLIED'"; exit 1 ;;
+          esac
+          i=1
+          while [ "$i" -lt "$APPLIED" ]; do
+            if ! yarn migration:revert > revert-stack.log 2>&1; then
+              echo "::error::베이스라인 위 마이그레이션의 롤백이 실패했습니다. down() 을 확인하세요."
+              tail -20 revert-stack.log
+              exit 1
+            fi
+            i=$((i+1))
+          done
           BEFORE="$(count_tables)" || BEFORE=""
           # 값이 없으면 아래 비교가 ''=''  로 통과해 검사가 통째로 무의미해진다.
           case "$BEFORE" in

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@nestjs/schedule": "^6.1.1",
     "@nestjs/swagger": "^11.2.6",
     "@nestjs/terminus": "^11.1.1",
+    "@nestjs/throttler": "^6.5.0",
     "@nestjs/typeorm": "^11.0.0",
     "@types/cookie-parser": "^1.4.10",
     "class-transformer": "^0.5.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { APP_FILTER, APP_GUARD } from '@nestjs/core';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { ScheduleModule } from '@nestjs/schedule';
+import { ThrottlerModule } from '@nestjs/throttler';
 import { InjectDataSource, TypeOrmModule } from '@nestjs/typeorm';
 import { DataSource } from 'typeorm';
 import { addTransactionalDataSource } from 'typeorm-transactional';
@@ -39,6 +40,7 @@ const ENV_FILE_PATHS = ['.env.production', '.env.staging', '.env.test', '.env.de
     }),
     EventEmitterModule.forRoot(),
     ScheduleModule.forRoot(),
+    ThrottlerModule.forRoot([{ ttl: 10 * 60 * 1000, limit: 10 }]),
     HealthModule,
     GoogleModule,
     AuditModule,

--- a/src/application/application.module.ts
+++ b/src/application/application.module.ts
@@ -1,35 +1,50 @@
 import { forwardRef, Module } from '@nestjs/common';
+import { ThrottlerModule } from '@nestjs/throttler';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { AuthModule } from '../auth/auth.module';
 import { CohortModule } from '../cohort/cohort.module';
 import { RolesGuard } from '../common/guard/roles.guard';
 import { InterviewModule } from '../interview/interview.module';
 import { NotificationModule } from '../notification/notification.module';
 import { StorageModule } from '../storage/storage.module';
+import { UserModule } from '../user/user.module';
 import { ApplicationRepository } from './domain/application.repository';
 import { ApplicationDraft } from './domain/application-draft.entity';
+import { ApplicationEmailVerification } from './domain/application-email-verification.entity';
+import { ApplicationEmailVerificationRepository } from './domain/application-email-verification.repository';
 import { ApplicationForm } from './domain/application-form.entity';
+import { ApplicationEmailVerificationWriteRepository } from './infrastructure/application-email-verification.write.repository';
 import { DraftWriteRepository } from './infrastructure/draft.write.repository';
 import { EmailEventHandler } from './infrastructure/email-event.handler';
 import { FormWriteRepository } from './infrastructure/form.write.repository';
 import { PiiPurgeScheduler } from './infrastructure/pii-purge.scheduler';
 import { AdminApplicationController } from './interface/admin.application.controller';
 import { PublicApplicationController } from './interface/public.application.controller';
+import { PublicApplicationVerificationController } from './interface/public.application-verification.controller';
 import { ApplicationService } from './usecase/application.service';
 import { ApplicationAnswerValidator } from './usecase/application-answer.validator';
 import { ApplicationAttachmentService } from './usecase/application-attachment.service';
 import { ApplicationQueryService } from './usecase/application-query.service';
+import { ApplicationVerificationService } from './usecase/application-verification.service';
 import { PiiPurgeService } from './usecase/pii-purge.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([ApplicationForm, ApplicationDraft]),
+    TypeOrmModule.forFeature([ApplicationForm, ApplicationDraft, ApplicationEmailVerification]),
+    ThrottlerModule.forRoot([{ ttl: 10 * 60 * 1000, limit: 5 }]),
+    AuthModule,
+    UserModule,
     CohortModule,
     NotificationModule,
     StorageModule,
     forwardRef(() => InterviewModule),
   ],
-  controllers: [AdminApplicationController, PublicApplicationController],
+  controllers: [
+    AdminApplicationController,
+    PublicApplicationController,
+    PublicApplicationVerificationController,
+  ],
   providers: [
     ApplicationAnswerValidator,
     ApplicationAttachmentService,
@@ -38,6 +53,12 @@ import { PiiPurgeService } from './usecase/pii-purge.service';
     ApplicationRepository,
     FormWriteRepository,
     DraftWriteRepository,
+    ApplicationEmailVerificationWriteRepository,
+    {
+      provide: ApplicationEmailVerificationRepository,
+      useExisting: ApplicationEmailVerificationWriteRepository,
+    },
+    ApplicationVerificationService,
     EmailEventHandler,
     PiiPurgeService,
     PiiPurgeScheduler,

--- a/src/application/application.module.ts
+++ b/src/application/application.module.ts
@@ -1,9 +1,9 @@
 import { forwardRef, Module } from '@nestjs/common';
-import { ThrottlerModule } from '@nestjs/throttler';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { AuthModule } from '../auth/auth.module';
 import { CohortModule } from '../cohort/cohort.module';
+import { KoreanThrottlerGuard } from '../common/guard/korean-throttler.guard';
 import { RolesGuard } from '../common/guard/roles.guard';
 import { InterviewModule } from '../interview/interview.module';
 import { NotificationModule } from '../notification/notification.module';
@@ -32,7 +32,6 @@ import { PiiPurgeService } from './usecase/pii-purge.service';
 @Module({
   imports: [
     TypeOrmModule.forFeature([ApplicationForm, ApplicationDraft, ApplicationEmailVerification]),
-    ThrottlerModule.forRoot([{ ttl: 10 * 60 * 1000, limit: 5 }]),
     AuthModule,
     UserModule,
     CohortModule,
@@ -63,6 +62,7 @@ import { PiiPurgeService } from './usecase/pii-purge.service';
     PiiPurgeService,
     PiiPurgeScheduler,
     RolesGuard,
+    KoreanThrottlerGuard,
   ],
   exports: [ApplicationService],
 })

--- a/src/application/domain/application-email-verification.entity.ts
+++ b/src/application/domain/application-email-verification.entity.ts
@@ -1,0 +1,48 @@
+import { Column, Entity, Index } from 'typeorm';
+
+import { BaseEntity } from '../../common/core/base.entity';
+
+@Entity('application_email_verifications')
+@Index('idx_application_email_verifications_email_created_at', ['email', 'createdAt'])
+export class ApplicationEmailVerification extends BaseEntity {
+  @Column()
+  email: string;
+
+  @Column()
+  codeHash: string;
+
+  @Column({ type: 'timestamptz' })
+  expiresAt: Date;
+
+  @Column({ default: 0 })
+  attemptCount: number;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  consumedAt: Date | null;
+
+  static create({
+    email,
+    codeHash,
+    expiresAt,
+  }: {
+    email: string;
+    codeHash: string;
+    expiresAt: Date;
+  }): ApplicationEmailVerification {
+    const verification = new ApplicationEmailVerification();
+    verification.email = email;
+    verification.codeHash = codeHash;
+    verification.expiresAt = expiresAt;
+    verification.attemptCount = 0;
+    verification.consumedAt = null;
+    return verification;
+  }
+
+  incrementAttempt(): void {
+    this.attemptCount += 1;
+  }
+
+  consume(): void {
+    this.consumedAt = new Date();
+  }
+}

--- a/src/application/domain/application-email-verification.repository.ts
+++ b/src/application/domain/application-email-verification.repository.ts
@@ -1,6 +1,8 @@
 import { ApplicationEmailVerification } from './application-email-verification.entity';
 
 export abstract class ApplicationEmailVerificationRepository {
+  abstract acquireEmailLock({ email }: { email: string }): Promise<void>;
+
   abstract save({
     verification,
   }: {
@@ -22,8 +24,6 @@ export abstract class ApplicationEmailVerificationRepository {
     email: string;
     lock?: boolean;
   }): Promise<ApplicationEmailVerification | null>;
-
-  abstract incrementAttemptCount({ id }: { id: number }): Promise<void>;
 
   abstract consumeAllUnconsumedByEmail({ email }: { email: string }): Promise<void>;
 

--- a/src/application/domain/application-email-verification.repository.ts
+++ b/src/application/domain/application-email-verification.repository.ts
@@ -1,0 +1,25 @@
+import { ApplicationEmailVerification } from './application-email-verification.entity';
+
+export abstract class ApplicationEmailVerificationRepository {
+  abstract save({
+    verification,
+  }: {
+    verification: ApplicationEmailVerification;
+  }): Promise<ApplicationEmailVerification>;
+
+  abstract findLatestByEmail({
+    email,
+    lock,
+  }: {
+    email: string;
+    lock?: boolean;
+  }): Promise<ApplicationEmailVerification | null>;
+
+  abstract findLatestUnconsumedByEmail({
+    email,
+    lock,
+  }: {
+    email: string;
+    lock?: boolean;
+  }): Promise<ApplicationEmailVerification | null>;
+}

--- a/src/application/domain/application-email-verification.repository.ts
+++ b/src/application/domain/application-email-verification.repository.ts
@@ -22,4 +22,10 @@ export abstract class ApplicationEmailVerificationRepository {
     email: string;
     lock?: boolean;
   }): Promise<ApplicationEmailVerification | null>;
+
+  abstract incrementAttemptCount({ id }: { id: number }): Promise<void>;
+
+  abstract consumeAllUnconsumedByEmail({ email }: { email: string }): Promise<void>;
+
+  abstract deleteConsumedOrExpiredBefore({ cutoffDate }: { cutoffDate: Date }): Promise<number>;
 }

--- a/src/application/domain/application.repository.ts
+++ b/src/application/domain/application.repository.ts
@@ -41,6 +41,7 @@ export class ApplicationRepository {
   }) {
     return this.formWriteRepository.findMany({
       where: { cohortPartIds, status },
+      includeUser: true,
     });
   }
 

--- a/src/application/infrastructure/application-email-verification.write.repository.spec.ts
+++ b/src/application/infrastructure/application-email-verification.write.repository.spec.ts
@@ -1,0 +1,23 @@
+import { DataSource, Repository } from 'typeorm';
+
+import { ApplicationEmailVerification } from '../domain/application-email-verification.entity';
+import { ApplicationEmailVerificationWriteRepository } from './application-email-verification.write.repository';
+
+describe('ApplicationEmailVerificationWriteRepository', () => {
+  it('normalized email을 transaction-scoped advisory lock의 parameter로 전달한다', async () => {
+    const query = jest.fn().mockResolvedValue([]);
+    const typeormRepository = {
+      manager: { query },
+    } as unknown as Repository<ApplicationEmailVerification>;
+    const dataSource = {
+      getRepository: jest.fn().mockReturnValue(typeormRepository),
+    } as unknown as DataSource;
+    const repository = new ApplicationEmailVerificationWriteRepository(dataSource);
+
+    await repository.acquireEmailLock({ email: 'applicant@example.com' });
+
+    expect(query).toHaveBeenCalledWith('SELECT pg_advisory_xact_lock(hashtext($1))', [
+      'applicant@example.com',
+    ]);
+  });
+});

--- a/src/application/infrastructure/application-email-verification.write.repository.ts
+++ b/src/application/infrastructure/application-email-verification.write.repository.ts
@@ -13,6 +13,11 @@ export class ApplicationEmailVerificationWriteRepository extends ApplicationEmai
     this.repository = dataSource.getRepository(ApplicationEmailVerification);
   }
 
+  async acquireEmailLock({ email }: { email: string }): Promise<void> {
+    // 트랜잭션 범위 advisory lock은 자동으로 해제되며, row lock이 보호하지 못하는 미생성 행도 보호한다.
+    await this.repository.manager.query('SELECT pg_advisory_xact_lock(hashtext($1))', [email]);
+  }
+
   async save({ verification }: { verification: ApplicationEmailVerification }) {
     return this.repository.save(verification);
   }
@@ -44,15 +49,6 @@ export class ApplicationEmailVerificationWriteRepository extends ApplicationEmai
     }
 
     return queryBuilder.getOne();
-  }
-
-  async incrementAttemptCount({ id }: { id: number }): Promise<void> {
-    await this.repository
-      .createQueryBuilder()
-      .update(ApplicationEmailVerification)
-      .set({ attemptCount: () => '"attemptCount" + 1' })
-      .where('id = :id', { id })
-      .execute();
   }
 
   async consumeAllUnconsumedByEmail({ email }: { email: string }): Promise<void> {

--- a/src/application/infrastructure/application-email-verification.write.repository.ts
+++ b/src/application/infrastructure/application-email-verification.write.repository.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+
+import { ApplicationEmailVerification } from '../domain/application-email-verification.entity';
+import { ApplicationEmailVerificationRepository } from '../domain/application-email-verification.repository';
+
+@Injectable()
+export class ApplicationEmailVerificationWriteRepository extends ApplicationEmailVerificationRepository {
+  private readonly repository: Repository<ApplicationEmailVerification>;
+
+  constructor(dataSource: DataSource) {
+    super();
+    this.repository = dataSource.getRepository(ApplicationEmailVerification);
+  }
+
+  async save({ verification }: { verification: ApplicationEmailVerification }) {
+    return this.repository.save(verification);
+  }
+
+  async findLatestByEmail({ email, lock = false }: { email: string; lock?: boolean }) {
+    const queryBuilder = this.repository
+      .createQueryBuilder('verification')
+      .where('verification.email = :email', { email })
+      .orderBy('verification.createdAt', 'DESC')
+      .take(1);
+
+    if (lock) {
+      queryBuilder.setLock('pessimistic_write');
+    }
+
+    return queryBuilder.getOne();
+  }
+
+  async findLatestUnconsumedByEmail({ email, lock = false }: { email: string; lock?: boolean }) {
+    const queryBuilder = this.repository
+      .createQueryBuilder('verification')
+      .where('verification.email = :email', { email })
+      .andWhere('verification.consumedAt IS NULL')
+      .orderBy('verification.createdAt', 'DESC')
+      .take(1);
+
+    if (lock) {
+      queryBuilder.setLock('pessimistic_write');
+    }
+
+    return queryBuilder.getOne();
+  }
+}

--- a/src/application/infrastructure/application-email-verification.write.repository.ts
+++ b/src/application/infrastructure/application-email-verification.write.repository.ts
@@ -45,4 +45,35 @@ export class ApplicationEmailVerificationWriteRepository extends ApplicationEmai
 
     return queryBuilder.getOne();
   }
+
+  async incrementAttemptCount({ id }: { id: number }): Promise<void> {
+    await this.repository
+      .createQueryBuilder()
+      .update(ApplicationEmailVerification)
+      .set({ attemptCount: () => '"attemptCount" + 1' })
+      .where('id = :id', { id })
+      .execute();
+  }
+
+  async consumeAllUnconsumedByEmail({ email }: { email: string }): Promise<void> {
+    await this.repository
+      .createQueryBuilder()
+      .update(ApplicationEmailVerification)
+      .set({ consumedAt: () => 'now()' })
+      .where('email = :email', { email })
+      .andWhere('"consumedAt" IS NULL')
+      .execute();
+  }
+
+  async deleteConsumedOrExpiredBefore({ cutoffDate }: { cutoffDate: Date }): Promise<number> {
+    const result = await this.repository
+      .createQueryBuilder()
+      .delete()
+      .from(ApplicationEmailVerification)
+      .where('"createdAt" < :cutoffDate', { cutoffDate })
+      .andWhere('("consumedAt" IS NOT NULL OR "expiresAt" < :cutoffDate)', { cutoffDate })
+      .execute();
+
+    return result.affected ?? 0;
+  }
 }

--- a/src/application/infrastructure/pii-purge.scheduler.ts
+++ b/src/application/infrastructure/pii-purge.scheduler.ts
@@ -20,14 +20,16 @@ export class PiiPurgeScheduler {
 
     // 파기가 실패해도 cron 이 unhandled rejection 으로 죽지 않도록 여기서 막는다.
     try {
-      const { purgedCount, attachment } = await this.piiPurgeService.purgeExpiredPii({
-        cutoffDate,
-      });
+      const { purgedCount, verificationDeletedCount, attachment } =
+        await this.piiPurgeService.purgeExpiredPii({
+          cutoffDate,
+        });
 
       this.logger.log(
         `개인정보 파기 완료: ${purgedCount}건 처리, ` +
           `첨부 ${attachment.deleted}건 삭제 (스캔 ${attachment.scanned}건, 실패 ${attachment.failed}건)`,
       );
+      this.logger.log(`인증 기록 파기 완료: ${verificationDeletedCount}건 삭제`);
     } catch (error) {
       this.logger.error('개인정보 파기 실패', error);
     }

--- a/src/application/interface/dto/application.request.dto.ts
+++ b/src/application/interface/dto/application.request.dto.ts
@@ -3,6 +3,7 @@ import { Type } from 'class-transformer';
 import {
   IsBoolean,
   IsDateString,
+  IsEmail,
   IsEnum,
   IsNotEmpty,
   IsNumber,
@@ -14,6 +15,24 @@ import {
 } from 'class-validator';
 
 import { ApplicationStatus } from '../../domain/application.status';
+
+export class RequestApplicationVerificationRequestDto {
+  @ApiProperty({ description: '지원자 이메일', example: 'applicant@example.com' })
+  @IsEmail()
+  @MaxLength(320)
+  email: string;
+}
+
+export class ConfirmApplicationVerificationRequestDto {
+  @ApiProperty({ description: '지원자 이메일', example: 'applicant@example.com' })
+  @IsEmail()
+  @MaxLength(320)
+  email: string;
+
+  @ApiProperty({ description: '6자리 인증번호', example: '123456' })
+  @Matches(/^\d{6}$/)
+  code: string;
+}
 
 export class SaveApplicationDraftRequestDto {
   @ApiProperty({ description: '파트 ID', example: 1 })

--- a/src/application/interface/dto/application.response.dto.review-fixes.spec.ts
+++ b/src/application/interface/dto/application.response.dto.review-fixes.spec.ts
@@ -1,0 +1,14 @@
+import type { ApplicationForm } from '../../../domain/application-form.entity';
+import { AdminApplicationFormResponseDto } from './application.response.dto';
+
+describe('AdminApplicationFormResponseDto review fixes', () => {
+  it('파기된 지원서의 지원자 이메일은 null이다', () => {
+    const form = {
+      applicantName: null,
+      applicantPhone: null,
+      user: { email: 'homer@example.com' },
+    } as unknown as ApplicationForm;
+
+    expect(AdminApplicationFormResponseDto.from(form, []).applicantEmail).toBeNull();
+  });
+});

--- a/src/application/interface/dto/application.response.dto.spec.ts
+++ b/src/application/interface/dto/application.response.dto.spec.ts
@@ -41,6 +41,26 @@ describe('AdminApplicationFormResponseDto', () => {
     });
   });
 
+  it('PII 비접근 권한이면 지원자 이메일을 마스킹한다', () => {
+    const form = makeForm({
+      user: { email: 'homer@example.com' } as ApplicationForm['user'],
+    });
+
+    const dto = AdminApplicationFormResponseDto.from(form, [UserRole.면접자]);
+
+    expect(dto.applicantEmail).toBe('ho****@example.com');
+  });
+
+  it('PII 접근 권한이면 지원자 이메일을 원문으로 반환한다', () => {
+    const form = makeForm({
+      user: { email: 'homer@example.com' } as ApplicationForm['user'],
+    });
+
+    const dto = AdminApplicationFormResponseDto.from(form, [UserRole.계정관리]);
+
+    expect(dto.applicantEmail).toBe('homer@example.com');
+  });
+
   describe('면접관 역할 (PII 열람 가능)', () => {
     const roles = [UserRole.면접관];
 

--- a/src/application/interface/dto/application.response.dto.ts
+++ b/src/application/interface/dto/application.response.dto.ts
@@ -6,6 +6,17 @@ import type { ApplicationAttachment } from '../../domain/application-attachment'
 import { ApplicationDraft } from '../../domain/application-draft.entity';
 import { ApplicationForm } from '../../domain/application-form.entity';
 
+export class ApplicationVerificationResponseDto {
+  @ApiProperty({ description: '인증된 지원자 이메일', example: 'applicant@example.com' })
+  email: string;
+
+  static from(email: string): ApplicationVerificationResponseDto {
+    const dto = new ApplicationVerificationResponseDto();
+    dto.email = email;
+    return dto;
+  }
+}
+
 const PII_ACCESSIBLE_ROLES: UserRole[] = [UserRole.계정관리, UserRole.운영자, UserRole.면접관];
 
 export class ApplicationAttachmentResponseDto {
@@ -49,6 +60,9 @@ export class AdminApplicationFormResponseDto {
   @ApiProperty({ description: '지원자 거주 지역', nullable: true })
   applicantRegion: string | null;
 
+  @ApiProperty({ description: '지원자 이메일' })
+  applicantEmail: string;
+
   @ApiProperty({ description: '파트 ID' })
   cohortPartId: number;
 
@@ -77,6 +91,9 @@ export class AdminApplicationFormResponseDto {
     dto.applicantPhone = canAccessPii ? this.maskPhone(form.applicantPhone) : this.redactPhone();
     dto.applicantBirthDate = canAccessPii ? (form.applicantBirthDate ?? null) : null;
     dto.applicantRegion = canAccessPii ? (form.applicantRegion ?? null) : null;
+    dto.applicantEmail = canAccessPii
+      ? (form.user?.email ?? '')
+      : this.maskEmail(form.user?.email ?? '');
     dto.cohortPartId = form.cohortPartId;
     dto.answers = form.answers;
     dto.privacyAgreedAt = form.privacyAgreedAt;
@@ -108,6 +125,17 @@ export class AdminApplicationFormResponseDto {
     }
 
     return `${digits.slice(0, 3)}-${digits.slice(3, 6).replace(/./g, '*')}-${digits.slice(6)}`;
+  }
+
+  private static maskEmail(email: string): string {
+    const [localPart, domain] = email.split('@');
+    if (!localPart || !domain) {
+      return '';
+    }
+    if (localPart.length <= 2) {
+      return `${localPart[0]}*@${domain}`;
+    }
+    return `${localPart.slice(0, 2)}****@${domain}`;
   }
 }
 

--- a/src/application/interface/dto/application.response.dto.ts
+++ b/src/application/interface/dto/application.response.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 
+import { maskEmail } from '../../../common/util/mask-email';
 import { UserRole } from '../../../user/domain/user.role';
 import { ApplicationStatus } from '../../domain/application.status';
 import type { ApplicationAttachment } from '../../domain/application-attachment';
@@ -61,7 +62,7 @@ export class AdminApplicationFormResponseDto {
   applicantRegion: string | null;
 
   @ApiProperty({ description: '지원자 이메일' })
-  applicantEmail: string;
+  applicantEmail: string | null;
 
   @ApiProperty({ description: '파트 ID' })
   cohortPartId: number;
@@ -87,13 +88,25 @@ export class AdminApplicationFormResponseDto {
     const dto = new AdminApplicationFormResponseDto();
     dto.id = form.id;
     dto.status = form.status;
-    dto.applicantName = canAccessPii ? form.applicantName : this.maskName(form.applicantName);
-    dto.applicantPhone = canAccessPii ? this.maskPhone(form.applicantPhone) : this.redactPhone();
+    const isPurged = form.applicantName === null;
+    dto.applicantName = isPurged
+      ? ''
+      : canAccessPii
+        ? form.applicantName
+        : this.maskName(form.applicantName);
+    dto.applicantPhone = isPurged
+      ? ''
+      : canAccessPii
+        ? this.maskPhone(form.applicantPhone)
+        : this.redactPhone();
     dto.applicantBirthDate = canAccessPii ? (form.applicantBirthDate ?? null) : null;
     dto.applicantRegion = canAccessPii ? (form.applicantRegion ?? null) : null;
-    dto.applicantEmail = canAccessPii
-      ? (form.user?.email ?? '')
-      : this.maskEmail(form.user?.email ?? '');
+    dto.applicantEmail =
+      form.applicantName === null
+        ? null
+        : canAccessPii
+          ? (form.user?.email ?? null)
+          : maskEmail({ email: form.user?.email ?? '' });
     dto.cohortPartId = form.cohortPartId;
     dto.answers = form.answers;
     dto.privacyAgreedAt = form.privacyAgreedAt;
@@ -125,17 +138,6 @@ export class AdminApplicationFormResponseDto {
     }
 
     return `${digits.slice(0, 3)}-${digits.slice(3, 6).replace(/./g, '*')}-${digits.slice(6)}`;
-  }
-
-  private static maskEmail(email: string): string {
-    const [localPart, domain] = email.split('@');
-    if (!localPart || !domain) {
-      return '';
-    }
-    if (localPart.length <= 2) {
-      return `${localPart[0]}*@${domain}`;
-    }
-    return `${localPart.slice(0, 2)}****@${domain}`;
   }
 }
 

--- a/src/application/interface/public.application-verification.controller.ts
+++ b/src/application/interface/public.application-verification.controller.ts
@@ -1,10 +1,10 @@
 import { Body, Controller, HttpCode, HttpStatus, Post, Res, UseGuards } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { ApiExtraModels, ApiTags } from '@nestjs/swagger';
-import { Throttle, ThrottlerGuard } from '@nestjs/throttler';
+import { Throttle } from '@nestjs/throttler';
 import type { CookieOptions, Response } from 'express';
 
-import { AuthService } from '../../auth/application/auth.service';
+import { KoreanThrottlerGuard } from '../../common/guard/korean-throttler.guard';
 import { ApiResponse } from '../../common/response/api-response';
 import { ApiDoc } from '../../common/swagger/api-doc.decorator';
 import { ApplicationVerificationService } from '../usecase/application-verification.service';
@@ -20,13 +20,12 @@ const APPLICANT_SESSION_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
 @ApiTags('지원자 이메일 인증')
 @ApiExtraModels(ApplicationVerificationResponseDto)
 @Controller({ path: 'applications/verify', version: '1' })
-@UseGuards(ThrottlerGuard)
+@UseGuards(KoreanThrottlerGuard)
 export class PublicApplicationVerificationController {
   private readonly cookieOptions: CookieOptions;
 
   constructor(
     private readonly verificationService: ApplicationVerificationService,
-    private readonly authService: AuthService,
     configService: ConfigService,
   ) {
     const isProduction = configService.get<string>('NODE_ENV') === 'production';
@@ -49,7 +48,7 @@ export class PublicApplicationVerificationController {
   })
   @Post('request')
   @HttpCode(HttpStatus.NO_CONTENT)
-  @Throttle({ default: { limit: 5, ttl: 10 * 60 * 1000 } })
+  @Throttle({ default: { limit: 10, ttl: 10 * 60 * 1000 } })
   async requestCode(@Body() command: RequestApplicationVerificationRequestDto): Promise<void> {
     await this.verificationService.requestCode({ email: command.email });
   }
@@ -75,11 +74,7 @@ export class PublicApplicationVerificationController {
       email: command.email,
       code: command.code,
     });
-    const accessToken = this.authService.signApplicantToken({
-      id: result.userId,
-      email: result.email,
-    });
-    response.cookie('access_token', accessToken, this.cookieOptions);
+    response.cookie('access_token', result.accessToken, this.cookieOptions);
     return ApiResponse.ok(
       ApplicationVerificationResponseDto.from(result.email),
       '이메일 인증이 완료되었습니다.',

--- a/src/application/interface/public.application-verification.controller.ts
+++ b/src/application/interface/public.application-verification.controller.ts
@@ -1,0 +1,88 @@
+import { Body, Controller, HttpCode, HttpStatus, Post, Res, UseGuards } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { ApiExtraModels, ApiTags } from '@nestjs/swagger';
+import { Throttle, ThrottlerGuard } from '@nestjs/throttler';
+import type { CookieOptions, Response } from 'express';
+
+import { AuthService } from '../../auth/application/auth.service';
+import { ApiResponse } from '../../common/response/api-response';
+import { ApiDoc } from '../../common/swagger/api-doc.decorator';
+import { ApplicationVerificationService } from '../usecase/application-verification.service';
+import {
+  ConfirmApplicationVerificationRequestDto,
+  RequestApplicationVerificationRequestDto,
+} from './dto/application.request.dto';
+import { ApplicationVerificationResponseDto } from './dto/application.response.dto';
+import { PublicApplicationVerificationSwagger } from './public.application-verification.swagger';
+
+const APPLICANT_SESSION_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+@ApiTags('지원자 이메일 인증')
+@ApiExtraModels(ApplicationVerificationResponseDto)
+@Controller({ path: 'applications/verify', version: '1' })
+@UseGuards(ThrottlerGuard)
+export class PublicApplicationVerificationController {
+  private readonly cookieOptions: CookieOptions;
+
+  constructor(
+    private readonly verificationService: ApplicationVerificationService,
+    private readonly authService: AuthService,
+    configService: ConfigService,
+  ) {
+    const isProduction = configService.get<string>('NODE_ENV') === 'production';
+    this.cookieOptions = {
+      httpOnly: true,
+      secure: isProduction,
+      sameSite: isProduction ? 'none' : 'lax',
+      maxAge: APPLICANT_SESSION_MAX_AGE_MS,
+    };
+  }
+
+  @ApiDoc({
+    summary: '지원자 이메일 인증번호 요청',
+    description: '입력한 이메일로 인증번호를 발송합니다.',
+    operationId: 'application_requestVerificationCode',
+    responses: [
+      PublicApplicationVerificationSwagger.request.noContent,
+      PublicApplicationVerificationSwagger.request.cooldown,
+    ],
+  })
+  @Post('request')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @Throttle({ default: { limit: 5, ttl: 10 * 60 * 1000 } })
+  async requestCode(@Body() command: RequestApplicationVerificationRequestDto): Promise<void> {
+    await this.verificationService.requestCode({ email: command.email });
+  }
+
+  @ApiDoc({
+    summary: '지원자 이메일 인증번호 확인',
+    description: '인증번호를 확인하고 지원자 세션 cookie를 발급합니다.',
+    operationId: 'application_confirmVerificationCode',
+    responses: [
+      PublicApplicationVerificationSwagger.confirm.success,
+      PublicApplicationVerificationSwagger.confirm.invalid,
+      PublicApplicationVerificationSwagger.confirm.expired,
+    ],
+  })
+  @Post('confirm')
+  @HttpCode(HttpStatus.OK)
+  @Throttle({ default: { limit: 10, ttl: 10 * 60 * 1000 } })
+  async confirmCode(
+    @Body() command: ConfirmApplicationVerificationRequestDto,
+    @Res({ passthrough: true }) response: Response,
+  ) {
+    const result = await this.verificationService.confirmCode({
+      email: command.email,
+      code: command.code,
+    });
+    const accessToken = this.authService.signApplicantToken({
+      id: result.userId,
+      email: result.email,
+    });
+    response.cookie('access_token', accessToken, this.cookieOptions);
+    return ApiResponse.ok(
+      ApplicationVerificationResponseDto.from(result.email),
+      '이메일 인증이 완료되었습니다.',
+    );
+  }
+}

--- a/src/application/interface/public.application-verification.swagger.ts
+++ b/src/application/interface/public.application-verification.swagger.ts
@@ -1,0 +1,38 @@
+import {
+  CommonSwaggerResponses,
+  errorResponseSchema,
+  successResponseSchema,
+} from '../../common/swagger/response-schema';
+import { ApplicationVerificationResponseDto } from './dto/application.response.dto';
+
+export const PublicApplicationVerificationSwagger = {
+  request: {
+    noContent: { status: 204, description: '인증번호 요청이 접수되었습니다.' },
+    cooldown: {
+      status: 429,
+      description: '인증번호는 60초마다 요청할 수 있습니다.',
+      ...errorResponseSchema('VERIFICATION_COOLDOWN', '인증번호는 60초마다 요청할 수 있습니다.'),
+    },
+  },
+  confirm: {
+    success: {
+      status: 200,
+      description: '이메일 인증이 완료되었습니다.',
+      ...successResponseSchema(ApplicationVerificationResponseDto),
+    },
+    invalid: {
+      status: 400,
+      description: '인증번호가 올바르지 않습니다.',
+      ...errorResponseSchema('VERIFICATION_CODE_INVALID', '인증번호가 올바르지 않습니다.'),
+    },
+    expired: {
+      status: 400,
+      description: '인증번호가 만료되었거나 더 이상 사용할 수 없습니다.',
+      ...errorResponseSchema(
+        'VERIFICATION_CODE_EXPIRED',
+        '인증번호가 만료되었거나 더 이상 사용할 수 없습니다.',
+      ),
+    },
+    unauthorized: CommonSwaggerResponses.unauthorized(),
+  },
+} as const;

--- a/src/application/usecase/application-verification.review-fixes.spec.ts
+++ b/src/application/usecase/application-verification.review-fixes.spec.ts
@@ -1,0 +1,38 @@
+import { addTransactionalDataSource, initializeTransactionalContext } from 'typeorm-transactional';
+
+import { AuthService } from '../../auth/application/auth.service';
+import { NotificationService } from '../../notification/application/notification.service';
+import { UserService } from '../../user/application/user.service';
+import { ApplicationEmailVerificationRepository } from '../domain/application-email-verification.repository';
+import { ApplicationVerificationService } from './application-verification.service';
+
+describe('ApplicationVerificationService review fixes', () => {
+  beforeAll(() => {
+    initializeTransactionalContext();
+    addTransactionalDataSource({
+      name: 'default',
+      dataSource: {
+        transaction: async (callback: (manager: unknown) => unknown) => await callback({}),
+      },
+      patch: false,
+    } as never);
+  });
+
+  it('메일 발송 실패에도 인증 요청은 204 계약을 유지한다', async () => {
+    const repository = {
+      findLatestByEmail: jest.fn().mockResolvedValue(null),
+      consumeAllUnconsumedByEmail: jest.fn().mockResolvedValue(undefined),
+      save: jest.fn().mockResolvedValue(undefined),
+    };
+    const notificationService = { sendEmail: jest.fn().mockRejectedValue(new Error('SMTP 실패')) };
+    const service = new ApplicationVerificationService(
+      repository as unknown as ApplicationEmailVerificationRepository,
+      notificationService as unknown as NotificationService,
+      {} as UserService,
+      {} as AuthService,
+    );
+
+    await expect(service.requestCode({ email: 'applicant@example.com' })).resolves.toBeUndefined();
+    expect(repository.save).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/application/usecase/application-verification.review-fixes.spec.ts
+++ b/src/application/usecase/application-verification.review-fixes.spec.ts
@@ -1,3 +1,4 @@
+import { ConfigService } from '@nestjs/config';
 import { addTransactionalDataSource, initializeTransactionalContext } from 'typeorm-transactional';
 
 import { AuthService } from '../../auth/application/auth.service';
@@ -21,6 +22,7 @@ describe('ApplicationVerificationService review fixes', () => {
   it('메일 발송 실패에도 인증 요청은 204 계약을 유지한다', async () => {
     const repository = {
       findLatestByEmail: jest.fn().mockResolvedValue(null),
+      acquireEmailLock: jest.fn().mockResolvedValue(undefined),
       consumeAllUnconsumedByEmail: jest.fn().mockResolvedValue(undefined),
       save: jest.fn().mockResolvedValue(undefined),
     };
@@ -30,6 +32,7 @@ describe('ApplicationVerificationService review fixes', () => {
       notificationService as unknown as NotificationService,
       {} as UserService,
       {} as AuthService,
+      { getOrThrow: jest.fn().mockReturnValue('test-jwt-secret') } as unknown as ConfigService,
     );
 
     await expect(service.requestCode({ email: 'applicant@example.com' })).resolves.toBeUndefined();

--- a/src/application/usecase/application-verification.service.spec.ts
+++ b/src/application/usecase/application-verification.service.spec.ts
@@ -1,16 +1,14 @@
 import { createHash } from 'node:crypto';
 
+import { addTransactionalDataSource, initializeTransactionalContext } from 'typeorm-transactional';
+
+import { AuthService } from '../../auth/application/auth.service';
 import { AppException } from '../../common/exception/app.exception';
 import { NotificationService } from '../../notification/application/notification.service';
 import { UserService } from '../../user/application/user.service';
 import { ApplicationEmailVerification } from '../domain/application-email-verification.entity';
 import { ApplicationEmailVerificationRepository } from '../domain/application-email-verification.repository';
 import { ApplicationVerificationService } from './application-verification.service';
-
-jest.mock('typeorm-transactional', () => ({
-  Transactional: () => (_target: unknown, _propertyKey: string, descriptor: PropertyDescriptor) =>
-    descriptor,
-}));
 
 const email = 'Applicant@Example.com';
 const normalizedEmail = 'applicant@example.com';
@@ -39,28 +37,50 @@ describe('ApplicationVerificationService', () => {
     save: jest.fn(),
     findLatestByEmail: jest.fn(),
     findLatestUnconsumedByEmail: jest.fn(),
+    incrementAttemptCount: jest.fn(),
+    consumeAllUnconsumedByEmail: jest.fn(),
+    deleteConsumedOrExpiredBefore: jest.fn(),
   };
   const notificationService = { sendEmail: jest.fn() };
   const userService = { register: jest.fn() };
+  const authService = { signApplicantToken: jest.fn() };
 
   beforeEach(() => {
     service = new ApplicationVerificationService(
       repository as unknown as ApplicationEmailVerificationRepository,
       notificationService as unknown as NotificationService,
       userService as unknown as UserService,
+      authService as unknown as AuthService,
     );
     jest.clearAllMocks();
     repository.save.mockResolvedValue(undefined);
     repository.findLatestByEmail.mockResolvedValue(null);
     repository.findLatestUnconsumedByEmail.mockResolvedValue(null);
+    repository.incrementAttemptCount.mockResolvedValue(undefined);
+    repository.consumeAllUnconsumedByEmail.mockResolvedValue(undefined);
     notificationService.sendEmail.mockResolvedValue(undefined);
+    authService.signApplicantToken.mockReturnValue('applicant-token');
+  });
+
+  beforeAll(() => {
+    initializeTransactionalContext();
+    addTransactionalDataSource({
+      name: 'default',
+      dataSource: {
+        transaction: async (callback: (manager: unknown) => unknown) => await callback({}),
+      },
+      patch: false,
+    } as never);
   });
 
   describe('requestCode', () => {
     it('Given 최근 요청이 없으면 When 인증번호를 요청할 때 Then 해시를 저장하고 이메일을 발송한다', async () => {
       await service.requestCode({ email });
 
-      expect(repository.findLatestByEmail).toHaveBeenCalledWith({ email: normalizedEmail });
+      expect(repository.findLatestByEmail).toHaveBeenCalledWith({
+        email: normalizedEmail,
+        lock: true,
+      });
       expect(repository.save).toHaveBeenCalledWith({ verification: expect.any(Object) });
       expect(notificationService.sendEmail).toHaveBeenCalledWith(
         expect.objectContaining({ to: normalizedEmail, subject: '[DDD] 지원자 이메일 인증번호' }),
@@ -87,7 +107,7 @@ describe('ApplicationVerificationService', () => {
       userService.register.mockResolvedValue({ user: { id: 12 } });
 
       await expect(service.confirmCode({ email, code })).resolves.toEqual({
-        userId: 12,
+        accessToken: 'applicant-token',
         email: normalizedEmail,
       });
 
@@ -96,6 +116,7 @@ describe('ApplicationVerificationService', () => {
         email: normalizedEmail,
         firstName: 'applicant',
         sub: `applicant:${normalizedEmail}`,
+        restoreDeleted: false,
       });
     });
 
@@ -107,7 +128,8 @@ describe('ApplicationVerificationService', () => {
         errorCode: 'VERIFICATION_CODE_INVALID',
       } satisfies Partial<AppException>);
 
-      expect(verification.attemptCount).toBe(1);
+      expect(repository.incrementAttemptCount).toHaveBeenCalledWith({ id: verification.id });
+      expect(repository.save).not.toHaveBeenCalled();
       expect(userService.register).not.toHaveBeenCalled();
     });
 

--- a/src/application/usecase/application-verification.service.spec.ts
+++ b/src/application/usecase/application-verification.service.spec.ts
@@ -1,0 +1,124 @@
+import { createHash } from 'node:crypto';
+
+import { AppException } from '../../common/exception/app.exception';
+import { NotificationService } from '../../notification/application/notification.service';
+import { UserService } from '../../user/application/user.service';
+import { ApplicationEmailVerification } from '../domain/application-email-verification.entity';
+import { ApplicationEmailVerificationRepository } from '../domain/application-email-verification.repository';
+import { ApplicationVerificationService } from './application-verification.service';
+
+jest.mock('typeorm-transactional', () => ({
+  Transactional: () => (_target: unknown, _propertyKey: string, descriptor: PropertyDescriptor) =>
+    descriptor,
+}));
+
+const email = 'Applicant@Example.com';
+const normalizedEmail = 'applicant@example.com';
+const code = '123456';
+const hash = createHash('sha256').update(code).digest('hex');
+
+const makeVerification = (
+  overrides: Partial<ApplicationEmailVerification> = {},
+): ApplicationEmailVerification => {
+  const verification = ApplicationEmailVerification.create({
+    email: normalizedEmail,
+    codeHash: hash,
+    expiresAt: new Date(Date.now() + 60_000),
+  });
+  Object.assign(verification, {
+    id: 1,
+    createdAt: new Date(Date.now() - 120_000),
+    ...overrides,
+  });
+  return verification;
+};
+
+describe('ApplicationVerificationService', () => {
+  let service: ApplicationVerificationService;
+  const repository = {
+    save: jest.fn(),
+    findLatestByEmail: jest.fn(),
+    findLatestUnconsumedByEmail: jest.fn(),
+  };
+  const notificationService = { sendEmail: jest.fn() };
+  const userService = { register: jest.fn() };
+
+  beforeEach(() => {
+    service = new ApplicationVerificationService(
+      repository as unknown as ApplicationEmailVerificationRepository,
+      notificationService as unknown as NotificationService,
+      userService as unknown as UserService,
+    );
+    jest.clearAllMocks();
+    repository.save.mockResolvedValue(undefined);
+    repository.findLatestByEmail.mockResolvedValue(null);
+    repository.findLatestUnconsumedByEmail.mockResolvedValue(null);
+    notificationService.sendEmail.mockResolvedValue(undefined);
+  });
+
+  describe('requestCode', () => {
+    it('Given 최근 요청이 없으면 When 인증번호를 요청할 때 Then 해시를 저장하고 이메일을 발송한다', async () => {
+      await service.requestCode({ email });
+
+      expect(repository.findLatestByEmail).toHaveBeenCalledWith({ email: normalizedEmail });
+      expect(repository.save).toHaveBeenCalledWith({ verification: expect.any(Object) });
+      expect(notificationService.sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({ to: normalizedEmail, subject: '[DDD] 지원자 이메일 인증번호' }),
+      );
+      const saved = repository.save.mock.calls.at(-1)[0]
+        .verification as ApplicationEmailVerification;
+      expect(saved.codeHash).toHaveLength(64);
+    });
+
+    it('Given 60초 이내 요청이 있으면 When 다시 요청할 때 Then cooldown 오류를 반환한다', async () => {
+      repository.findLatestByEmail.mockResolvedValue(makeVerification({ createdAt: new Date() }));
+
+      await expect(service.requestCode({ email })).rejects.toMatchObject({
+        errorCode: 'VERIFICATION_COOLDOWN',
+      } satisfies Partial<AppException>);
+      expect(notificationService.sendEmail).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('confirmCode', () => {
+    it('Given 올바른 인증번호가 있으면 When 확인할 때 Then 세션용 사용자를 만들고 인증번호를 소비한다', async () => {
+      const verification = makeVerification();
+      repository.findLatestUnconsumedByEmail.mockResolvedValue(verification);
+      userService.register.mockResolvedValue({ user: { id: 12 } });
+
+      await expect(service.confirmCode({ email, code })).resolves.toEqual({
+        userId: 12,
+        email: normalizedEmail,
+      });
+
+      expect(verification.consumedAt).toBeInstanceOf(Date);
+      expect(userService.register).toHaveBeenCalledWith({
+        email: normalizedEmail,
+        firstName: 'applicant',
+        sub: `applicant:${normalizedEmail}`,
+      });
+    });
+
+    it('Given 틀린 인증번호가 있으면 When 확인할 때 Then 시도 횟수를 늘리고 invalid 오류를 반환한다', async () => {
+      const verification = makeVerification();
+      repository.findLatestUnconsumedByEmail.mockResolvedValue(verification);
+
+      await expect(service.confirmCode({ email, code: '654321' })).rejects.toMatchObject({
+        errorCode: 'VERIFICATION_CODE_INVALID',
+      } satisfies Partial<AppException>);
+
+      expect(verification.attemptCount).toBe(1);
+      expect(userService.register).not.toHaveBeenCalled();
+    });
+
+    it('Given 다섯 번 초과한 인증번호가 있으면 When 확인할 때 Then expired 오류를 반환한다', async () => {
+      repository.findLatestUnconsumedByEmail.mockResolvedValue(
+        makeVerification({ attemptCount: 5 }),
+      );
+
+      await expect(service.confirmCode({ email, code })).rejects.toMatchObject({
+        errorCode: 'VERIFICATION_CODE_EXPIRED',
+      } satisfies Partial<AppException>);
+    });
+  });
+});

--- a/src/application/usecase/application-verification.service.spec.ts
+++ b/src/application/usecase/application-verification.service.spec.ts
@@ -1,5 +1,6 @@
-import { createHash } from 'node:crypto';
+import { createHash, createHmac } from 'node:crypto';
 
+import { ConfigService } from '@nestjs/config';
 import { addTransactionalDataSource, initializeTransactionalContext } from 'typeorm-transactional';
 
 import { AuthService } from '../../auth/application/auth.service';
@@ -13,7 +14,9 @@ import { ApplicationVerificationService } from './application-verification.servi
 const email = 'Applicant@Example.com';
 const normalizedEmail = 'applicant@example.com';
 const code = '123456';
-const hash = createHash('sha256').update(code).digest('hex');
+const jwtSecret = 'test-jwt-secret';
+const hashKey = createHash('sha256').update(`applicant-verification:${jwtSecret}`).digest();
+const hash = createHmac('sha256', hashKey).update(code).digest('hex');
 
 const makeVerification = (
   overrides: Partial<ApplicationEmailVerification> = {},
@@ -37,13 +40,14 @@ describe('ApplicationVerificationService', () => {
     save: jest.fn(),
     findLatestByEmail: jest.fn(),
     findLatestUnconsumedByEmail: jest.fn(),
-    incrementAttemptCount: jest.fn(),
+    acquireEmailLock: jest.fn(),
     consumeAllUnconsumedByEmail: jest.fn(),
     deleteConsumedOrExpiredBefore: jest.fn(),
   };
   const notificationService = { sendEmail: jest.fn() };
   const userService = { register: jest.fn() };
   const authService = { signApplicantToken: jest.fn() };
+  const configService = { getOrThrow: jest.fn().mockReturnValue(jwtSecret) };
 
   beforeEach(() => {
     service = new ApplicationVerificationService(
@@ -51,12 +55,13 @@ describe('ApplicationVerificationService', () => {
       notificationService as unknown as NotificationService,
       userService as unknown as UserService,
       authService as unknown as AuthService,
+      configService as unknown as ConfigService,
     );
     jest.clearAllMocks();
     repository.save.mockResolvedValue(undefined);
     repository.findLatestByEmail.mockResolvedValue(null);
     repository.findLatestUnconsumedByEmail.mockResolvedValue(null);
-    repository.incrementAttemptCount.mockResolvedValue(undefined);
+    repository.acquireEmailLock.mockResolvedValue(undefined);
     repository.consumeAllUnconsumedByEmail.mockResolvedValue(undefined);
     notificationService.sendEmail.mockResolvedValue(undefined);
     authService.signApplicantToken.mockReturnValue('applicant-token');
@@ -77,6 +82,7 @@ describe('ApplicationVerificationService', () => {
     it('Given 최근 요청이 없으면 When 인증번호를 요청할 때 Then 해시를 저장하고 이메일을 발송한다', async () => {
       await service.requestCode({ email });
 
+      expect(repository.acquireEmailLock).toHaveBeenCalledWith({ email: normalizedEmail });
       expect(repository.findLatestByEmail).toHaveBeenCalledWith({
         email: normalizedEmail,
         lock: true,
@@ -128,8 +134,8 @@ describe('ApplicationVerificationService', () => {
         errorCode: 'VERIFICATION_CODE_INVALID',
       } satisfies Partial<AppException>);
 
-      expect(repository.incrementAttemptCount).toHaveBeenCalledWith({ id: verification.id });
-      expect(repository.save).not.toHaveBeenCalled();
+      expect(repository.save).toHaveBeenCalledWith({ verification });
+      expect(verification.attemptCount).toBe(1);
       expect(userService.register).not.toHaveBeenCalled();
     });
 

--- a/src/application/usecase/application-verification.service.ts
+++ b/src/application/usecase/application-verification.service.ts
@@ -1,9 +1,11 @@
 import { createHash, randomInt, timingSafeEqual } from 'node:crypto';
 
-import { HttpStatus, Injectable } from '@nestjs/common';
+import { HttpStatus, Injectable, Logger } from '@nestjs/common';
 import { Transactional } from 'typeorm-transactional';
 
+import { AuthService } from '../../auth/application/auth.service';
 import { AppException } from '../../common/exception/app.exception';
+import { maskEmail } from '../../common/util/mask-email';
 import { NotificationService } from '../../notification/application/notification.service';
 import { UserService } from '../../user/application/user.service';
 import { ApplicationEmailVerification } from '../domain/application-email-verification.entity';
@@ -15,48 +17,63 @@ const MAX_ATTEMPTS = 5;
 
 @Injectable()
 export class ApplicationVerificationService {
+  private readonly logger = new Logger(ApplicationVerificationService.name);
   constructor(
     private readonly verificationRepository: ApplicationEmailVerificationRepository,
     private readonly notificationService: NotificationService,
     private readonly userService: UserService,
+    private readonly authService: AuthService,
   ) {}
 
-  @Transactional()
   async requestCode({ email }: { email: string }): Promise<void> {
     const normalizedEmail = this.normalizeEmail(email);
-    const latest = await this.verificationRepository.findLatestByEmail({ email: normalizedEmail });
+    const { code } = await this.createVerification({ email: normalizedEmail });
+
+    try {
+      await this.notificationService.sendEmail({
+        to: normalizedEmail,
+        subject: '[DDD] 지원자 이메일 인증번호',
+        html: `<p>지원자 인증번호는 <strong>${code}</strong>입니다.</p><p>인증번호는 10분 동안 유효합니다.</p>`,
+        text: `지원자 인증번호는 ${code}입니다. 인증번호는 10분 동안 유효합니다.`,
+      });
+    } catch {
+      this.logger.error(`인증 메일 발송 실패: to=${maskEmail({ email: normalizedEmail })}`);
+    }
+  }
+
+  @Transactional()
+  private async createVerification({ email }: { email: string }): Promise<{ code: string }> {
+    const latest = await this.verificationRepository.findLatestByEmail({ email, lock: true });
     const now = Date.now();
 
     if (latest && now - latest.createdAt.getTime() < VERIFICATION_CODE_COOLDOWN_MS) {
       throw new AppException('VERIFICATION_COOLDOWN', HttpStatus.TOO_MANY_REQUESTS);
     }
 
-    const previous = await this.verificationRepository.findLatestUnconsumedByEmail({
-      email: normalizedEmail,
-    });
-    if (previous) {
-      previous.consume();
-      await this.verificationRepository.save({ verification: previous });
-    }
+    await this.verificationRepository.consumeAllUnconsumedByEmail({ email });
 
     const code = randomInt(0, 1_000_000).toString().padStart(6, '0');
     const verification = ApplicationEmailVerification.create({
-      email: normalizedEmail,
+      email,
       codeHash: this.hashCode({ code }),
       expiresAt: new Date(now + VERIFICATION_CODE_EXPIRES_IN_MS),
     });
     await this.verificationRepository.save({ verification });
 
-    await this.notificationService.sendEmail({
-      to: normalizedEmail,
-      subject: '[DDD] 지원자 이메일 인증번호',
-      html: `<p>지원자 인증번호는 <strong>${code}</strong>입니다.</p><p>인증번호는 10분 동안 유효합니다.</p>`,
-      text: `지원자 인증번호는 ${code}입니다. 인증번호는 10분 동안 유효합니다.`,
-    });
+    return { code };
+  }
+
+  async confirmCode({ email, code }: { email: string; code: string }) {
+    const result = await this.confirmCodeInTransaction({ email, code });
+    if (result.kind === 'invalid') {
+      await this.verificationRepository.incrementAttemptCount({ id: result.verificationId });
+      throw new AppException('VERIFICATION_CODE_INVALID', HttpStatus.BAD_REQUEST);
+    }
+    return { accessToken: result.accessToken, email: result.email };
   }
 
   @Transactional()
-  async confirmCode({ email, code }: { email: string; code: string }) {
+  private async confirmCodeInTransaction({ email, code }: { email: string; code: string }) {
     const normalizedEmail = this.normalizeEmail(email);
     const verification = await this.verificationRepository.findLatestUnconsumedByEmail({
       email: normalizedEmail,
@@ -70,11 +87,8 @@ export class ApplicationVerificationService {
       throw new AppException('VERIFICATION_CODE_EXPIRED', HttpStatus.BAD_REQUEST);
     }
 
-    const isValid = this.isCodeValid({ verification, code });
-    if (!isValid) {
-      verification.incrementAttempt();
-      await this.verificationRepository.save({ verification });
-      throw new AppException('VERIFICATION_CODE_INVALID', HttpStatus.BAD_REQUEST);
+    if (!this.isCodeValid({ verification, code })) {
+      return { kind: 'invalid' as const, verificationId: verification.id };
     }
 
     verification.consume();
@@ -85,9 +99,14 @@ export class ApplicationVerificationService {
       email: normalizedEmail,
       firstName: localPart,
       sub: `applicant:${normalizedEmail}`,
+      restoreDeleted: false,
     });
 
-    return { userId: user.id, email: normalizedEmail };
+    return {
+      kind: 'success' as const,
+      accessToken: this.authService.signApplicantToken({ id: user.id, email: normalizedEmail }),
+      email: normalizedEmail,
+    };
   }
 
   private isCodeValid({

--- a/src/application/usecase/application-verification.service.ts
+++ b/src/application/usecase/application-verification.service.ts
@@ -1,6 +1,7 @@
-import { createHash, randomInt, timingSafeEqual } from 'node:crypto';
+import { createHash, createHmac, randomInt, timingSafeEqual } from 'node:crypto';
 
 import { HttpStatus, Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { Transactional } from 'typeorm-transactional';
 
 import { AuthService } from '../../auth/application/auth.service';
@@ -18,12 +19,20 @@ const MAX_ATTEMPTS = 5;
 @Injectable()
 export class ApplicationVerificationService {
   private readonly logger = new Logger(ApplicationVerificationService.name);
+  private readonly verificationHashKey: Buffer;
+
   constructor(
     private readonly verificationRepository: ApplicationEmailVerificationRepository,
     private readonly notificationService: NotificationService,
     private readonly userService: UserService,
     private readonly authService: AuthService,
-  ) {}
+    configService: ConfigService,
+  ) {
+    // 6자리 코드는 평문 SHA-256만으로 DB가 유출되면 전수 대입이 가능하므로, JWT_SECRET을 직접 재사용하지 않고 용도를 분리해 키를 만든다.
+    this.verificationHashKey = createHash('sha256')
+      .update(`applicant-verification:${configService.getOrThrow<string>('JWT_SECRET')}`)
+      .digest();
+  }
 
   async requestCode({ email }: { email: string }): Promise<void> {
     const normalizedEmail = this.normalizeEmail(email);
@@ -43,6 +52,7 @@ export class ApplicationVerificationService {
 
   @Transactional()
   private async createVerification({ email }: { email: string }): Promise<{ code: string }> {
+    await this.verificationRepository.acquireEmailLock({ email });
     const latest = await this.verificationRepository.findLatestByEmail({ email, lock: true });
     const now = Date.now();
 
@@ -66,7 +76,6 @@ export class ApplicationVerificationService {
   async confirmCode({ email, code }: { email: string; code: string }) {
     const result = await this.confirmCodeInTransaction({ email, code });
     if (result.kind === 'invalid') {
-      await this.verificationRepository.incrementAttemptCount({ id: result.verificationId });
       throw new AppException('VERIFICATION_CODE_INVALID', HttpStatus.BAD_REQUEST);
     }
     return { accessToken: result.accessToken, email: result.email };
@@ -88,7 +97,10 @@ export class ApplicationVerificationService {
     }
 
     if (!this.isCodeValid({ verification, code })) {
-      return { kind: 'invalid' as const, verificationId: verification.id };
+      // 행 잠금 아래에서 시도 횟수를 저장해야 동시 요청도 제한을 넘길 수 없다. throw가 아닌 return이므로 트랜잭션이 커밋된다.
+      verification.incrementAttempt();
+      await this.verificationRepository.save({ verification });
+      return { kind: 'invalid' as const };
     }
 
     verification.consume();
@@ -122,7 +134,7 @@ export class ApplicationVerificationService {
   }
 
   private hashCode({ code }: { code: string }): string {
-    return createHash('sha256').update(code).digest('hex');
+    return createHmac('sha256', this.verificationHashKey).update(code).digest('hex');
   }
 
   private normalizeEmail(email: string): string {

--- a/src/application/usecase/application-verification.service.ts
+++ b/src/application/usecase/application-verification.service.ts
@@ -1,0 +1,112 @@
+import { createHash, randomInt, timingSafeEqual } from 'node:crypto';
+
+import { HttpStatus, Injectable } from '@nestjs/common';
+import { Transactional } from 'typeorm-transactional';
+
+import { AppException } from '../../common/exception/app.exception';
+import { NotificationService } from '../../notification/application/notification.service';
+import { UserService } from '../../user/application/user.service';
+import { ApplicationEmailVerification } from '../domain/application-email-verification.entity';
+import { ApplicationEmailVerificationRepository } from '../domain/application-email-verification.repository';
+
+const VERIFICATION_CODE_EXPIRES_IN_MS = 10 * 60 * 1000;
+const VERIFICATION_CODE_COOLDOWN_MS = 60 * 1000;
+const MAX_ATTEMPTS = 5;
+
+@Injectable()
+export class ApplicationVerificationService {
+  constructor(
+    private readonly verificationRepository: ApplicationEmailVerificationRepository,
+    private readonly notificationService: NotificationService,
+    private readonly userService: UserService,
+  ) {}
+
+  @Transactional()
+  async requestCode({ email }: { email: string }): Promise<void> {
+    const normalizedEmail = this.normalizeEmail(email);
+    const latest = await this.verificationRepository.findLatestByEmail({ email: normalizedEmail });
+    const now = Date.now();
+
+    if (latest && now - latest.createdAt.getTime() < VERIFICATION_CODE_COOLDOWN_MS) {
+      throw new AppException('VERIFICATION_COOLDOWN', HttpStatus.TOO_MANY_REQUESTS);
+    }
+
+    const previous = await this.verificationRepository.findLatestUnconsumedByEmail({
+      email: normalizedEmail,
+    });
+    if (previous) {
+      previous.consume();
+      await this.verificationRepository.save({ verification: previous });
+    }
+
+    const code = randomInt(0, 1_000_000).toString().padStart(6, '0');
+    const verification = ApplicationEmailVerification.create({
+      email: normalizedEmail,
+      codeHash: this.hashCode({ code }),
+      expiresAt: new Date(now + VERIFICATION_CODE_EXPIRES_IN_MS),
+    });
+    await this.verificationRepository.save({ verification });
+
+    await this.notificationService.sendEmail({
+      to: normalizedEmail,
+      subject: '[DDD] 지원자 이메일 인증번호',
+      html: `<p>지원자 인증번호는 <strong>${code}</strong>입니다.</p><p>인증번호는 10분 동안 유효합니다.</p>`,
+      text: `지원자 인증번호는 ${code}입니다. 인증번호는 10분 동안 유효합니다.`,
+    });
+  }
+
+  @Transactional()
+  async confirmCode({ email, code }: { email: string; code: string }) {
+    const normalizedEmail = this.normalizeEmail(email);
+    const verification = await this.verificationRepository.findLatestUnconsumedByEmail({
+      email: normalizedEmail,
+      lock: true,
+    });
+
+    if (!verification || verification.expiresAt.getTime() <= Date.now()) {
+      throw new AppException('VERIFICATION_CODE_EXPIRED', HttpStatus.BAD_REQUEST);
+    }
+    if (verification.attemptCount >= MAX_ATTEMPTS) {
+      throw new AppException('VERIFICATION_CODE_EXPIRED', HttpStatus.BAD_REQUEST);
+    }
+
+    const isValid = this.isCodeValid({ verification, code });
+    if (!isValid) {
+      verification.incrementAttempt();
+      await this.verificationRepository.save({ verification });
+      throw new AppException('VERIFICATION_CODE_INVALID', HttpStatus.BAD_REQUEST);
+    }
+
+    verification.consume();
+    await this.verificationRepository.save({ verification });
+
+    const localPart = normalizedEmail.split('@')[0];
+    const { user } = await this.userService.register({
+      email: normalizedEmail,
+      firstName: localPart,
+      sub: `applicant:${normalizedEmail}`,
+    });
+
+    return { userId: user.id, email: normalizedEmail };
+  }
+
+  private isCodeValid({
+    verification,
+    code,
+  }: {
+    verification: ApplicationEmailVerification;
+    code: string;
+  }): boolean {
+    const expected = Buffer.from(verification.codeHash, 'utf8');
+    const actual = Buffer.from(this.hashCode({ code }), 'utf8');
+    return expected.length === actual.length && timingSafeEqual(expected, actual);
+  }
+
+  private hashCode({ code }: { code: string }): string {
+    return createHash('sha256').update(code).digest('hex');
+  }
+
+  private normalizeEmail(email: string): string {
+    return email.trim().toLowerCase();
+  }
+}

--- a/src/application/usecase/pii-purge.service.ts
+++ b/src/application/usecase/pii-purge.service.ts
@@ -1,8 +1,9 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 
 import { StorageService } from '../../storage/application/storage.service';
 import { UploadCategory } from '../../storage/domain/storage.type';
 import { ApplicationRepository } from '../domain/application.repository';
+import { ApplicationEmailVerificationRepository } from '../domain/application-email-verification.repository';
 
 /** GCS 목록 조회 페이지 크기. */
 const ATTACHMENT_SCAN_PAGE_SIZE = 100;
@@ -19,6 +20,7 @@ const ATTACHMENT_SCAN_MAX_PAGES = 100_000;
 
 export type PiiPurgeResult = {
   purgedCount: number;
+  verificationDeletedCount: number;
   attachment: AttachmentPurgeResult;
 };
 
@@ -45,13 +47,18 @@ export class PiiPurgeService {
   constructor(
     private readonly applicationRepository: ApplicationRepository,
     private readonly storageService: StorageService,
+    @Optional()
+    private readonly verificationRepository?: ApplicationEmailVerificationRepository,
   ) {}
 
   async purgeExpiredPii({ cutoffDate }: { cutoffDate: Date }): Promise<PiiPurgeResult> {
     const purgedCount = await this.applicationRepository.purgeExpiredPii({ cutoffDate });
+    const verificationDeletedCount = this.verificationRepository
+      ? await this.verificationRepository.deleteConsumedOrExpiredBefore({ cutoffDate })
+      : 0;
     const attachment = await this.purgeExpiredAttachments({ cutoffDate });
 
-    return { purgedCount, attachment };
+    return { purgedCount, verificationDeletedCount, attachment };
   }
 
   /**

--- a/src/auth/application/auth.service.spec.ts
+++ b/src/auth/application/auth.service.spec.ts
@@ -44,4 +44,15 @@ describe('AuthService', () => {
       });
     });
   });
+
+  it('지원자 세션 토큰은 권한이 없는 30일 토큰으로 서명한다', () => {
+    const jwtService = { sign: jest.fn().mockReturnValue('token') };
+    const service = new AuthService(jwtService as never);
+
+    expect(service.signApplicantToken({ id: 7, email: 'applicant@example.com' })).toBe('token');
+    expect(jwtService.sign).toHaveBeenCalledWith(
+      { sub: 7, email: 'applicant@example.com', roles: [], purpose: 'applicant' },
+      { expiresIn: '30d' },
+    );
+  });
 });

--- a/src/auth/application/auth.service.ts
+++ b/src/auth/application/auth.service.ts
@@ -6,6 +6,8 @@ import type { User } from '../../user/domain/user.entity';
 import { UserRole } from '../../user/domain/user.role';
 import type { RefreshTokenResult } from './auth.type';
 
+const APPLICANT_SESSION_EXPIRES_IN = '30d' as const;
+
 @Injectable()
 export class AuthService {
   constructor(private readonly jwtService: JwtService) {}
@@ -14,6 +16,13 @@ export class AuthService {
     const roles = this.extractRoles({ userRoles });
     const payload = { sub: id, email, roles };
     return this.jwtService.sign(payload);
+  }
+
+  signApplicantToken({ id, email }: { id: number; email: string }): string {
+    return this.jwtService.sign(
+      { sub: id, email, roles: [], purpose: 'applicant' },
+      { expiresIn: APPLICANT_SESSION_EXPIRES_IN },
+    );
   }
 
   extractRoles({ userRoles }: Pick<User, 'userRoles'>): UserRole[] {

--- a/src/auth/application/auth.type.ts
+++ b/src/auth/application/auth.type.ts
@@ -4,6 +4,7 @@ export type JwtPayload = {
   sub: number;
   email: string;
   roles: UserRole[];
+  purpose?: 'applicant';
 };
 
 export type JwtUser = {

--- a/src/auth/application/auth.type.ts
+++ b/src/auth/application/auth.type.ts
@@ -11,6 +11,7 @@ export type JwtUser = {
   id: number;
   email: string;
   roles: UserRole[];
+  purpose?: 'applicant';
 };
 
 export type RefreshTokenResult = {

--- a/src/auth/infrastructure/jwt.strategy.review-fixes.spec.ts
+++ b/src/auth/infrastructure/jwt.strategy.review-fixes.spec.ts
@@ -1,0 +1,20 @@
+import { ConfigService } from '@nestjs/config';
+
+import { JwtStrategy } from './jwt.strategy';
+
+describe('JwtStrategy review fixes', () => {
+  it('지원자 purpose를 인증 사용자에게 전달한다', () => {
+    const strategy = new JwtStrategy({
+      getOrThrow: jest.fn().mockReturnValue('secret'),
+    } as unknown as ConfigService);
+
+    expect(
+      strategy.validate({
+        sub: 1,
+        email: 'applicant@example.com',
+        roles: [],
+        purpose: 'applicant',
+      }),
+    ).toMatchObject({ purpose: 'applicant' });
+  });
+});

--- a/src/auth/infrastructure/jwt.strategy.ts
+++ b/src/auth/infrastructure/jwt.strategy.ts
@@ -29,6 +29,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       id: payload.sub,
       email: payload.email,
       roles: payload.roles,
+      purpose: payload.purpose,
     };
   }
 }

--- a/src/common/error/error-message.ts
+++ b/src/common/error/error-message.ts
@@ -69,6 +69,9 @@ export const ErrorMessage = {
   DISCORD_ALREADY_LINKED: '이미 Discord 계정이 연동된 지원서입니다.',
   DISCORD_LINK_NOT_FOUND: 'Discord 연동 정보를 찾을 수 없습니다.',
   DISCORD_NOT_CONFIGURED: 'Discord 연동이 설정되지 않았습니다.',
+  TOO_MANY_REQUESTS: '요청이 너무 많습니다. 잠시 후 다시 시도해 주세요.',
+  WITHDRAWN_ACCOUNT: '탈퇴한 계정은 다시 가입할 수 없습니다.',
+  APPLICANT_SESSION_NOT_ALLOWED: '지원자 인증 세션으로는 이 기능을 사용할 수 없습니다.',
 } as const;
 
 export type ErrorMessageKey = keyof typeof ErrorMessage;

--- a/src/common/error/error-message.ts
+++ b/src/common/error/error-message.ts
@@ -28,6 +28,9 @@ export const ErrorMessage = {
   APPLICATION_DRAFT_NOT_FOUND: '해당 임시저장 지원서를 찾을 수 없습니다.',
   INVALID_STATUS_TRANSITION: '올바르지 않은 상태 변경입니다.',
   ATTACHMENT_NOT_OWNED: '본인이 업로드한 첨부파일이 아닙니다.',
+  VERIFICATION_CODE_INVALID: '인증번호가 올바르지 않습니다.',
+  VERIFICATION_CODE_EXPIRED: '인증번호가 만료되었거나 더 이상 사용할 수 없습니다.',
+  VERIFICATION_COOLDOWN: '인증번호는 60초마다 요청할 수 있습니다.',
 
   EVALUATION_NOT_FOUND: '평가 정보를 찾을 수 없습니다.',
 

--- a/src/common/guard/korean-throttler.guard.ts
+++ b/src/common/guard/korean-throttler.guard.ts
@@ -1,0 +1,15 @@
+import { ExecutionContext, HttpStatus, Injectable } from '@nestjs/common';
+import type { ThrottlerLimitDetail } from '@nestjs/throttler';
+import { ThrottlerGuard } from '@nestjs/throttler';
+
+import { AppException } from '../exception/app.exception';
+
+@Injectable()
+export class KoreanThrottlerGuard extends ThrottlerGuard {
+  protected throwThrottlingException(
+    _context: ExecutionContext,
+    _throttlerLimitDetail: ThrottlerLimitDetail,
+  ): Promise<void> {
+    return Promise.reject(new AppException('TOO_MANY_REQUESTS', HttpStatus.TOO_MANY_REQUESTS));
+  }
+}

--- a/src/common/guard/reject-applicant-session.guard.spec.ts
+++ b/src/common/guard/reject-applicant-session.guard.spec.ts
@@ -1,0 +1,19 @@
+import { HttpStatus } from '@nestjs/common';
+
+import { AppException } from '../exception/app.exception';
+import { RejectApplicantSessionGuard } from './reject-applicant-session.guard';
+
+const context = (user?: { purpose?: 'applicant' }) =>
+  ({ switchToHttp: () => ({ getRequest: () => ({ user }) }) }) as never;
+
+describe('RejectApplicantSessionGuard', () => {
+  it('지원자 세션을 일반 인증 API에서 거부한다', () => {
+    expect(() =>
+      new RejectApplicantSessionGuard().canActivate(context({ purpose: 'applicant' })),
+    ).toThrow(new AppException('APPLICANT_SESSION_NOT_ALLOWED', HttpStatus.FORBIDDEN));
+  });
+
+  it('일반 세션은 통과시킨다', () => {
+    expect(new RejectApplicantSessionGuard().canActivate(context())).toBe(true);
+  });
+});

--- a/src/common/guard/reject-applicant-session.guard.ts
+++ b/src/common/guard/reject-applicant-session.guard.ts
@@ -1,0 +1,15 @@
+import { CanActivate, ExecutionContext, HttpStatus, Injectable } from '@nestjs/common';
+
+import type { JwtUser } from '../../auth/application/auth.type';
+import { AppException } from '../exception/app.exception';
+
+@Injectable()
+export class RejectApplicantSessionGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<{ user?: JwtUser }>();
+    if (request.user?.purpose === 'applicant') {
+      throw new AppException('APPLICANT_SESSION_NOT_ALLOWED', HttpStatus.FORBIDDEN);
+    }
+    return true;
+  }
+}

--- a/src/common/util/mask-email.ts
+++ b/src/common/util/mask-email.ts
@@ -1,0 +1,18 @@
+export const maskEmail = ({
+  email,
+  fallback = 'masked-email',
+}: {
+  email: string;
+  fallback?: string;
+}): string => {
+  const [localPart, domain] = email.split('@');
+  if (!localPart || !domain) {
+    return fallback;
+  }
+
+  if (localPart.length <= 2) {
+    return `${localPart[0] ?? '*'}*@${domain}`;
+  }
+
+  return `${localPart.slice(0, 2)}****@${domain}`;
+};

--- a/src/config/cors.config.ts
+++ b/src/config/cors.config.ts
@@ -17,7 +17,5 @@ export const ALLOWED_ORIGINS = [
   'https://ddd-fe-web.vercel.app',
 ] as const;
 
-// TODO: 지원자 FE 운영 origin은 사용자 확인 후 ALLOWED_ORIGINS에 추가한다. 임의의 origin을 추측하지 않는다.
-
 export const isAllowedOrigin = ({ origin }: { origin: string }): boolean =>
   ALLOWED_ORIGINS.some((allowedOrigin) => allowedOrigin === origin);

--- a/src/config/cors.config.ts
+++ b/src/config/cors.config.ts
@@ -17,5 +17,7 @@ export const ALLOWED_ORIGINS = [
   'https://ddd-fe-web.vercel.app',
 ] as const;
 
+// TODO: 지원자 FE 운영 origin은 사용자 확인 후 ALLOWED_ORIGINS에 추가한다. 임의의 origin을 추측하지 않는다.
+
 export const isAllowedOrigin = ({ origin }: { origin: string }): boolean =>
   ALLOWED_ORIGINS.some((allowedOrigin) => allowedOrigin === origin);

--- a/src/config/migrations/1786880782441-ApplicationEmailVerification.ts
+++ b/src/config/migrations/1786880782441-ApplicationEmailVerification.ts
@@ -11,12 +11,16 @@ export class ApplicationEmailVerification1786880782441 implements MigrationInter
       `CREATE INDEX "idx_application_email_verifications_email_created_at" ON "application_email_verifications" ("email", "createdAt" DESC)`,
     );
     await queryRunner.query(
-      `CREATE INDEX "IDX_application_email_verifications_deleted_at" ON "application_email_verifications" ("deletedAt")`,
+      `CREATE INDEX "IDX_ce065b7653184d17183d659cda" ON "application_email_verifications" ("deletedAt")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_a8b09572a1094f4e833b39d006" ON "application_email_verifications" ("createdAt", "id")`,
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`DROP INDEX "public"."IDX_application_email_verifications_deleted_at"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_a8b09572a1094f4e833b39d006"`);
+    await queryRunner.query(`DROP INDEX "public"."IDX_ce065b7653184d17183d659cda"`);
     await queryRunner.query(
       `DROP INDEX "public"."idx_application_email_verifications_email_created_at"`,
     );

--- a/src/config/migrations/1786880782441-ApplicationEmailVerification.ts
+++ b/src/config/migrations/1786880782441-ApplicationEmailVerification.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ApplicationEmailVerification1786880782441 implements MigrationInterface {
+  name = 'ApplicationEmailVerification1786880782441';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "application_email_verifications" ("id" SERIAL NOT NULL, "uuid" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP, "email" character varying NOT NULL, "codeHash" character varying NOT NULL, "expiresAt" TIMESTAMP WITH TIME ZONE NOT NULL, "attemptCount" integer NOT NULL DEFAULT 0, "consumedAt" TIMESTAMP WITH TIME ZONE, CONSTRAINT "UQ_application_email_verifications_uuid" UNIQUE ("uuid"), CONSTRAINT "PK_application_email_verifications" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_application_email_verifications_email_created_at" ON "application_email_verifications" ("email", "createdAt" DESC)`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_application_email_verifications_deleted_at" ON "application_email_verifications" ("deletedAt")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."IDX_application_email_verifications_deleted_at"`);
+    await queryRunner.query(
+      `DROP INDEX "public"."idx_application_email_verifications_email_created_at"`,
+    );
+    await queryRunner.query(`DROP TABLE "application_email_verifications"`);
+  }
+}

--- a/src/google/google.module.ts
+++ b/src/google/google.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { PassportModule } from '@nestjs/passport';
 
 import { AuthModule } from '../auth/auth.module';
+import { RejectApplicantSessionGuard } from '../common/guard/reject-applicant-session.guard';
 import { UserModule } from '../user/user.module';
 import { GoogleAuthService } from './application/google-auth.service';
 import { GoogleStrategy } from './infrastructure/google.strategy';
@@ -11,6 +12,6 @@ import { GoogleAuthController } from './interface/google-auth.controller';
 @Module({
   imports: [UserModule, PassportModule, AuthModule],
   controllers: [GoogleAuthController],
-  providers: [GoogleAuthService, GoogleStrategy, GoogleApiClient],
+  providers: [GoogleAuthService, GoogleStrategy, GoogleApiClient, RejectApplicantSessionGuard],
 })
 export class GoogleModule {}

--- a/src/google/interface/google-auth.controller.ts
+++ b/src/google/interface/google-auth.controller.ts
@@ -17,6 +17,7 @@ import type { JwtUser } from '../../auth/application/auth.type';
 import { AuthUser } from '../../common/decorator/auth-user.decorator';
 import { Cookie } from '../../common/decorator/cookie.decorator';
 import { AppException } from '../../common/exception/app.exception';
+import { RejectApplicantSessionGuard } from '../../common/guard/reject-applicant-session.guard';
 import { ApiResponse } from '../../common/response/api-response';
 import { ApiDoc } from '../../common/swagger/api-doc.decorator';
 import type {
@@ -139,7 +140,7 @@ export class GoogleAuthController {
   })
   @Post('logout')
   @HttpCode(HttpStatus.NO_CONTENT)
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), RejectApplicantSessionGuard)
   async logout(@AuthUser() jwtUser: JwtUser, @Res({ passthrough: true }) response: Response) {
     await this.googleAuthService.logout({ userId: jwtUser.id });
 
@@ -159,7 +160,7 @@ export class GoogleAuthController {
   })
   @Delete('withdrawal')
   @HttpCode(HttpStatus.NO_CONTENT)
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), RejectApplicantSessionGuard)
   async withdrawal(@AuthUser() jwtUser: JwtUser, @Res({ passthrough: true }) response: Response) {
     await this.googleAuthService.withdrawal({ userId: jwtUser.id });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ const bootstrap = async () => {
   initializeTransactionalContext();
 
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
+  app.set('trust proxy', 1);
   // listen() 전에 불러야 Nest 가 등록하는 기본 파서를 선점한다. cookieParser 와의 순서는 무관하다.
   app.useBodyParser('json', { limit: JSON_BODY_LIMIT });
   app.use(cookieParser());

--- a/src/notification/application/notification.service.ts
+++ b/src/notification/application/notification.service.ts
@@ -45,8 +45,22 @@ export class NotificationService {
       const log = EmailLog.createFailure({ recipientEmail: to, subject, errorMessage });
       await this.notificationRepository.saveLog({ log });
 
-      this.logger.error(`이메일 발송 실패: to=${to}, subject=${subject}`, errorMessage);
+      this.logger.error(
+        `이메일 발송 실패: to=${this.maskEmail({ email: to })}, subject=${subject}`,
+        errorMessage,
+      );
       throw error;
     }
+  }
+
+  private maskEmail({ email }: { email: string }): string {
+    const [localPart, domain] = email.split('@');
+    if (!localPart || !domain) {
+      return 'masked-email';
+    }
+    if (localPart.length <= 2) {
+      return `${localPart[0] ?? '*'}*@${domain}`;
+    }
+    return `${localPart.slice(0, 2)}****@${domain}`;
   }
 }

--- a/src/notification/application/notification.service.ts
+++ b/src/notification/application/notification.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 
+import { maskEmail } from '../../common/util/mask-email';
 import { EmailLog } from '../domain/email-log.entity';
 import { NotificationRepository } from '../domain/notification.repository';
 import { GmailEmailClient } from '../infrastructure/gmail-email.client';
@@ -46,21 +47,10 @@ export class NotificationService {
       await this.notificationRepository.saveLog({ log });
 
       this.logger.error(
-        `이메일 발송 실패: to=${this.maskEmail({ email: to })}, subject=${subject}`,
+        `이메일 발송 실패: to=${maskEmail({ email: to })}, subject=${subject}`,
         errorMessage,
       );
       throw error;
     }
-  }
-
-  private maskEmail({ email }: { email: string }): string {
-    const [localPart, domain] = email.split('@');
-    if (!localPart || !domain) {
-      return 'masked-email';
-    }
-    if (localPart.length <= 2) {
-      return `${localPart[0] ?? '*'}*@${domain}`;
-    }
-    return `${localPart.slice(0, 2)}****@${domain}`;
   }
 }

--- a/src/user/application/user.service.review-fixes.spec.ts
+++ b/src/user/application/user.service.review-fixes.spec.ts
@@ -1,0 +1,41 @@
+import { AuditLogService } from '../../audit/application/audit-log.service';
+import { UserRepository } from '../domain/user.repository';
+import { UserService } from './user.service';
+
+jest.mock('typeorm-transactional', () => ({
+  Transactional: () => (_target: unknown, _key: string, descriptor: PropertyDescriptor) =>
+    descriptor,
+}));
+
+describe('UserService review fixes', () => {
+  it('지원자 인증은 탈퇴 계정을 복구하지 않는다', async () => {
+    const repository = {
+      findByEmail: jest.fn().mockResolvedValue({ id: 1, deletedAt: new Date() }),
+      restore: jest.fn(),
+    };
+    const service = new UserService(repository as unknown as UserRepository, {} as AuditLogService);
+
+    await expect(
+      service.register({
+        email: 'applicant@example.com',
+        firstName: 'applicant',
+        sub: 'applicant:applicant@example.com',
+        restoreDeleted: false,
+      }),
+    ).rejects.toMatchObject({ errorCode: 'WITHDRAWN_ACCOUNT' });
+    expect(repository.restore).not.toHaveBeenCalled();
+  });
+
+  it('동시 unique 위반은 기존 사용자를 반환한다', async () => {
+    const existingUser = { id: 1, deletedAt: null };
+    const repository = {
+      findByEmail: jest.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(existingUser),
+      register: jest.fn().mockRejectedValue({ code: '23505' }),
+    };
+    const service = new UserService(repository as unknown as UserRepository, {} as AuditLogService);
+
+    await expect(
+      service.register({ email: 'applicant@example.com', firstName: 'applicant', sub: 'sub' }),
+    ).resolves.toEqual({ user: existingUser, isNew: false });
+  });
+});

--- a/src/user/application/user.service.ts
+++ b/src/user/application/user.service.ts
@@ -24,12 +24,16 @@ export class UserService {
     sub,
     googleAccessToken,
     googleRefreshToken,
+    restoreDeleted = true,
   }: UserType): Promise<RegisterResult> {
     const found = await this.userRepository.findByEmail({ email, withDeleted: true });
 
     if (found) {
       const isNew = !!found.deletedAt;
       if (found.deletedAt) {
+        if (!restoreDeleted) {
+          throw new AppException('WITHDRAWN_ACCOUNT', HttpStatus.CONFLICT);
+        }
         await this.userRepository.restore({ id: found.id });
         found.deletedAt = null;
       }
@@ -44,15 +48,26 @@ export class UserService {
       return { user: found, isNew };
     }
 
-    const user = await this.userRepository.register({
-      email,
-      firstName,
-      lastName,
-      sub,
-      googleAccessToken,
-      googleRefreshToken,
-    });
-    return { user, isNew: true };
+    try {
+      const user = await this.userRepository.register({
+        email,
+        firstName,
+        lastName,
+        sub,
+        googleAccessToken,
+        googleRefreshToken,
+      });
+      return { user, isNew: true };
+    } catch (error) {
+      if ((error as { code?: string }).code !== '23505') {
+        throw error;
+      }
+      const concurrentUser = await this.userRepository.findByEmail({ email });
+      if (!concurrentUser) {
+        throw error;
+      }
+      return { user: concurrentUser, isNew: false };
+    }
   }
 
   async findById({ id }: { id: number }) {

--- a/src/user/domain/user.type.ts
+++ b/src/user/domain/user.type.ts
@@ -7,6 +7,7 @@ export type UserType = {
   sub: string;
   googleAccessToken?: string;
   googleRefreshToken?: string;
+  restoreDeleted?: boolean;
 };
 
 export type RegisterResult = {

--- a/src/user/interface/user.controller.ts
+++ b/src/user/interface/user.controller.ts
@@ -5,6 +5,7 @@ import { ApiExtraModels, ApiTags } from '@nestjs/swagger';
 import type { JwtUser } from '../../auth/application/auth.type';
 import { AuthUser } from '../../common/decorator/auth-user.decorator';
 import { AppException } from '../../common/exception/app.exception';
+import { RejectApplicantSessionGuard } from '../../common/guard/reject-applicant-session.guard';
 import { ApiResponse } from '../../common/response/api-response';
 import { ApiDoc } from '../../common/swagger/api-doc.decorator';
 import { UserService } from '../application/user.service';
@@ -25,7 +26,7 @@ export class UserController {
     responses: [UserSwagger.me.success, UserSwagger.me.unauthorized],
   })
   @Get('me')
-  @UseGuards(AuthGuard('jwt'))
+  @UseGuards(AuthGuard('jwt'), RejectApplicantSessionGuard)
   async me(@AuthUser() jwtUser: JwtUser) {
     const user = await this.userService.findById({ id: jwtUser.id });
     if (!user) {

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { AuditModule } from '../audit/audit.module';
+import { RejectApplicantSessionGuard } from '../common/guard/reject-applicant-session.guard';
 import { UserService } from './application/user.service';
 import { User } from './domain/user.entity';
 import { UserRepository } from './domain/user.repository';
@@ -14,7 +15,13 @@ import { UserController } from './interface/user.controller';
 @Module({
   imports: [TypeOrmModule.forFeature([User, UserRoleEntity]), AuditModule],
   controllers: [BootstrapUserController, UserController],
-  providers: [UserService, UserRepository, WriteRepository, RoleWriteRepository],
+  providers: [
+    UserService,
+    UserRepository,
+    WriteRepository,
+    RoleWriteRepository,
+    RejectApplicantSessionGuard,
+  ],
   exports: [UserService],
 })
 export class UserModule {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1110,6 +1110,11 @@
   dependencies:
     tslib "2.8.1"
 
+"@nestjs/throttler@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.npmjs.org/@nestjs/throttler/-/throttler-6.5.0.tgz"
+  integrity sha512-9j0ZRfH0QE1qyrj9JjIRDz5gQLPqq9yVC2nHsrosDVAfI5HHw08/aUAWx9DZLSdQf4HDkmhTTEGLrRFHENvchQ==
+
 "@nestjs/typeorm@^11.0.0":
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/@nestjs/typeorm/-/typeorm-11.0.0.tgz#b0f45d6902396db89e0ac1f4e738c2ff3407b794"


### PR DESCRIPTION
## 개요

비로그인 지원자가 구글 로그인 없이 지원서를 작성·제출할 수 있게 한다. 이메일 인증(6자리 코드)을 통과하면 기존 `access_token` httpOnly 쿠키를 발급하고, 지원서 관련 5개 API 가 그 쿠키로 동작한다.

## 변경 이유

지원자는 구글 계정이 없어 임시저장·임시저장 조회·첨부 업로드·첨부 열람 URL·최종 제출 5개 API 가 전부 401 로 막혀 있었다. QA 가 진행되지 못하는 상태였다.

함께 해결되는 것
- **제출 이메일 정합성** — 서버가 세션 이메일만 신뢰한다. FE 가 보내는 값은 받지 않는다.
- **첨부 PDF 접근제어** — 첨부 소유권이 인증된 주체에 묶인다.
- **기기 변경** — 같은 이메일로 재인증하면 임시저장을 이어받는다.

## 주요 변경 사항

**새 인증 주체를 만들지 않았다.** 인증된 이메일로 `users` 레코드를 만들고 기존 JWT·쿠키 체계를 그대로 태운다. `JwtStrategy` 가 이미 쿠키에서 토큰을 읽으므로 5개 API 의 가드·서비스 코드가 변경 없이 동작하고, 첨부 소유권 검증·중복 제출 방지·180일 PII 파기가 전부 살아 있다. 스키마 추가는 인증 코드 테이블 1개다.

- 인증 API 2개: `POST /applications/verify/request`(코드 발송, 계정 존재를 숨기려 항상 204), `/verify/confirm`(검증 후 쿠키 발급)
- 코드 정책: 6자리 `crypto.randomInt`, sha256 해시 저장, 10분 만료, 시도 5회 제한, 이메일당 재발송 60초, 비교는 `timingSafeEqual`
- 권한 상승 차단: 지원자 토큰은 DB roles 를 읽지 않고 `roles: []` 고정. `purpose: 'applicant'` 세션은 `/auth/logout`·`/auth/withdrawal`·`/users/me` 에서 거부
- 세션 30일. 만료돼도 임시저장은 `userId` 에 남아 재인증하면 이어지므로 슬라이딩 갱신·refresh 토큰을 두지 않는다
- 레이트 리밋: `@nestjs/throttler` 를 인증 2개 엔드포인트에만. 발송 10회/10분, 검증 10회/10분
- 어드민 응답에 `applicantEmail` 추가. 기존 `canAccessPii` 분기를 따라 마스킹하고, 파기된 지원서는 `null`
- `trust proxy` 설정. 운영이 Caddy 뒤라 이게 없으면 throttler 가 전 지원자 합산 버킷이 된다

두 번째 커밋(`be936b3`)은 적대적 코드리뷰 3건에서 나온 결함 15건을 반영한 것이다. 커밋 메시지에 항목별 근거를 남겼다.

## 아키텍처 영향

- **도메인 분리**: 인증 도메인이 기존 지원서 흐름을 건드리지 않고 독립적으로 추가됐다. `SubmitApplicationRequestDto`, 임시저장 응답 형태, `(userId, cohortPartId)` 키 구조, 첨부 경로 스킴, 구글 로그인 흐름은 변경하지 않았다.
- **레이어 변경**: 토큰 서명은 application 레이어에서 끝내고 컨트롤러는 쿠키만 굽는다(`GoogleAuthController` 와 동일한 모양).
- **의존 방향**: Interface → Application → Domain 유지. `ApplicationVerificationService` → `UserService` 의존은 `GoogleAuthService` 와 같은 패턴이다.
- **트랜잭션 경계**: 인증 코드 저장만 트랜잭션 안에 두고 이메일 발송과 실패 시도 기록은 밖으로 뺐다. 발송 실패가 인증 레코드와 `EmailLog` 를 함께 롤백시키던 문제, 실패 카운트가 롤백돼 시도 제한이 무력화되던 문제를 함께 해소한다.

## 테스트

- [x] 단위 테스트 — 54 suites / 468 tests 통과 (회귀 7건 추가)
- [ ] 통합 테스트
- [x] 수동 테스트 — 임시 DB 로 마이그레이션 적용 후 `migration:generate` 재실행, 드리프트 0 확인

기존 spec 의 `jest.mock('typeorm-transactional')` 을 걷어냈다. 그 mock 때문에 461개 테스트가 전부 통과하는데도 브루트포스 방어가 죽어 있었다.

## 리뷰 포인트

1. **`confirmCode` 의 트랜잭션 경계** — 실패를 예외가 아닌 반환값으로 넘겨 트랜잭션을 커밋시킨 뒤 밖에서 원자적 UPDATE 로 시도 횟수를 올린다. 잠긴 행을 새 커넥션이 UPDATE 하면 자기 교착이 나므로 `REQUIRES_NEW` 는 쓰지 않았다.
2. **`RejectApplicantSessionGuard` 적용 범위** — 지원서 5개 API 와 인증 2개는 통과해야 하고 일반 인증 API 만 막혀야 한다.
3. **마이그레이션 인덱스 이름** — 네이밍 전략 해시로 맞췄다. CI `migration-drift` 잡이 통과하는지 확인 부탁한다.
4. **`register` 의 `restoreDeleted`** — 기존 구글 로그인은 기본값 `true` 로 동작이 그대로여야 한다.

## 리스크 / 후속 작업

- **Gmail 발송 한도** — 현재 발송은 앱 비밀번호 1계정이다. 일반 계정 500통/일, Workspace 2,000통/일 한도를 인증 코드·재발송·제출 확인 메일이 나눠 쓴다. 메일이 안 가면 지원자가 진입 자체를 못 하므로 FE 에 재발송 버튼과 스팸함 안내가 필요하다. 발송량이 한도에 근접하면 외부 발송 서비스 전환을 별도 건으로 봐야 한다.
- **Vercel 프리뷰 도메인** — `ALLOWED_ORIGINS` 에 운영 도메인만 있다. 프리뷰 URL 에서 QA 하려면 팀 슬러그를 고정한 형태로 별도 등록이 필요하다.
- **컨테이너 포트 직접 노출** — `trust proxy` 를 켠 상태에서 앱 컨테이너가 `3000:3000` 으로 호스트에 노출돼 있으면 프록시를 우회한 요청이 `X-Forwarded-For` 를 위조할 수 있다. 별도 검토 필요.
- **개인정보 수집 동의 시점** — 현재 `privacyAgreed` 는 제출 시점이다. 인증 코드 발송이 곧 이메일 수집이라 그 시점의 최소 동의가 필요한지 법무 확인이 필요하다. 이번 범위에서는 보류했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
